### PR TITLE
Ajusta esquema de cores dos badges nas abas

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -367,12 +367,12 @@ const isProcessStatusActiveOrPending = (status) => {
 };
 
 const STATUS_VARIANT_CLASSES = {
-  success: "bg-emerald-500 text-white border-emerald-500",
-  warning: "bg-amber-500 text-white border-amber-500",
-  danger: "bg-red-500 text-white border-red-500",
-  info: "bg-sky-500 text-white border-sky-500",
-  neutral: "bg-slate-500 text-white border-slate-500",
-  muted: "bg-slate-400 text-white border-slate-400",
+  success: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  warning: "bg-amber-100 text-amber-700 border-amber-200",
+  danger: "bg-red-100 text-red-700 border-red-200",
+  info: "bg-sky-100 text-sky-700 border-sky-200",
+  neutral: "bg-slate-200 text-slate-700 border-slate-300",
+  muted: "bg-slate-100 text-slate-600 border-slate-200",
   plain: "bg-transparent border-transparent text-slate-500",
 };
 
@@ -1920,10 +1920,10 @@ export default function App() {
                       <InlineBadge className="bg-amber-100 text-amber-800 border-amber-200">
                         ≤30d {soon}
                       </InlineBadge>
-                      <InlineBadge className="bg-red-100 text-red-700 border-red-200">
+                      <InlineBadge className="bg-orange-100 text-orange-800 border-orange-200">
                         Vencido {venc}
                       </InlineBadge>
-                      <InlineBadge className="bg-slate-200 text-slate-800 border-slate-300">
+                      <InlineBadge className="bg-red-100 text-red-700 border-red-200">
                         Sujeito {subj}
                       </InlineBadge>
                       <InlineBadge className="bg-indigo-100 text-indigo-700 border-indigo-200">


### PR DESCRIPTION
## Summary
- harmoniza a paleta de cores utilizada pelos badges de status das abas conforme o esquema solicitado
- ajusta os indicadores resumidos de licenças para refletir as novas cores de vencido e sujeito

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5617cf06c832692a735422b5da349