### PR TITLE
Convert PostCSS config to ESM

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
## Summary
- convert the PostCSS configuration to use an ES module default export so Vite loads it correctly

## Testing
- npm run dev -- --host 0.0.0.0 --open=false

------
https://chatgpt.com/codex/tasks/task_e_68ded87a47f483269fdf13acd9e8e867