### PR TITLE
Atualiza gráfico de alertas do painel

### DIFF
--- a/frontend/src/features/painel/PainelScreen.jsx
+++ b/frontend/src/features/painel/PainelScreen.jsx
@@ -15,14 +15,46 @@ import {
   ShieldAlert,
   Sparkles,
 } from "lucide-react";
-import { LineChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { formatMonthLabel, normalizeTextLower, parsePtDate } from "@/lib/text";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { normalizeTextLower, parsePtDate } from "@/lib/text";
 import {
   getStatusKey,
   hasRelevantStatus,
   isAlertStatus,
   isProcessStatusInactive,
 } from "@/lib/status";
+
+const MONTHS_WINDOW = 12;
+
+const formatMonthYearLabel = (date) => {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return "";
+  }
+  const monthLabel = date
+    .toLocaleDateString("pt-BR", { month: "short" })
+    .replace(/\./g, "")
+    .toLowerCase();
+  return `${monthLabel}/${String(date.getFullYear()).slice(-2)}`;
+};
+
+const formatMonthYearFromValue = (value) => {
+  if (value instanceof Date) {
+    return formatMonthYearLabel(value);
+  }
+  const numericValue = typeof value === "number" ? value : Number(value);
+  if (Number.isNaN(numericValue)) {
+    return "";
+  }
+  return formatMonthYearLabel(new Date(numericValue));
+};
 
 export default function PainelScreen(props) {
   const {
@@ -64,33 +96,72 @@ export default function PainelScreen(props) {
     );
   }, [filteredLicencas]);
 
-  const alertTrendData = useMemo(() => {
-    const monthly = new Map();
-    filteredLicencas.forEach((lic) => {
-      const validade = parsePtDate(lic.validade);
-      if (!validade) return;
-      if (!hasRelevantStatus(lic.status)) return;
-      const statusKey = getStatusKey(lic.status);
-      const key = `${validade.getFullYear()}-${validade.getMonth()}`;
-      const entry = monthly.get(key) || { date: validade, vencidas: 0, vencendo: 0 };
-      if (statusKey.includes("vencid")) entry.vencidas += 1;
-      else if (statusKey.includes("vence")) entry.vencendo += 1;
-      monthly.set(key, entry);
+  const { data: alertTrendData, hasAlerts } = useMemo(() => {
+    const licencasList = Array.isArray(filteredLicencas) ? filteredLicencas : [];
+
+    const now = new Date();
+    const end = new Date(now.getFullYear(), now.getMonth(), 1);
+    const start = new Date(end.getFullYear(), end.getMonth() - (MONTHS_WINDOW - 1), 1);
+
+    const counts = new Map();
+
+    licencasList.forEach((lic) => {
+      if (!lic) return;
+
+      const status = lic.status;
+      if (!status || !isAlertStatus(status)) return;
+
+      const statusKey = getStatusKey(status);
+      if (!statusKey) return;
+      if (!statusKey.includes("vencid") && !statusKey.includes("vence")) return;
+
+      let validade = parsePtDate(lic.validade);
+      if (!validade && typeof lic.validade === "string") {
+        const isoCandidate = new Date(lic.validade);
+        if (!Number.isNaN(isoCandidate?.getTime())) {
+          validade = isoCandidate;
+        }
+      }
+
+      if (!(validade instanceof Date) || Number.isNaN(validade.getTime())) {
+        return;
+      }
+
+      const monthDate = new Date(validade.getFullYear(), validade.getMonth(), 1);
+      if (monthDate < start || monthDate > end) return;
+
+      const key = `${monthDate.getFullYear()}-${monthDate.getMonth()}`;
+      counts.set(key, (counts.get(key) ?? 0) + 1);
     });
-    if (monthly.size === 0) {
-      return [
-        { mes: "Sem dados", vencidas: 0, vencendo: 0 },
-      ];
+
+    const data = [];
+
+    for (
+      let year = start.getFullYear(), month = start.getMonth();
+      year < end.getFullYear() || (year === end.getFullYear() && month <= end.getMonth());
+    ) {
+      const currentDate = new Date(year, month, 1);
+      const key = `${year}-${month}`;
+      const total = counts.get(key) ?? 0;
+      data.push({
+        date: currentDate,
+        ts: currentDate.getTime(),
+        label: formatMonthYearLabel(currentDate),
+        total_alertas: total,
+      });
+
+      month += 1;
+      if (month > 11) {
+        month = 0;
+        year += 1;
+      }
     }
-    const sorted = Array.from(monthly.values())
-      .filter((entry) => entry.date !== null)
-      .sort((a, b) => a.date.getTime() - b.date.getTime());
-    return sorted.slice(-6).map((entry) => ({
-      mes: `${formatMonthLabel(entry.date)}`,
-      vencidas: entry.vencidas,
-      vencendo: entry.vencendo,
-    }));
+
+    return { data, hasAlerts: counts.size > 0 };
   }, [filteredLicencas]);
+
+  const hasFilteredLicencas = Array.isArray(filteredLicencas) && filteredLicencas.length > 0;
+  const shouldRenderAlertChart = hasAlerts || hasFilteredLicencas;
 
   const processosAtivos = useMemo(() => {
     return processosNormalizados.filter((proc) => !isProcessStatusInactive(proc.status));
@@ -148,33 +219,53 @@ export default function PainelScreen(props) {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="h-56">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={alertTrendData}>
-                  <XAxis dataKey="mes" tick={{ fontSize: 12 }} stroke="#94a3b8" />
-                  <YAxis tick={{ fontSize: 12 }} stroke="#94a3b8" allowDecimals={false} />
-                  <Tooltip
-                    contentStyle={{ fontSize: 12 }}
-                    labelStyle={{ color: "#0f172a", fontWeight: 600 }}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="vencendo"
-                    strokeWidth={2}
-                    dot={false}
-                    stroke="#f59e0b"
-                    name="Vencendo"
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="vencidas"
-                    strokeWidth={2}
-                    dot={false}
-                    stroke="#ef4444"
-                    name="Vencidas"
-                  />
-                </LineChart>
-              </ResponsiveContainer>
+            <div className="h-56 md:h-64">
+              {shouldRenderAlertChart ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={alertTrendData}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                    <XAxis
+                      dataKey="ts"
+                      type="number"
+                      scale="time"
+                      domain={["dataMin", "dataMax"]}
+                      tickFormatter={formatMonthYearFromValue}
+                      tick={{ fontSize: 12 }}
+                      stroke="#94a3b8"
+                    />
+                    <YAxis
+                      tick={{ fontSize: 12 }}
+                      stroke="#94a3b8"
+                      allowDecimals={false}
+                    />
+                    <Tooltip
+                      cursor={{ strokeDasharray: "3 3" }}
+                      contentStyle={{ fontSize: 12 }}
+                      labelStyle={{ color: "#0f172a", fontWeight: 600 }}
+                      labelFormatter={(value, payload) => {
+                        const first = Array.isArray(payload) ? payload[0] : undefined;
+                        if (first?.payload?.label) {
+                          return first.payload.label;
+                        }
+                        return formatMonthYearFromValue(value);
+                      }}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="total_alertas"
+                      stroke="#f97316"
+                      strokeWidth={2}
+                      fill="#fb923c"
+                      fillOpacity={0.2}
+                      name="Alertas de vencimento"
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="flex h-full items-center justify-center px-4 text-center text-sm text-slate-500">
+                  Sem dados para o período/filtro.
+                </div>
+              )}
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- usa filteredLicencas reais para montar a série temporal de alertas por mês
- substitui o LineChart por AreaChart com layout responsivo e mensagem quando não há dados
- consolida alertas por ano/mês em uma janela móvel de 12 meses com rótulos mmm/aa e eixo temporal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6bd5d66008326a544d07629675a8a