### PR TITLE
Normalize debit check in empresas pendencias list

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -727,7 +727,9 @@ export default function App() {
                           </p>
                         </div>
                         <div className="flex flex-wrap gap-1">
-                          {empresa.debito?.toLowerCase() === "sim" && <StatusBadge status="Não pago" />}
+                          {normalizeTextLower(empresa.debito) === "sim" && (
+                            <StatusBadge status="Não pago" />
+                          )}
                           {empresa.certificado === "NÃO" && <StatusBadge status="NÃO" />}
                           {(licencasByEmpresa.get(empresa.empresa) || [])
                             .filter((lic) => ALERT_STATUSES.has(lic.status))


### PR DESCRIPTION
## Summary
- use the existing normalizeTextLower helper when checking the debito flag in the pendências list to avoid TypeErrors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfbffb47c48326a67c944ae15b5e48