### PR TITLE
Add PostCSS configuration for Tailwind

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Summary
- add a PostCSS configuration so Vite loads Tailwind utilities

## Testing
- npm run dev *(fails: Vite exits under Node.js v22.19.0 while attempting to start)*

------
https://chatgpt.com/codex/tasks/task_e_68ded6d525148326a5195c9d9a41f979