### PR TITLE
Ajusta processamento de taxas e status padronizados

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -103,6 +103,10 @@ class TaxaResponse(BaseModel):
     func: str
     publicidade: str
     sanitaria: str
+    localizacao_instalacao: str
+    area_publica: str
+    bombeiros: str
+    status_geral: Optional[str]
 
 
 class ProcessoResponse(BaseModel):
@@ -178,6 +182,18 @@ PROCESSO_TIPOS = {
 }
 
 
+TAXA_TIPOS_OUTPUT = [
+    ("TPI", "tpi"),
+    ("Funcionamento", "func"),
+    ("Publicidade", "publicidade"),
+    ("Sanitária", "sanitaria"),
+    ("Localização/Instalação", "localizacao_instalacao"),
+    ("Área Pública", "area_publica"),
+    ("Bombeiros", "bombeiros"),
+    ("Status Geral", "status_geral"),
+]
+
+
 def _processo_tipo_label(proc_key: str) -> str:
     return PROCESSO_TIPOS.get(proc_key, proc_key.replace("_", " ").title())
 
@@ -200,8 +216,9 @@ def _rows_to_processos(proc_key: str, rows: List[Dict[str, Any]]) -> List[Proces
             protocolo=protocolo,
             data_solicitacao=_format_excel_date(row.get("DATA_SOLICITACAO")) or _to_str(row.get("DATA_SOLICITACAO")),
             situacao=_to_str(row.get("SITUACAO")),
+            status_padrao=_to_str(row.get("STATUS_PADRAO")),
             obs=_to_str(row.get("OBS")),
-            prazo=_format_excel_date(row.get("PRAZO")),
+            prazo=_format_excel_date(row.get("PRAZO")) or _to_str(row.get("PRAZO")),
         )
 
         if proc_key == "diversos":
@@ -305,11 +322,20 @@ def carregar_dados_do_excel() -> None:
                 funcionamento=_to_str(r.get("FUNCIONAMENTO"), "*"),
                 publicidade=_to_str(r.get("PUBLICIDADE"), "*"),
                 sanitaria=_to_str(r.get("SANITARIA"), "*"),
+                localizacao_instalacao=(
+                    _to_str(r.get("LOCALIZACAO_INSTALACAO"), "")
+                    or _to_str(r.get("LOCALIZACAO"), "*")
+                ),
+                area_publica=(
+                    _to_str(r.get("AREA_PUBLICA"), "")
+                    or _to_str(r.get("OCUPACAO"), "*")
+                ),
                 localizacao=_to_str(r.get("LOCALIZACAO"), "*"),
                 ocupacao=_to_str(r.get("OCUPACAO"), "*"),
                 bombeiros=_to_str(r.get("BOMBEIROS"), "*"),
                 tpi=_to_str(r.get("TPI"), "*"),
                 status_taxas=_to_str(r.get("STATUS_TAXAS")),
+                obs=_to_str(r.get("OBS")),
             )
             for r in taxas_raw_data
             if _to_int(r.get("ID")) and _to_str(r.get("EMPRESA"))
@@ -435,7 +461,7 @@ def get_licencas(empresa: Optional[str] = None):
     return result
 
 
-@app.get("/api/taxas")
+@app.get("/api/taxas", response_model=List[TaxaResponse])
 def get_taxas():
     taxas: List[Taxa] = cache["taxas"]
 
@@ -444,15 +470,10 @@ def get_taxas():
     empresas_unicas = sorted(set(t.empresa for t in taxas))
     for emp in empresas_unicas:
         taxas_emp = {t.tipo: t.status_display for t in taxas if t.empresa == emp}
-        result.append(
-            {
-                "empresa": emp,
-                "tpi": taxas_emp.get("TPI", "*"),
-                "func": taxas_emp.get("Funcionamento", "*"),
-                "publicidade": taxas_emp.get("Publicidade", "*"),
-                "sanitaria": taxas_emp.get("Sanitária", "*"),
-            }
-        )
+        linha = {"empresa": emp}
+        for tipo_label, output_key in TAXA_TIPOS_OUTPUT:
+            linha[output_key] = taxas_emp.get(tipo_label, "*")
+        result.append(linha)
     return result
 
 
@@ -468,7 +489,7 @@ def get_processos(tipo: Optional[str] = None, apenas_ativos: bool = False):
             "codigo": p.protocolo,
             "inicio": p.data_solicitacao,
             "prazo": p.prazo,
-            "status": p.situacao,
+            "status": p.status_display,
         }
         for p in processos
     ]
@@ -537,12 +558,12 @@ def diagnostico():
         proc_sheet = _sheet_name("processos", "PROCESSOS")
         processos_tables = repo.config.get("table_names", {}).get("processos", {})
         processos_required = {
-            "processos_diversos": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
-            "processos_funcionamento": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
-            "processos_bombeiros": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
-            "processos_uso_solo": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
-            "processos_sanitario": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
-            "processos_ambiental": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
+            "processos_diversos": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
+            "processos_funcionamento": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
+            "processos_bombeiros": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
+            "processos_uso_solo": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
+            "processos_sanitario": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
+            "processos_ambiental": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
         }
         for proc_key, table_name in processos_tables.items():
             sheet_key = f"processos_{proc_key}"

--- a/backend/models.py
+++ b/backend/models.py
@@ -91,6 +91,7 @@ class Processo:
     protocolo: str
     data_solicitacao: str
     situacao: str
+    status_padrao: Optional[str] = None
     obs: str = ""
     prazo: Optional[str] = None
     # Campos específicos por tipo (opcionais)
@@ -106,9 +107,14 @@ class Processo:
     data_val: Optional[str] = None  # Sanitário
 
     @property
+    def status_display(self) -> str:
+        """Status padronizado para exibição."""
+        return (self.status_padrao or self.situacao or "").strip()
+
+    @property
     def status_cor(self) -> str:
         """Retorna emoji de cor baseado no status"""
-        status_lower = self.situacao.lower()
+        status_lower = self.status_display.lower()
         if "concluído" in status_lower or "aprovado" in status_lower or "licenciado" in status_lower:
             return "🟢"
         if "vencido" in status_lower or "indeferido" in status_lower:
@@ -173,9 +179,11 @@ class TaxaRaw:
     funcionamento: str = "*"
     publicidade: str = "*"
     sanitaria: str = "*"
-    localizacao: str = "*"
-    ocupacao: str = "*"
-    bombeiros: str = "*"
+    localizacao_instalacao: str = "*"
+    area_publica: str = "*"
+    localizacao: str = "*"  # compatibilidade retroativa
+    ocupacao: str = "*"  # compatibilidade retroativa
+    bombeiros: str = "*"  # compatibilidade retroativa
     tpi: str = "*"
     status_taxas: str = "Regular"
     obs: str = ""

--- a/backend/services.py
+++ b/backend/services.py
@@ -130,32 +130,43 @@ def normalizar_taxas(taxas_raw: List[TaxaRaw]) -> List[Taxa]:
     Transforma estrutura 'larga' em 'longa'
     """
     taxas_norm = []
-    
-    tipos_map = {
-        "tpi": "TPI",
-        "funcionamento": "Funcionamento",
-        "publicidade": "Publicidade",
-        "sanitaria": "Sanitária",
-        "localizacao": "Localização",
-        "ocupacao": "Ocupação",
-        "bombeiros": "Bombeiros"
-    }
-    
+
+    tipos_map = [
+        ("tpi", "TPI"),
+        ("funcionamento", "Funcionamento"),
+        ("publicidade", "Publicidade"),
+        ("sanitaria", "Sanitária"),
+        ("localizacao_instalacao", "Localização/Instalação"),
+        ("localizacao", "Localização/Instalação"),
+        ("area_publica", "Área Pública"),
+        ("ocupacao", "Área Pública"),
+        ("bombeiros", "Bombeiros"),
+        ("status_taxas", "Status Geral"),
+    ]
+
     for raw in taxas_raw:
-        for campo, tipo in tipos_map.items():
+        status_por_tipo: Dict[str, str] = {}
+
+        for campo, tipo in tipos_map:
             status_raw = getattr(raw, campo, "*")
-            if status_raw in ["", None]:
+            if status_raw in ("", None):
                 status_raw = "*"
-            
+            status_raw = str(status_raw)
+
+            atual = status_por_tipo.get(tipo)
+            if atual is None or (atual == "*" and status_raw != "*"):
+                status_por_tipo[tipo] = status_raw
+
+        for tipo, status_valor in status_por_tipo.items():
             taxas_norm.append(Taxa(
                 id=raw.id,
                 empresa=raw.empresa,
                 cnpj=raw.cnpj,
                 tipo=tipo,
-                status=str(status_raw),
+                status=status_valor,
                 data_envio=raw.data_envio
             ))
-    
+
     return taxas_norm
 
 
@@ -251,14 +262,20 @@ def filtrar_processos(
     
     if tipo:
         resultado = [p for p in resultado if p.tipo == tipo]
-    
+
     if situacao:
-        resultado = [p for p in resultado if p.situacao == situacao]
-    
+        resultado = [
+            p for p in resultado
+            if (p.status_padrao or p.situacao) == situacao
+        ]
+
     if apenas_ativos:
         inativos = {"CONCLUÍDO", "LICENCIADO", "Aprovado", "INDEFERIDO"}
-        resultado = [p for p in resultado if p.situacao not in inativos]
-    
+        resultado = [
+            p for p in resultado
+            if (p.status_padrao or p.situacao) not in inativos
+        ]
+
     return resultado
 
 


### PR DESCRIPTION
## Summary
- atualiza a carga de taxas para considerar os novos campos definidos em `config.yaml` e expõe todos eles na API
- utiliza os status padronizados dos processos e ajusta diagnósticos e filtros para a nova coluna auxiliar

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e032605f008326a19b5de111353686