### PR TITLE
Normalize municipality list and filter blanks

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -391,7 +391,14 @@ def get_kpis():
 
 @app.get("/api/municipios")
 def get_municipios():
-    return sorted(set(e.municipio for e in cache["empresas"]))
+    municipios_normalizados = set()
+    for empresa in cache["empresas"]:
+        municipio = str(getattr(empresa, "municipio", "") or "").strip()
+        if not municipio:
+            continue
+        municipios_normalizados.add(municipio.title())
+
+    return sorted(municipios_normalizados)
 
 
 @app.post("/api/refresh")


### PR DESCRIPTION
## Summary
- skip empty municipality names when building the `/api/municipios` response
- normalize municipality capitalization to keep dropdown options consistent

## Testing
- PYTHONPATH=backend python - <<'PY'
from api import cache, get_municipios
from models import Empresa

cache["empresas"] = [
    Empresa(id=1, empresa="A", cnpj="1", porte="ME", municipio="  sao paulo  "),
    Empresa(id=2, empresa="B", cnpj="2", porte="ME", municipio=""),
    Empresa(id=3, empresa="C", cnpj="3", porte="ME", municipio=None),
    Empresa(id=4, empresa="D", cnpj="4", porte="ME", municipio="rio de janeiro"),
]

print(get_municipios())
PY

------
https://chatgpt.com/codex/tasks/task_e_68dfce76f428832681a4aa7770307891