### PR TITLE
Refactor App.jsx to reduce redundancy

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -194,6 +194,15 @@ const hasRelevantStatus = (status) => {
   return Boolean(statusKey && statusKey !== "*");
 };
 
+const createFieldsMatcher = (normalizedQuery) => (fields = []) => {
+  if (!normalizedQuery) {
+    return true;
+  }
+  return fields
+    .filter((field) => field !== null && field !== undefined)
+    .some((field) => normalizeTextLower(field).includes(normalizedQuery));
+};
+
 const toFiniteNumber = (value) => {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
@@ -514,6 +523,81 @@ const normalizeText = (value) => {
 
 const normalizeTextLower = (value) => normalizeText(value).toLowerCase();
 
+const sortContatos = (lista = []) =>
+  [...lista]
+    .filter((item) => item && (item.contato || item.email || item.telefone))
+    .sort((a, b) => {
+      const catA = normalizeText(a?.categoria || "");
+      const catB = normalizeText(b?.categoria || "");
+      if (catA !== catB) {
+        return catA.localeCompare(catB, "pt-BR");
+      }
+      const nomeA = normalizeText(a?.contato || "");
+      const nomeB = normalizeText(b?.contato || "");
+      return nomeA.localeCompare(nomeB, "pt-BR");
+    });
+
+const sortModelos = (lista = []) =>
+  [...lista]
+    .filter((item) => item && (item.modelo || item.descricao))
+    .sort((a, b) => {
+      const usoA = normalizeText(a?.utilizacao || "");
+      const usoB = normalizeText(b?.utilizacao || "");
+      if (usoA !== usoB) {
+        return usoA.localeCompare(usoB, "pt-BR");
+      }
+      const descA = normalizeText(a?.descricao || "");
+      const descB = normalizeText(b?.descricao || "");
+      return descA.localeCompare(descB, "pt-BR");
+    });
+
+const getLicencaTipo = (lic) => normalizeText(lic?.tipo).trim();
+
+const aggregateLicencasPorTipo = (licencas) => {
+  const mapa = new Map();
+  let totalRelevantes = 0;
+
+  licencas.forEach((lic) => {
+    const tipo = getLicencaTipo(lic);
+    if (!tipo) {
+      return;
+    }
+
+    const existente =
+      mapa.get(tipo) || {
+        tipo,
+        items: [],
+        relevantes: [],
+        contagens: { vencido: 0, vencendo: 0, sujeito: 0, dispensa: 0, possui: 0 },
+      };
+
+    existente.items.push(lic);
+
+    const statusNormalizado = normalizeText(lic?.status).trim();
+    if (statusNormalizado === "Vencido") existente.contagens.vencido += 1;
+    else if (statusNormalizado === "Vence≤30d") existente.contagens.vencendo += 1;
+    else if (statusNormalizado === "Sujeito") existente.contagens.sujeito += 1;
+    else if (statusNormalizado === "Dispensa") existente.contagens.dispensa += 1;
+
+    if (hasRelevantStatus(lic.status)) {
+      existente.relevantes.push(lic);
+      totalRelevantes += 1;
+    }
+
+    mapa.set(tipo, existente);
+  });
+
+  mapa.forEach((grupo) => {
+    const { contagens, items } = grupo;
+    contagens.possui = Math.max(
+      items.length - contagens.vencido - contagens.vencendo - contagens.sujeito - contagens.dispensa,
+      0,
+    );
+  });
+
+  return { byTipo: mapa, totalRelevant: totalRelevantes };
+};
+
 const normalizeProcessType = (proc) => {
   const rawValue =
     typeof proc === "string"
@@ -741,7 +825,7 @@ export default function App() {
       }
     });
     licencas.forEach((lic) => {
-      const tipo = normalizeText(lic?.tipo).trim();
+      const tipo = getLicencaTipo(lic);
       if (tipo === "" || seen.has(tipo)) {
         return;
       }
@@ -779,36 +863,6 @@ export default function App() {
       return acc;
     }, []);
   }, [municipios]);
-
-  const contatosOrdenados = useMemo(() => {
-    return [...contatos]
-      .filter((item) => item && (item.contato || item.email || item.telefone))
-      .sort((a, b) => {
-        const catA = normalizeText(a?.categoria || "");
-        const catB = normalizeText(b?.categoria || "");
-        if (catA !== catB) {
-          return catA.localeCompare(catB, "pt-BR");
-        }
-        const nomeA = normalizeText(a?.contato || "");
-        const nomeB = normalizeText(b?.contato || "");
-        return nomeA.localeCompare(nomeB, "pt-BR");
-      });
-  }, [contatos]);
-
-  const modelosOrdenados = useMemo(() => {
-    return [...modelos]
-      .filter((item) => item && (item.modelo || item.descricao))
-      .sort((a, b) => {
-        const usoA = normalizeText(a?.utilizacao || "");
-        const usoB = normalizeText(b?.utilizacao || "");
-        if (usoA !== usoB) {
-          return usoA.localeCompare(usoB, "pt-BR");
-        }
-        const descA = normalizeText(a?.descricao || "");
-        const descB = normalizeText(b?.descricao || "");
-        return descA.localeCompare(descB, "pt-BR");
-      });
-  }, [modelos]);
 
   useEffect(() => {
     let mounted = true;
@@ -935,27 +989,13 @@ export default function App() {
     return map;
   }, [processosNormalizados]);
 
-  const matchesQuery = useCallback(
-    (fields) => {
-      if (normalizedQueryValue === "") {
-        return true;
-      }
-      return fields
-        .filter((field) => field !== null && field !== undefined)
-        .some((field) => normalizeTextLower(field).includes(normalizedQueryValue));
-    },
+  const matchesQuery = useMemo(
+    () => createFieldsMatcher(normalizedQueryValue),
     [normalizedQueryValue],
   );
 
-  const matchesUteisQuery = useCallback(
-    (fields) => {
-      if (normalizedUteisQuery === "") {
-        return true;
-      }
-      return fields
-        .filter((field) => field !== null && field !== undefined)
-        .some((field) => normalizeTextLower(field).includes(normalizedUteisQuery));
-    },
+  const matchesUteisQuery = useMemo(
+    () => createFieldsMatcher(normalizedUteisQuery),
     [normalizedUteisQuery],
   );
 
@@ -1082,37 +1122,20 @@ export default function App() {
     );
   }, [matchesMunicipioFilter, matchesUteisQuery, modelos]);
 
-  const contatosOrdenadosLista = useMemo(() => {
-    const lista = Array.isArray(filteredContatos) ? filteredContatos : [];
-    return [...lista]
-      .filter((item) => item && (item.contato || item.email || item.telefone))
-      .sort((a, b) => {
-        const catA = normalizeText(a?.categoria || "");
-        const catB = normalizeText(b?.categoria || "");
-        if (catA !== catB) {
-          return catA.localeCompare(catB, "pt-BR");
-        }
-        const nomeA = normalizeText(a?.contato || "");
-        const nomeB = normalizeText(b?.contato || "");
-        return nomeA.localeCompare(nomeB, "pt-BR");
-      });
-  }, [filteredContatos]);
+  const { byTipo: licencasPorTipo, totalRelevant: licencasRelevantesTotal } = useMemo(
+    () => aggregateLicencasPorTipo(filteredLicencas),
+    [filteredLicencas],
+  );
 
-  const modelosOrdenadosLista = useMemo(() => {
-    const lista = Array.isArray(filteredModelos) ? filteredModelos : [];
-    return [...lista]
-      .filter((item) => item && (item.modelo || item.descricao))
-      .sort((a, b) => {
-        const usoA = normalizeText(a?.utilizacao || "");
-        const usoB = normalizeText(b?.utilizacao || "");
-        if (usoA !== usoB) {
-          return usoA.localeCompare(usoB, "pt-BR");
-        }
-        const descA = normalizeText(a?.descricao || "");
-        const descB = normalizeText(b?.descricao || "");
-        return descA.localeCompare(descB, "pt-BR");
-      });
-  }, [filteredModelos]);
+  const contatosOrdenadosLista = useMemo(
+    () => sortContatos(filteredContatos),
+    [filteredContatos],
+  );
+
+  const modelosOrdenadosLista = useMemo(
+    () => sortModelos(filteredModelos),
+    [filteredModelos],
+  );
 
   const taxasVisiveis = useMemo(() => {
     if (!modoFoco) {
@@ -1893,12 +1916,20 @@ export default function App() {
         <TabsContent value="licencas" className="mt-4">
           <div className="grid md:grid-cols-2 gap-3 mb-3">
             {tiposLicenca.map((tipo) => {
-              const items = filteredLicencas.filter((lic) => normalizeText(lic?.tipo).trim() === tipo);
-              const venc = items.filter((item) => item.status === "Vencido").length;
-              const soon = items.filter((item) => item.status === "Vence≤30d").length;
-              const subj = items.filter((item) => item.status === "Sujeito").length;
-              const disp = items.filter((item) => item.status === "Dispensa").length;
-              const poss = Math.max(items.length - venc - soon - subj - disp, 0);
+              const grupo = licencasPorTipo.get(tipo);
+              const items = grupo?.items ?? [];
+              const contagens = grupo?.contagens ?? {
+                vencido: 0,
+                vencendo: 0,
+                sujeito: 0,
+                dispensa: 0,
+                possui: 0,
+              };
+              const venc = contagens.vencido;
+              const soon = contagens.vencendo;
+              const subj = contagens.sujeito;
+              const disp = contagens.dispensa;
+              const poss = contagens.possui;
               const icon = LIC_ICONS[tipo] || <Settings className="h-4 w-4" />;
               const colorClasses = LIC_COLORS[tipo] || "border-slate-400 text-slate-700";
               return (
@@ -1938,15 +1969,10 @@ export default function App() {
 
           <div className="flex flex-wrap gap-2 mb-3">
             {["Todos", ...tiposLicenca].map((tipo) => {
-              const count = filteredLicencas.filter((lic) => {
-                if (!hasRelevantStatus(lic.status)) {
-                  return false;
-                }
-                if (tipo === "Todos") {
-                  return true;
-                }
-                return normalizeText(lic?.tipo).trim() === tipo;
-              }).length;
+              const count =
+                tipo === "Todos"
+                  ? licencasRelevantesTotal
+                  : licencasPorTipo.get(tipo)?.relevantes.length || 0;
               const icon = tipo === "Todos" ? null : LIC_ICONS[tipo] || <Settings className="h-4 w-4" />;
               return (
                 <Button
@@ -1973,14 +1999,12 @@ export default function App() {
               </Card>
             ) : (
               tiposLicencaSelecionados.map((tipo) => {
-                const registros = filteredLicencas
-                  .filter((lic) => normalizeText(lic?.tipo).trim() === tipo)
-                  .filter((lic) => hasRelevantStatus(lic.status))
-                  .filter((lic) =>
-                    modoFoco
-                      ? isAlertStatus(lic.status) || getStatusKey(lic.status).includes("sujeit")
-                      : true,
-                  );
+                const baseRegistros = licencasPorTipo.get(tipo)?.relevantes ?? [];
+                const registros = modoFoco
+                  ? baseRegistros.filter(
+                      (lic) => isAlertStatus(lic.status) || getStatusKey(lic.status).includes("sujeit"),
+                    )
+                  : baseRegistros;
                 const icon = LIC_ICONS[tipo] || <Settings className="h-4 w-4" />;
                 return (
                   <Card key={tipo} className="shadow-sm">


### PR DESCRIPTION
## Summary
- extract reusable helpers for query matching, contato/modelo ordering, and license grouping
- reuse grouped license data to simplify list rendering and counters in the licenses tab
- keep existing behaviour while reducing repeated filters and sort logic in App.jsx

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e552e78a04832681edcc9617527079