### PR TITLE
Use empresa IDs across data and enhance status badges

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -17,7 +17,16 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from repo_excel import ExcelRepo
-from models import Empresa, Licenca, Taxa, Processo, LicencaRaw, TaxaRaw
+from models import (
+    Empresa,
+    Licenca,
+    Taxa,
+    Processo,
+    Contato,
+    Modelo,
+    LicencaRaw,
+    TaxaRaw,
+)
 from services import (
     filtrar_empresas, filtrar_processos,
     normalizar_licencas, normalizar_taxas,
@@ -63,6 +72,8 @@ cache: Dict[str, object] = {
     "licencas": [],
     "taxas": [],
     "processos": [],
+    "contatos": [],
+    "modelos": [],
     "last_update": None,
 }
 
@@ -90,6 +101,7 @@ class EmpresaResponse(BaseModel):
 
 
 class LicencaResponse(BaseModel):
+    empresa_id: int
     empresa: str
     tipo: str
     status: str
@@ -98,20 +110,52 @@ class LicencaResponse(BaseModel):
 
 
 class TaxaResponse(BaseModel):
+    empresa_id: int
     empresa: str
     tpi: str
     func: str
     publicidade: str
     sanitaria: str
+    localizacao_instalacao: str
+    area_publica: str
+    bombeiros: str
+    status_geral: Optional[str]
 
 
 class ProcessoResponse(BaseModel):
+    empresa_id: int
     empresa: str
     tipo: str
     codigo: str
     inicio: str
     prazo: Optional[str]
     status: str
+
+
+class ContatoResponse(BaseModel):
+    contato: str
+    municipio: str
+    telefone: str
+    whatsapp: str
+    email: str
+    categoria: str
+
+    class Config:
+        from_attributes = True
+
+
+class ModeloResponse(BaseModel):
+    descricao: str
+    utilizacao: str
+    modelo: str
+
+    class Config:
+        from_attributes = True
+
+
+class UteisResponse(BaseModel):
+    contatos: List[ContatoResponse]
+    modelos: List[ModeloResponse]
 
 
 class KPIsResponse(BaseModel):
@@ -178,6 +222,18 @@ PROCESSO_TIPOS = {
 }
 
 
+TAXA_TIPOS_OUTPUT = [
+    ("TPI", "tpi"),
+    ("Funcionamento", "func"),
+    ("Publicidade", "publicidade"),
+    ("Sanitária", "sanitaria"),
+    ("Localização/Instalação", "localizacao_instalacao"),
+    ("Área Pública", "area_publica"),
+    ("Bombeiros", "bombeiros"),
+    ("Status Geral", "status_geral"),
+]
+
+
 def _processo_tipo_label(proc_key: str) -> str:
     return PROCESSO_TIPOS.get(proc_key, proc_key.replace("_", " ").title())
 
@@ -187,21 +243,25 @@ def _rows_to_processos(proc_key: str, rows: List[Dict[str, Any]]) -> List[Proces
     tipo_label = _processo_tipo_label(proc_key)
 
     for row in rows:
+        empresa_id = _to_int(row.get("ID"))
         empresa = _to_str(row.get("EMPRESA"))
         protocolo = _to_str(row.get("PROTOCOLO"))
+        if not empresa_id:
+            continue
         if not empresa and not protocolo:
             continue
 
         processo = Processo(
-            id=_to_int(row.get("ID")),
+            empresa_id=empresa_id,
             empresa=empresa,
             cnpj=_to_str(row.get("CNPJ")),
             tipo=tipo_label,
             protocolo=protocolo,
             data_solicitacao=_format_excel_date(row.get("DATA_SOLICITACAO")) or _to_str(row.get("DATA_SOLICITACAO")),
             situacao=_to_str(row.get("SITUACAO")),
+            status_padrao=_to_str(row.get("STATUS_PADRAO")),
             obs=_to_str(row.get("OBS")),
-            prazo=_format_excel_date(row.get("PRAZO")),
+            prazo=_format_excel_date(row.get("PRAZO")) or _to_str(row.get("PRAZO")),
         )
 
         if proc_key == "diversos":
@@ -240,6 +300,7 @@ def carregar_dados_do_excel() -> None:
         lic_sheet = sheet_cfg.get("licencas", "LICENÇAS")
         tax_sheet = sheet_cfg.get("taxas", "TAXAS")
         proc_sheet = sheet_cfg.get("processos", "PROCESSOS")
+        uteis_sheet = sheet_cfg.get("uteis", "CONTATOS E MODELOS")
 
         # Empresas
         empresas_raw = repo.read_sheet(emp_sheet, "empresas")
@@ -273,7 +334,7 @@ def carregar_dados_do_excel() -> None:
         licencas_raw_data = repo.read_sheet(lic_sheet, "licencas")
         licencas_raw_objs = [
             LicencaRaw(
-                id=_to_int(r.get("ID")),
+                empresa_id=_to_int(r.get("ID")),
                 empresa=_to_str(r.get("EMPRESA")),
                 cnpj=_to_str(r.get("CNPJ")),
                 municipio=_to_str(r.get("MUNICIPIO")),
@@ -298,18 +359,27 @@ def carregar_dados_do_excel() -> None:
         taxas_raw_data = repo.read_sheet(tax_sheet, "taxas")
         taxas_raw_objs = [
             TaxaRaw(
-                id=_to_int(r.get("ID")),
+                empresa_id=_to_int(r.get("ID")),
                 empresa=_to_str(r.get("EMPRESA")),
                 cnpj=_to_str(r.get("CNPJ")),
                 data_envio=_format_excel_date(r.get("DATA_ENVIO")) or _to_str(r.get("DATA_ENVIO")),
                 funcionamento=_to_str(r.get("FUNCIONAMENTO"), "*"),
                 publicidade=_to_str(r.get("PUBLICIDADE"), "*"),
                 sanitaria=_to_str(r.get("SANITARIA"), "*"),
+                localizacao_instalacao=(
+                    _to_str(r.get("LOCALIZACAO_INSTALACAO"), "")
+                    or _to_str(r.get("LOCALIZACAO"), "*")
+                ),
+                area_publica=(
+                    _to_str(r.get("AREA_PUBLICA"), "")
+                    or _to_str(r.get("OCUPACAO"), "*")
+                ),
                 localizacao=_to_str(r.get("LOCALIZACAO"), "*"),
                 ocupacao=_to_str(r.get("OCUPACAO"), "*"),
                 bombeiros=_to_str(r.get("BOMBEIROS"), "*"),
                 tpi=_to_str(r.get("TPI"), "*"),
                 status_taxas=_to_str(r.get("STATUS_TAXAS")),
+                obs=_to_str(r.get("OBS")),
             )
             for r in taxas_raw_data
             if _to_int(r.get("ID")) and _to_str(r.get("EMPRESA"))
@@ -324,21 +394,63 @@ def carregar_dados_do_excel() -> None:
             if rows:
                 processos.extend(_rows_to_processos(proc_key, rows))
 
+        contatos: List[Contato] = []
+        modelos: List[Modelo] = []
+        uteis_tables = table_cfg.get("uteis", {})
+
+        contatos_table = uteis_tables.get("contatos")
+        if contatos_table:
+            contato_rows = repo.read_table(uteis_sheet, contatos_table, "uteis_contatos")
+            for row in contato_rows:
+                nome = _to_str(row.get("CONTATO"))
+                if not nome:
+                    continue
+                contatos.append(
+                    Contato(
+                        contato=nome,
+                        municipio=_to_str(row.get("MUNICIPIO")),
+                        telefone=_to_str(row.get("TELEFONE")),
+                        whatsapp=_to_str(row.get("WHATSAPP"), "NÃO"),
+                        email=_to_str(row.get("E_MAIL")),
+                        categoria=_to_str(row.get("CATEGORIA")),
+                    )
+                )
+
+        modelos_table = uteis_tables.get("modelos")
+        if modelos_table:
+            modelo_rows = repo.read_table(uteis_sheet, modelos_table, "uteis_modelos")
+            for row in modelo_rows:
+                texto = _to_str(row.get("MODELO"))
+                descricao = _to_str(row.get("DESCRICAO"))
+                if not texto and not descricao:
+                    continue
+                modelos.append(
+                    Modelo(
+                        modelo=texto,
+                        descricao=descricao or "Modelo",
+                        utilizacao=_to_str(row.get("UTILIZACAO")) or "WhatsApp",
+                    )
+                )
+
         cache.update(
             {
                 "empresas": empresas,
                 "licencas": licencas,
                 "taxas": taxas,
                 "processos": processos,
+                "contatos": contatos,
+                "modelos": modelos,
                 "last_update": datetime.now().isoformat(),
             }
         )
         logger.info(
-            "Dados carregados: %s empresas, %s licenças, %s taxas, %s processos",
+            "Dados carregados: %s empresas, %s licenças, %s taxas, %s processos, %s contatos, %s modelos",
             len(empresas),
             len(licencas),
             len(taxas),
             len(processos),
+            len(contatos),
+            len(modelos),
         )
     except Exception as e:
         logger.exception("Erro ao carregar dados")
@@ -402,9 +514,9 @@ def get_empresa(empresa_id: int):
     if not empresa:
         raise HTTPException(status_code=404, detail="Empresa não encontrada")
 
-    licencas_stats = contar_licencas_por_status(cache["licencas"], empresa.empresa)
-    taxas_pend = contar_taxas_pendentes(cache["taxas"], empresa.empresa)
-    processos_count = contar_processos_empresa(cache["processos"], empresa.empresa)
+    licencas_stats = contar_licencas_por_status(cache["licencas"], empresa.id)
+    taxas_pend = contar_taxas_pendentes(cache["taxas"], empresa.id)
+    processos_count = contar_processos_empresa(cache["processos"], empresa.id)
 
     return {
         "empresa": EmpresaResponse.from_orm(empresa),
@@ -416,15 +528,18 @@ def get_empresa(empresa_id: int):
 
 
 @app.get("/api/licencas")
-def get_licencas(empresa: Optional[str] = None):
+def get_licencas(empresa_id: Optional[int] = None, empresa: Optional[str] = None):
     licencas: List[Licenca] = cache["licencas"]
-    if empresa:
+    if empresa_id is not None:
+        licencas = [l for l in licencas if l.empresa_id == empresa_id]
+    elif empresa:
         licencas = [l for l in licencas if l.empresa == empresa]
 
     result = []
     for lic in licencas:
         result.append(
             {
+                "empresa_id": lic.empresa_id,
                 "empresa": lic.empresa,
                 "tipo": lic.tipo,
                 "status": lic.status_display,
@@ -435,24 +550,39 @@ def get_licencas(empresa: Optional[str] = None):
     return result
 
 
-@app.get("/api/taxas")
+@app.get("/api/taxas", response_model=List[TaxaResponse])
 def get_taxas():
     taxas: List[Taxa] = cache["taxas"]
 
-    # Agrupar por empresa → formato "largo" p/ UI
-    result = []
-    empresas_unicas = sorted(set(t.empresa for t in taxas))
-    for emp in empresas_unicas:
-        taxas_emp = {t.tipo: t.status_display for t in taxas if t.empresa == emp}
-        result.append(
+    agrupado: Dict[int, Dict[str, Any]] = {}
+    defaults = {
+        output_key: ("*" if output_key != "status_geral" else None)
+        for _, output_key in TAXA_TIPOS_OUTPUT
+    }
+
+    for taxa in taxas:
+        if not taxa.empresa_id:
+            continue
+        linha = agrupado.setdefault(
+            taxa.empresa_id,
             {
-                "empresa": emp,
-                "tpi": taxas_emp.get("TPI", "*"),
-                "func": taxas_emp.get("Funcionamento", "*"),
-                "publicidade": taxas_emp.get("Publicidade", "*"),
-                "sanitaria": taxas_emp.get("Sanitária", "*"),
-            }
+                "empresa_id": taxa.empresa_id,
+                "empresa": taxa.empresa,
+                **defaults,
+            },
         )
+        for tipo_label, output_key in TAXA_TIPOS_OUTPUT:
+            if taxa.tipo == tipo_label:
+                valor = taxa.status_display
+                if output_key == "status_geral" and valor in {"", "*"}:
+                    valor = None
+                linha[output_key] = valor
+                break
+
+    result = sorted(
+        agrupado.values(),
+        key=lambda item: (item.get("empresa") or "").lower(),
+    )
     return result
 
 
@@ -463,15 +593,35 @@ def get_processos(tipo: Optional[str] = None, apenas_ativos: bool = False):
     )
     return [
         {
+            "empresa_id": p.empresa_id,
             "empresa": p.empresa,
             "tipo": p.tipo,
             "codigo": p.protocolo,
             "inicio": p.data_solicitacao,
             "prazo": p.prazo,
-            "status": p.situacao,
+            "status": p.status_display,
         }
         for p in processos
     ]
+
+
+@app.get("/api/uteis", response_model=UteisResponse)
+def get_uteis():
+    contatos = sorted(
+        cache["contatos"],
+        key=lambda c: (
+            (getattr(c, "categoria", "") or "").lower(),
+            (getattr(c, "contato", "") or "").lower(),
+        ),
+    )
+    modelos = sorted(
+        cache["modelos"],
+        key=lambda m: (
+            (getattr(m, "utilizacao", "") or "").lower(),
+            (getattr(m, "descricao", "") or "").lower(),
+        ),
+    )
+    return UteisResponse(contatos=contatos, modelos=modelos)
 
 
 @app.get("/api/kpis", response_model=KPIsResponse)
@@ -537,12 +687,12 @@ def diagnostico():
         proc_sheet = _sheet_name("processos", "PROCESSOS")
         processos_tables = repo.config.get("table_names", {}).get("processos", {})
         processos_required = {
-            "processos_diversos": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
-            "processos_funcionamento": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
-            "processos_bombeiros": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
-            "processos_uso_solo": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
-            "processos_sanitario": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
-            "processos_ambiental": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO"],
+            "processos_diversos": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
+            "processos_funcionamento": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
+            "processos_bombeiros": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
+            "processos_uso_solo": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
+            "processos_sanitario": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
+            "processos_ambiental": ["ID", "EMPRESA", "PROTOCOLO", "SITUACAO", "STATUS_PADRAO"],
         }
         for proc_key, table_name in processos_tables.items():
             sheet_key = f"processos_{proc_key}"

--- a/backend/models.py
+++ b/backend/models.py
@@ -38,7 +38,7 @@ class Empresa:
 @dataclass
 class Licenca:
     """Licença (estrutura normalizada em memória)"""
-    id: int
+    empresa_id: int
     empresa: str
     cnpj: str
     municipio: str
@@ -62,7 +62,7 @@ class Licenca:
 @dataclass
 class Taxa:
     """Taxa (estrutura normalizada em memória)"""
-    id: int
+    empresa_id: int
     empresa: str
     cnpj: str
     tipo: str  # TPI, FUNCIONAMENTO, PUBLICIDADE, SANITÁRIA, etc.
@@ -84,13 +84,14 @@ class Taxa:
 @dataclass
 class Processo:
     """Processo (comum a todos os tipos)"""
-    id: int
+    empresa_id: int
     empresa: str
     cnpj: str
     tipo: str  # Diversos, Funcionamento, Bombeiros, etc.
     protocolo: str
     data_solicitacao: str
     situacao: str
+    status_padrao: Optional[str] = None
     obs: str = ""
     prazo: Optional[str] = None
     # Campos específicos por tipo (opcionais)
@@ -106,9 +107,14 @@ class Processo:
     data_val: Optional[str] = None  # Sanitário
 
     @property
+    def status_display(self) -> str:
+        """Status padronizado para exibição."""
+        return (self.status_padrao or self.situacao or "").strip()
+
+    @property
     def status_cor(self) -> str:
         """Retorna emoji de cor baseado no status"""
-        status_lower = self.situacao.lower()
+        status_lower = self.status_display.lower()
         if "concluído" in status_lower or "aprovado" in status_lower or "licenciado" in status_lower:
             return "🟢"
         if "vencido" in status_lower or "indeferido" in status_lower:
@@ -146,7 +152,7 @@ class Modelo:
 @dataclass
 class LicencaRaw:
     """Licença raw (estrutura larga do Excel) - uso temporário para leitura"""
-    id: int
+    empresa_id: int
     empresa: str
     cnpj: str
     municipio: str
@@ -166,16 +172,18 @@ class LicencaRaw:
 @dataclass
 class TaxaRaw:
     """Taxa raw (estrutura larga do Excel) - uso temporário para leitura"""
-    id: int
+    empresa_id: int
     empresa: str
     cnpj: str
     data_envio: str = ""
     funcionamento: str = "*"
     publicidade: str = "*"
     sanitaria: str = "*"
-    localizacao: str = "*"
-    ocupacao: str = "*"
-    bombeiros: str = "*"
+    localizacao_instalacao: str = "*"
+    area_publica: str = "*"
+    localizacao: str = "*"  # compatibilidade retroativa
+    ocupacao: str = "*"  # compatibilidade retroativa
+    bombeiros: str = "*"  # compatibilidade retroativa
     tpi: str = "*"
     status_taxas: str = "Regular"
     obs: str = ""

--- a/backend/repo_excel.py
+++ b/backend/repo_excel.py
@@ -29,13 +29,14 @@ logger = logging.getLogger(__name__)
 class ExcelRepo:
     """Repositório para leitura/escrita segura em Excel com macros"""
 
-    def __init__(self, excel_path: str, config_path: str = "config.yaml"):
+    def __init__(self, excel_path: str, config_path: str = "config.yaml", *, data_only: bool = True):
         self.excel_path = Path(excel_path)
         self.config = self._load_config(config_path)
         self.wb: Optional[openpyxl.Workbook] = None
         # mapas de colunas (por chave lógica)
         self._column_maps: Dict[str, Dict[str, int]] = {}
         self._lock: Optional[portalocker.Lock] = None
+        self._data_only = data_only
 
     # ------------------------------------------------------------------
     # Config
@@ -156,7 +157,11 @@ class ExcelRepo:
                     str(self.excel_path), "r", timeout=lock_timeout, flags=portalocker.LOCK_SH
                 )
                 self._lock.acquire()
-                self.wb = load_workbook(self.excel_path, keep_vba=True, data_only=False)
+                self.wb = load_workbook(
+                    self.excel_path,
+                    keep_vba=True,
+                    data_only=self._data_only,
+                )
                 logger.info("Excel aberto: %s", self.excel_path)
                 return
             except (PermissionError, portalocker.exceptions.LockException) as e:

--- a/backend/services.py
+++ b/backend/services.py
@@ -91,6 +91,8 @@ def normalizar_licencas(licencas_raw: List[LicencaRaw]) -> List[Licenca]:
     }
 
     for raw in licencas_raw:
+        if not getattr(raw, "empresa_id", None):
+            continue
         for campo, tipo in tipos_map.items():
             status_attr = f"{campo}_status"
             val_attr = f"{campo}_val"
@@ -111,8 +113,12 @@ def normalizar_licencas(licencas_raw: List[LicencaRaw]) -> List[Licenca]:
                 elif status not in {"Dispensa", "Sujeito", "Possui", "Vencido", "Vence≤30d"}:
                     status = calcular_status_vencimento(validade)
 
+            status = status.strip() if isinstance(status, str) else status
+            if status in {"", "*"}:
+                continue
+
             licencas_norm.append(Licenca(
-                id=raw.id,
+                empresa_id=raw.empresa_id,
                 empresa=raw.empresa,
                 cnpj=raw.cnpj,
                 municipio=raw.municipio,
@@ -130,32 +136,45 @@ def normalizar_taxas(taxas_raw: List[TaxaRaw]) -> List[Taxa]:
     Transforma estrutura 'larga' em 'longa'
     """
     taxas_norm = []
-    
-    tipos_map = {
-        "tpi": "TPI",
-        "funcionamento": "Funcionamento",
-        "publicidade": "Publicidade",
-        "sanitaria": "Sanitária",
-        "localizacao": "Localização",
-        "ocupacao": "Ocupação",
-        "bombeiros": "Bombeiros"
-    }
-    
+
+    tipos_map = [
+        ("tpi", "TPI"),
+        ("funcionamento", "Funcionamento"),
+        ("publicidade", "Publicidade"),
+        ("sanitaria", "Sanitária"),
+        ("localizacao_instalacao", "Localização/Instalação"),
+        ("localizacao", "Localização/Instalação"),
+        ("area_publica", "Área Pública"),
+        ("ocupacao", "Área Pública"),
+        ("bombeiros", "Bombeiros"),
+        ("status_taxas", "Status Geral"),
+    ]
+
     for raw in taxas_raw:
-        for campo, tipo in tipos_map.items():
+        if not getattr(raw, "empresa_id", None):
+            continue
+        status_por_tipo: Dict[str, str] = {}
+
+        for campo, tipo in tipos_map:
             status_raw = getattr(raw, campo, "*")
-            if status_raw in ["", None]:
+            if status_raw in ("", None):
                 status_raw = "*"
-            
+            status_raw = str(status_raw)
+
+            atual = status_por_tipo.get(tipo)
+            if atual is None or (atual == "*" and status_raw != "*"):
+                status_por_tipo[tipo] = status_raw
+
+        for tipo, status_valor in status_por_tipo.items():
             taxas_norm.append(Taxa(
-                id=raw.id,
+                empresa_id=raw.empresa_id,
                 empresa=raw.empresa,
                 cnpj=raw.cnpj,
                 tipo=tipo,
-                status=str(status_raw),
+                status=status_valor,
                 data_envio=raw.data_envio
             ))
-    
+
     return taxas_norm
 
 
@@ -251,14 +270,20 @@ def filtrar_processos(
     
     if tipo:
         resultado = [p for p in resultado if p.tipo == tipo]
-    
+
     if situacao:
-        resultado = [p for p in resultado if p.situacao == situacao]
-    
+        resultado = [
+            p for p in resultado
+            if (p.status_padrao or p.situacao) == situacao
+        ]
+
     if apenas_ativos:
         inativos = {"CONCLUÍDO", "LICENCIADO", "Aprovado", "INDEFERIDO"}
-        resultado = [p for p in resultado if p.situacao not in inativos]
-    
+        resultado = [
+            p for p in resultado
+            if (p.status_padrao or p.situacao) not in inativos
+        ]
+
     return resultado
 
 
@@ -266,21 +291,21 @@ def filtrar_processos(
 # MÉTRICAS (helpers para UI)
 # ============================================================================
 
-def contar_licencas_por_status(licencas: List[Licenca], empresa_nome: str) -> Dict[str, int]:
+def contar_licencas_por_status(licencas: List[Licenca], empresa_id: int) -> Dict[str, int]:
     """Conta licenças por status para uma empresa"""
-    lics = [l for l in licencas if l.empresa == empresa_nome]
-    
+    lics = [l for l in licencas if l.empresa_id == empresa_id]
+
     return {
         "ativas": len([l for l in lics if l.status_display == "Possui"]),
         "vencendo": len([l for l in lics if l.status_display == "Vence≤30d"]),
         "vencidas": len([l for l in lics if l.status_display == "Vencido"]),
-        "total": len(lics)
+        "total": len([l for l in lics if l.status_display not in {"", "*"}])
     }
 
 
-def contar_taxas_pendentes(taxas: List[Taxa], empresa_nome: str) -> int:
+def contar_taxas_pendentes(taxas: List[Taxa], empresa_id: int) -> int:
     """Conta taxas pendentes de uma empresa"""
-    txs = [t for t in taxas if t.empresa == empresa_nome]
+    txs = [t for t in taxas if t.empresa_id == empresa_id]
     pendentes = [
         t for t in txs
         if t.status_display in ["Não pago", "Vencido"] or "Aberto" in t.status
@@ -288,9 +313,9 @@ def contar_taxas_pendentes(taxas: List[Taxa], empresa_nome: str) -> int:
     return len(pendentes)
 
 
-def contar_processos_empresa(processos: List[Processo], empresa_nome: str) -> int:
+def contar_processos_empresa(processos: List[Processo], empresa_id: int) -> int:
     """Conta processos de uma empresa"""
-    return len([p for p in processos if p.empresa == empresa_nome])
+    return len([p for p in processos if p.empresa_id == empresa_id])
 
 
 def calcular_kpis_globais(

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -160,19 +160,146 @@ const LIC_COLORS = {
   Ambiental: "border-emerald-600 text-emerald-700",
 };
 
-const STATUS_STYLES = {
-  Possui: "bg-emerald-100 text-emerald-700 border-emerald-200",
-  Vencido: "bg-red-100 text-red-700 border-red-200",
-  "Vence≤30d": "bg-amber-100 text-amber-800 border-amber-200",
-  Dispensa: "bg-indigo-100 text-indigo-700 border-indigo-200",
-  Sujeito: "bg-slate-200 text-slate-700 border-slate-300",
-  Pago: "bg-emerald-100 text-emerald-700 border-emerald-200",
-  "Não pago": "bg-red-100 text-red-700 border-red-200",
-  SIM: "bg-emerald-100 text-emerald-700 border-emerald-200",
-  NÃO: "bg-red-100 text-red-700 border-red-200",
+const removeDiacritics = (value) => {
+  if (typeof value !== "string") return "";
+  return value.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 };
 
-const ALERT_STATUSES = new Set(["Vencido", "Vence≤30d", "Não pago"]);
+const getStatusKey = (status) => removeDiacritics(normalizeTextLower(status));
+
+const hasRelevantStatus = (status) => {
+  const statusText = normalizeText(status).trim();
+  if (!statusText || statusText === "*" || statusText === "-" || statusText === "—") {
+    return false;
+  }
+  const statusKey = getStatusKey(statusText);
+  return Boolean(statusKey && statusKey !== "*");
+};
+
+const toFiniteNumber = (value) => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return undefined;
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+};
+
+const extractEmpresaId = (entity) => {
+  if (!entity || typeof entity !== "object") return undefined;
+  const candidates = [entity.empresa_id, entity.empresaId, entity.id];
+  for (const candidate of candidates) {
+    const numeric = toFiniteNumber(candidate);
+    if (numeric !== undefined) {
+      return numeric;
+    }
+  }
+  return undefined;
+};
+
+const normalizeEmpresaRelacionada = (entity) => {
+  if (!entity || typeof entity !== "object") return entity;
+  const empresaId = extractEmpresaId(entity);
+  return {
+    ...entity,
+    empresaId,
+    empresa_id: empresaId,
+  };
+};
+
+const ALERT_STATUS_KEYWORDS = ["vencid", "vence", "nao pago", "nao-pago", "negad", "indefer"];
+
+const isAlertStatus = (status) => {
+  const key = getStatusKey(status);
+  if (!key) return false;
+  if (key.includes("nao se aplica") || key.includes("n/a")) return false;
+  return ALERT_STATUS_KEYWORDS.some((keyword) => key.includes(keyword));
+};
+
+const PROCESS_INACTIVE_KEYWORDS = ["concluido", "licenciado", "aprovado", "indeferido", "negado", "finalizado"];
+
+const isProcessStatusInactive = (status) => {
+  const key = getStatusKey(status);
+  if (!key) return false;
+  return PROCESS_INACTIVE_KEYWORDS.some((keyword) => key.includes(keyword));
+};
+
+const STATUS_VARIANT_CLASSES = {
+  success: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  warning: "bg-amber-100 text-amber-800 border-amber-200",
+  danger: "bg-red-100 text-red-700 border-red-200",
+  info: "bg-sky-100 text-sky-700 border-sky-200",
+  neutral: "bg-slate-100 text-slate-700 border-slate-200",
+};
+
+const resolveStatusClass = (status) => {
+  const key = getStatusKey(status);
+  if (!key || key === "*" || key === "-" || key === "—") {
+    return STATUS_VARIANT_CLASSES.neutral;
+  }
+  if (key.includes("nao se aplica") || key.includes("n/a")) {
+    return STATUS_VARIANT_CLASSES.info;
+  }
+  if (
+    key.startsWith("nao ") ||
+    key === "nao" ||
+    key.includes("nao pago") ||
+    key.includes("inadimpl") ||
+    key.includes("negad") ||
+    key.includes("indefer") ||
+    key.includes("vencid") ||
+    key.includes("irregular") ||
+    key.includes("suspens") ||
+    key.includes("cancel") ||
+    key.includes("bloque")
+  ) {
+    return STATUS_VARIANT_CLASSES.danger;
+  }
+  if (
+    key.includes("vence") ||
+    key.includes("pend") ||
+    key.includes("aguard") ||
+    key.includes("andament") ||
+    key.includes("analise") ||
+    key.includes("abert") ||
+    key.includes("tram") ||
+    key.includes("atraso")
+  ) {
+    return STATUS_VARIANT_CLASSES.warning;
+  }
+  if (
+    key.includes("dispens") ||
+    key.includes("sujeit") ||
+    key.includes("orient") ||
+    key.includes("inform") ||
+    key.includes("consult")
+  ) {
+    return STATUS_VARIANT_CLASSES.info;
+  }
+  if (
+    key.includes("conclu") ||
+    key.includes("aprov") ||
+    key.includes("licenc") ||
+    key.includes("defer") ||
+    key.includes("emit") ||
+    key.includes("vigent") ||
+    key.includes("pago") ||
+    key.includes("regular") ||
+    key.includes("quit") ||
+    key.includes("possui") ||
+    key.includes("ativo") ||
+    key === "sim"
+  ) {
+    return STATUS_VARIANT_CLASSES.success;
+  }
+  return STATUS_VARIANT_CLASSES.neutral;
+};
 
 const normalizeText = (value) => {
   if (value === null || value === undefined) {
@@ -213,10 +340,13 @@ const enhanceEmpresa = (empresa) => {
     normalizeIdentifier(empresa.inscricao_municipal) ||
     normalizeIdentifier(empresa.inscricaoMunicipal) ||
     normalizeIdentifier(empresa["inscrição_municipal"]);
+  const empresaId = extractEmpresaId(empresa);
   return {
     ...empresa,
     ie,
     im,
+    empresaId: empresaId ?? empresa?.id,
+    empresa_id: empresaId ?? empresa?.id,
   };
 };
 
@@ -252,10 +382,13 @@ function CopyableIdentifier({ label, value, onCopy }) {
 }
 
 function StatusBadge({ status }) {
-  const style = STATUS_STYLES[status] || "bg-slate-100 text-slate-700 border-slate-200";
+  const normalized = normalizeText(status);
+  const trimmed = normalized.trim();
+  const displayValue = trimmed === "" || trimmed === "*" || trimmed === "-" || trimmed === "—" ? "—" : trimmed;
+  const style = resolveStatusClass(status);
   return (
     <InlineBadge variant="outline" className={style}>
-      {status}
+      {displayValue}
     </InlineBadge>
   );
 }
@@ -302,6 +435,8 @@ export default function App() {
   const [processos, setProcessos] = useState([]);
   const [kpis, setKpis] = useState({});
   const [municipios, setMunicipios] = useState([]);
+  const [contatos, setContatos] = useState([]);
+  const [modelos, setModelos] = useState([]);
   const [loading, setLoading] = useState(true);
 
   const tiposLicenca = useMemo(() => {
@@ -346,6 +481,36 @@ export default function App() {
     }, []);
   }, [municipios]);
 
+  const contatosOrdenados = useMemo(() => {
+    return [...contatos]
+      .filter((item) => item && (item.contato || item.email || item.telefone))
+      .sort((a, b) => {
+        const catA = normalizeText(a?.categoria || "");
+        const catB = normalizeText(b?.categoria || "");
+        if (catA !== catB) {
+          return catA.localeCompare(catB, "pt-BR");
+        }
+        const nomeA = normalizeText(a?.contato || "");
+        const nomeB = normalizeText(b?.contato || "");
+        return nomeA.localeCompare(nomeB, "pt-BR");
+      });
+  }, [contatos]);
+
+  const modelosOrdenados = useMemo(() => {
+    return [...modelos]
+      .filter((item) => item && (item.modelo || item.descricao))
+      .sort((a, b) => {
+        const usoA = normalizeText(a?.utilizacao || "");
+        const usoB = normalizeText(b?.utilizacao || "");
+        if (usoA !== usoB) {
+          return usoA.localeCompare(usoB, "pt-BR");
+        }
+        const descA = normalizeText(a?.descricao || "");
+        const descB = normalizeText(b?.descricao || "");
+        return descA.localeCompare(descB, "pt-BR");
+      });
+  }, [modelos]);
+
   useEffect(() => {
     let mounted = true;
     setLoading(true);
@@ -356,18 +521,30 @@ export default function App() {
       fetchJson("/processos"),
       fetchJson("/kpis"),
       fetchJson("/municipios"),
+      fetchJson("/uteis"),
     ])
-      .then(([emp, lic, tax, proc, kpi, mun]) => {
+      .then(([emp, lic, tax, proc, kpi, mun, uteis]) => {
         if (!mounted) return;
         const empresasNormalizadas = Array.isArray(emp)
           ? emp.map((item) => enhanceEmpresa(item))
           : [];
+        const licencasNormalizadas = Array.isArray(lic)
+          ? lic.map((item) => normalizeEmpresaRelacionada(item))
+          : [];
+        const taxasNormalizadas = Array.isArray(tax)
+          ? tax.map((item) => normalizeEmpresaRelacionada(item))
+          : [];
+        const processosComEmpresa = Array.isArray(proc)
+          ? proc.map((item) => normalizeEmpresaRelacionada(item))
+          : [];
         setEmpresas(empresasNormalizadas);
-        setLicencas(Array.isArray(lic) ? lic : []);
-        setTaxas(Array.isArray(tax) ? tax : []);
-        setProcessos(Array.isArray(proc) ? proc : []);
+        setLicencas(licencasNormalizadas);
+        setTaxas(taxasNormalizadas);
+        setProcessos(processosComEmpresa);
         setKpis(kpi);
         setMunicipios(Array.isArray(mun) ? mun : []);
+        setContatos(Array.isArray(uteis?.contatos) ? uteis.contatos : []);
+        setModelos(Array.isArray(uteis?.modelos) ? uteis.modelos : []);
         setLoading(false);
       })
       .catch((error) => {
@@ -379,6 +556,8 @@ export default function App() {
           setProcessos([]);
           setKpis({});
           setMunicipios([]);
+          setContatos([]);
+          setModelos([]);
           setLoading(false);
           enqueueToast("Não foi possível carregar os dados.");
         }
@@ -391,9 +570,11 @@ export default function App() {
   const licencasByEmpresa = useMemo(() => {
     const map = new Map();
     licencas.forEach((lic) => {
-      const group = map.get(lic.empresa) || [];
+      const empresaId = extractEmpresaId(lic);
+      if (empresaId === undefined) return;
+      const group = map.get(empresaId) || [];
       group.push(lic);
-      map.set(lic.empresa, group);
+      map.set(empresaId, group);
     });
     return map;
   }, [licencas]);
@@ -401,26 +582,35 @@ export default function App() {
   const taxasByEmpresa = useMemo(() => {
     const map = new Map();
     taxas.forEach((tx) => {
-      map.set(tx.empresa, tx);
+      const empresaId = extractEmpresaId(tx);
+      if (empresaId === undefined) return;
+      map.set(empresaId, tx);
     });
     return map;
   }, [taxas]);
 
   const processosNormalizados = useMemo(
     () =>
-      processos.map((proc) => ({
-        ...proc,
-        tipoNormalizado: normalizeProcessType(proc),
-      })),
+      processos.map((proc) => {
+        const empresaId = extractEmpresaId(proc);
+        return {
+          ...proc,
+          empresaId,
+          empresa_id: empresaId,
+          tipoNormalizado: normalizeProcessType(proc),
+        };
+      }),
     [processos],
   );
 
   const processosByEmpresa = useMemo(() => {
     const map = new Map();
     processosNormalizados.forEach((proc) => {
-      const group = map.get(proc.empresa) || [];
+      const empresaId = extractEmpresaId(proc);
+      if (empresaId === undefined) return;
+      const group = map.get(empresaId) || [];
       group.push(proc);
-      map.set(proc.empresa, group);
+      map.set(empresaId, group);
     });
     return map;
   }, [processosNormalizados]);
@@ -460,24 +650,25 @@ export default function App() {
   const companyHasAlert = useCallback(
     (empresa) => {
       if (!empresa) return false;
+      const empresaId = extractEmpresaId(empresa);
+      if (empresaId === undefined) return false;
       const debitoLower = normalizeTextLower(empresa.debito);
       const certificadoLower = normalizeTextLower(empresa.certificado);
       if (debitoLower === "sim" || certificadoLower === "não") {
         return true;
       }
-      const licList = licencasByEmpresa.get(empresa.empresa) || [];
-      const hasLicencaAlert = licList.some((lic) => ALERT_STATUSES.has(lic.status));
+      const licList = licencasByEmpresa.get(empresaId) || [];
+      const hasLicencaAlert = licList.some((lic) => isAlertStatus(lic.status));
       if (hasLicencaAlert) return true;
-      const taxa = taxasByEmpresa.get(empresa.empresa);
+      const taxa = taxasByEmpresa.get(empresaId);
       if (taxa) {
         const entries = [taxa.tpi, taxa.func, taxa.publicidade, taxa.sanitaria];
-        if (entries.some((status) => ALERT_STATUSES.has(status))) {
+        if (entries.some((status) => isAlertStatus(status))) {
           return true;
         }
       }
-      const processosEmpresa = processosByEmpresa.get(empresa.empresa) || [];
-      const inativos = new Set(["CONCLUÍDO", "LICENCIADO", "Aprovado", "INDEFERIDO"]);
-      return processosEmpresa.some((proc) => !inativos.has(proc.status));
+      const processosEmpresa = processosByEmpresa.get(empresaId) || [];
+      return processosEmpresa.some((proc) => !isProcessStatusInactive(proc.status));
     },
     [licencasByEmpresa, processosByEmpresa, taxasByEmpresa],
   );
@@ -521,11 +712,15 @@ export default function App() {
   const licencaResumo = useMemo(() => {
     return licencas.reduce(
       (acc, lic) => {
+        if (!hasRelevantStatus(lic?.status)) {
+          return acc;
+        }
+        const statusKey = getStatusKey(lic.status);
         acc.total += 1;
-        if (lic.status === "Vencido") acc.vencidas += 1;
-        else if (lic.status === "Vence≤30d") acc.vencendo += 1;
-        else if (lic.status === "Dispensa") acc.dispensa += 1;
-        else if (lic.status === "Sujeito") acc.sujeito += 1;
+        if (statusKey.includes("vencid")) acc.vencidas += 1;
+        else if (statusKey.includes("vence")) acc.vencendo += 1;
+        else if (statusKey.includes("dispens")) acc.dispensa += 1;
+        else if (statusKey.includes("sujeit")) acc.sujeito += 1;
         else acc.ativas += 1;
         return acc;
       },
@@ -538,10 +733,12 @@ export default function App() {
     licencas.forEach((lic) => {
       const validade = parsePtDate(lic.validade);
       if (!validade) return;
+      if (!hasRelevantStatus(lic.status)) return;
+      const statusKey = getStatusKey(lic.status);
       const key = `${validade.getFullYear()}-${validade.getMonth()}`;
       const entry = monthly.get(key) || { date: validade, vencidas: 0, vencendo: 0 };
-      if (lic.status === "Vencido") entry.vencidas += 1;
-      else if (lic.status === "Vence≤30d") entry.vencendo += 1;
+      if (statusKey.includes("vencid")) entry.vencidas += 1;
+      else if (statusKey.includes("vence")) entry.vencendo += 1;
       monthly.set(key, entry);
     });
     if (monthly.size === 0) {
@@ -585,13 +782,11 @@ export default function App() {
         ? processosNormalizados
         : processosNormalizados.filter((proc) => proc.tipoNormalizado === selectedTipo);
     if (!modoFoco) return listaBase;
-    const inativos = new Set(["CONCLUÍDO", "LICENCIADO", "Aprovado", "INDEFERIDO"]);
-    return listaBase.filter((proc) => !inativos.has(proc.status));
+    return listaBase.filter((proc) => !isProcessStatusInactive(proc.status));
   }, [modoFoco, processosNormalizados, selectedTipo]);
 
   const processosAtivos = useMemo(() => {
-    const inativos = new Set(["CONCLUÍDO", "LICENCIADO", "Aprovado", "INDEFERIDO"]);
-    return processosNormalizados.filter((proc) => !inativos.has(proc.status));
+    return processosNormalizados.filter((proc) => !isProcessStatusInactive(proc.status));
   }, [processosNormalizados]);
 
   const selfTestResults = useMemo(
@@ -824,8 +1019,12 @@ export default function App() {
                       Nenhuma pendência identificada no momento.
                     </li>
                   )}
-                  {empresasComPendencias.map((empresa) => (
-                    <li key={empresa.id} className="px-4 py-3 text-sm">
+                  {empresasComPendencias.map((empresa) => {
+                    const empresaId = extractEmpresaId(empresa);
+                    const licencasPendentes =
+                      empresaId !== undefined ? licencasByEmpresa.get(empresaId) || [] : [];
+                    return (
+                      <li key={empresa.id} className="px-4 py-3 text-sm">
                       <div className="flex items-start justify-between gap-4">
                         <div>
                           <p className="font-medium text-slate-800">{empresa.empresa}</p>
@@ -838,16 +1037,17 @@ export default function App() {
                             <StatusBadge status="Não pago" />
                           )}
                           {normalizeTextLower(empresa.certificado) === "não" && <StatusBadge status="NÃO" />}
-                          {(licencasByEmpresa.get(empresa.empresa) || [])
-                            .filter((lic) => ALERT_STATUSES.has(lic.status))
+                          {licencasPendentes
+                            .filter((lic) => isAlertStatus(lic.status))
                             .slice(0, 2)
                             .map((lic) => (
                               <StatusBadge key={`${empresa.id}-${lic.tipo}`} status={lic.status} />
                             ))}
                         </div>
                       </div>
-                    </li>
-                  ))}
+                      </li>
+                    );
+                  })}
                 </ul>
               </ScrollArea>
             </CardContent>
@@ -863,21 +1063,27 @@ export default function App() {
           </div>
           <div className="grid gap-3 lg:grid-cols-2">
             {filteredEmpresas.map((empresa) => {
-              const licList = licencasByEmpresa.get(empresa.empresa) || [];
+              const empresaId = extractEmpresaId(empresa);
+              const licList = empresaId !== undefined ? licencasByEmpresa.get(empresaId) || [] : [];
               const licSummary = licList.reduce(
                 (acc, lic) => {
+                  if (!hasRelevantStatus(lic.status)) {
+                    return acc;
+                  }
+                  const statusKey = getStatusKey(lic.status);
                   acc.total += 1;
-                  if (lic.status === "Vencido") acc.vencidas += 1;
-                  else if (lic.status === "Vence≤30d") acc.vencendo += 1;
+                  if (statusKey.includes("vencid")) acc.vencidas += 1;
+                  else if (statusKey.includes("vence")) acc.vencendo += 1;
                   else acc.ativas += 1;
                   return acc;
                 },
                 { total: 0, ativas: 0, vencendo: 0, vencidas: 0 },
               );
-              const taxa = taxasByEmpresa.get(empresa.empresa);
-              const processosEmpresa = processosByEmpresa.get(empresa.empresa) || [];
-              const processosAtivosEmpresa = processosEmpresa.filter((proc) =>
-                processosAtivos.includes(proc),
+              const taxa = empresaId !== undefined ? taxasByEmpresa.get(empresaId) : undefined;
+              const processosEmpresa =
+                empresaId !== undefined ? processosByEmpresa.get(empresaId) || [] : [];
+              const processosAtivosEmpresa = processosEmpresa.filter(
+                (proc) => !isProcessStatusInactive(proc.status),
               );
               return (
                 <Card key={empresa.id} className="shadow-sm overflow-hidden border border-white/60">
@@ -960,7 +1166,7 @@ export default function App() {
                               Taxas pend.:
                               {taxa
                                 ? [taxa.tpi, taxa.func, taxa.publicidade, taxa.sanitaria].filter((status) =>
-                                    ALERT_STATUSES.has(status),
+                                    isAlertStatus(status),
                                   ).length
                                 : 0}
                             </p>
@@ -1056,10 +1262,15 @@ export default function App() {
 
           <div className="flex flex-wrap gap-2 mb-3">
             {["Todos", ...tiposLicenca].map((tipo) => {
-              const count =
-                tipo === "Todos"
-                  ? licencas.length
-                  : licencas.filter((lic) => normalizeText(lic?.tipo).trim() === tipo).length;
+              const count = licencas.filter((lic) => {
+                if (!hasRelevantStatus(lic.status)) {
+                  return false;
+                }
+                if (tipo === "Todos") {
+                  return true;
+                }
+                return normalizeText(lic?.tipo).trim() === tipo;
+              }).length;
               const icon = tipo === "Todos" ? null : LIC_ICONS[tipo] || <Settings className="h-4 w-4" />;
               return (
                 <Button
@@ -1088,8 +1299,11 @@ export default function App() {
               tiposLicencaSelecionados.map((tipo) => {
                 const registros = licencas
                   .filter((lic) => normalizeText(lic?.tipo).trim() === tipo)
+                  .filter((lic) => hasRelevantStatus(lic.status))
                   .filter((lic) =>
-                    modoFoco ? ALERT_STATUSES.has(lic.status) || lic.status === "Sujeito" : true,
+                    modoFoco
+                      ? isAlertStatus(lic.status) || getStatusKey(lic.status).includes("sujeit")
+                      : true,
                   );
                 const icon = LIC_ICONS[tipo] || <Settings className="h-4 w-4" />;
                 return (
@@ -1113,7 +1327,7 @@ export default function App() {
                           </TableHeader>
                           <TableBody>
                             {registros.map((lic, index) => (
-                              <TableRow key={`${lic.empresa}-${lic.tipo}-${index}`}>
+                              <TableRow key={`${lic.empresa_id ?? lic.empresa}-${lic.tipo}-${index}`}>
                                 <TableCell className="font-medium">{lic.empresa}</TableCell>
                                 <TableCell>
                                   <StatusBadge status={lic.status} />
@@ -1159,12 +1373,12 @@ export default function App() {
                       .filter((taxa) =>
                         modoFoco
                           ? [taxa.tpi, taxa.func, taxa.publicidade, taxa.sanitaria].some((status) =>
-                              ALERT_STATUSES.has(status),
+                              isAlertStatus(status),
                             )
                           : true,
                       )
                       .map((taxa, index) => (
-                        <TableRow key={`${taxa.empresa}-${index}`}>
+                        <TableRow key={`${taxa.empresa_id ?? taxa.empresa}-${index}`}>
                           <TableCell className="font-medium">{taxa.empresa}</TableCell>
                           <TableCell>
                             <StatusBadge status={taxa.tpi} />
@@ -1260,52 +1474,62 @@ export default function App() {
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-3 text-sm">
-                {["Prefeitura de Anápolis", "Vigilância Sanitária", "Corpo de Bombeiros"]
-                  .map((org, index) => {
-                    const contato =
-                      index === 0
-                        ? {
-                            email: "atendimento@anapolis.go.gov.br",
-                            fone: "(62) 3902-0000",
-                            site: "https://www.anapolis.go.gov.br",
-                          }
-                        : index === 1
-                          ? {
-                              email: "visa@go.gov.br",
-                              fone: "(62) 3201-0000",
-                              site: "https://saude.go.gov.br",
-                            }
-                          : {
-                              email: "atendimento@bombeiros.go.gov.br",
-                              fone: "193",
-                              site: "https://www.bombeiros.go.gov.br",
-                            };
-                    return (
-                      <div key={org} className="rounded-xl border border-slate-200 bg-white p-4 space-y-2">
-                        <div className="flex items-center justify-between gap-3">
-                          <div>
-                            <p className="font-medium text-slate-800">{org}</p>
-                            <p className="text-xs text-slate-500">{contato.site}</p>
-                          </div>
+                {contatosOrdenados.length === 0 && (
+                  <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">
+                    Nenhum contato cadastrado no Excel.
+                  </div>
+                )}
+                {contatosOrdenados.map((contato) => {
+                  const whatsappTexto = normalizeTextLower(contato.whatsapp || "");
+                  const temWhatsapp =
+                    whatsappTexto !== "" &&
+                    !["nao", "não", "nao possui", "não possui"].some((neg) => whatsappTexto.includes(neg));
+                  const info = [contato.email, contato.telefone, temWhatsapp ? contato.whatsapp : null]
+                    .filter((value) => value && value.toString().trim() !== "")
+                    .join(" • ");
+                  const municipioInfo = [contato.categoria, contato.municipio]
+                    .filter((value) => value && value.toString().trim() !== "")
+                    .join(" • ");
+                  return (
+                    <div
+                      key={`${contato.contato}-${contato.email}-${contato.telefone}`}
+                      className="rounded-xl border border-slate-200 bg-white p-4 space-y-2"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="font-medium text-slate-800">{contato.contato}</p>
+                          {municipioInfo && <p className="text-xs text-slate-500">{municipioInfo}</p>}
+                        </div>
+                        {info && (
                           <Button
                             size="icon"
                             variant="ghost"
-                            onClick={() => handleCopy(`${contato.email} • ${contato.fone}`, `Contato copiado de ${org}`)}
+                            onClick={() => handleCopy(info, `Contato copiado de ${contato.contato}`)}
                           >
                             <Clipboard className="h-4 w-4" />
                           </Button>
-                        </div>
-                        <div className="flex flex-wrap gap-2 text-xs">
+                        )}
+                      </div>
+                      <div className="flex flex-wrap gap-2 text-xs">
+                        {contato.email && (
                           <InlineBadge variant="outline" className="bg-white">
                             <Mail className="h-3 w-3 mr-1" /> {contato.email}
                           </InlineBadge>
+                        )}
+                        {contato.telefone && (
                           <InlineBadge variant="outline" className="bg-white">
-                            <Phone className="h-3 w-3 mr-1" /> {contato.fone}
+                            <Phone className="h-3 w-3 mr-1" /> {contato.telefone}
                           </InlineBadge>
-                        </div>
+                        )}
+                        {temWhatsapp && (
+                          <InlineBadge variant="outline" className="bg-white">
+                            <Phone className="h-3 w-3 mr-1" /> WhatsApp: {contato.whatsapp}
+                          </InlineBadge>
+                        )}
                       </div>
-                    );
-                  })}
+                    </div>
+                  );
+                })}
               </CardContent>
             </Card>
 
@@ -1316,40 +1540,36 @@ export default function App() {
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-3 text-sm">
-                {[
-                  {
-                    titulo: "Cobrança de documentos",
-                    texto:
-                      "Olá! Poderiam encaminhar os documentos pendentes listados no eControle para avançarmos no processo?",
-                  },
-                  {
-                    titulo: "Agendamento de vistoria",
-                    texto:
-                      "Boa tarde! Podemos agendar a vistoria para a próxima semana? Favor confirmar a disponibilidade da equipe.",
-                  },
-                  {
-                    titulo: "Lembrete de renovação",
-                    texto:
-                      "Estamos nos aproximando do prazo de renovação da licença. Poderiam verificar os documentos necessários?",
-                  },
-                ].map((modelo) => (
-                  <div key={modelo.titulo} className="rounded-xl border border-slate-200 bg-white p-4 space-y-2">
+                {modelosOrdenados.length === 0 && (
+                  <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">
+                    Nenhum modelo cadastrado no Excel.
+                  </div>
+                )}
+                {modelosOrdenados.map((modelo) => (
+                  <div
+                    key={`${modelo.descricao || "Modelo"}-${(modelo.modelo || "").slice(0, 20)}`}
+                    className="rounded-xl border border-slate-200 bg-white p-4 space-y-2"
+                  >
                     <div className="flex items-start justify-between gap-3">
                       <div>
-                        <p className="font-medium text-slate-800">{modelo.titulo}</p>
+                        <p className="font-medium text-slate-800">{modelo.descricao || "Modelo"}</p>
                         <p className="text-xs text-slate-500">
-                          Clique para copiar e enviar no canal preferido.
+                          {modelo.utilizacao ? `Uso: ${modelo.utilizacao}` : "Clique para copiar e enviar."}
                         </p>
                       </div>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        onClick={() => handleCopy(modelo.texto, `Mensagem copiada: ${modelo.titulo}`)}
-                      >
-                        <Clipboard className="h-4 w-4" />
-                      </Button>
+                      {modelo.modelo && (
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={() => handleCopy(modelo.modelo, `Mensagem copiada: ${modelo.descricao || "Modelo"}`)}
+                        >
+                          <Clipboard className="h-4 w-4" />
+                        </Button>
+                      )}
                     </div>
-                    <p className="text-sm text-slate-600 leading-relaxed">{modelo.texto}</p>
+                    {modelo.modelo && (
+                      <p className="text-sm text-slate-600 leading-relaxed whitespace-pre-line">{modelo.modelo}</p>
+                    )}
                   </div>
                 ))}
               </CardContent>


### PR DESCRIPTION
## Summary
- align backend models and API responses to surface the empresa ID across licenças, taxas e processos
- ignore licenças sem status válido ao normalizar e ao calcular totais, além de agrupar taxas por ID interno
- atualizar o frontend para cruzar dados via ID e aplicar nova paleta consistente aos badges de status

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e032605f008326a19b5de111353686