### PR TITLE
Fix badge colors for certificate statuses

### DIFF
--- a/frontend/src/lib/status.js
+++ b/frontend/src/lib/status.js
@@ -126,6 +126,15 @@ export const resolveStatusClass = (status) => {
   }
 
   const key = removeDiacritics(trimmed.toLowerCase());
+  const normalizedKey = key.replace(/\s+/g, " ").trim();
+
+  if (normalizedKey === "valido") {
+    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+  }
+
+  if (normalizedKey === "vencido") {
+    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+  }
 
   const fraction = parseProgressFraction(trimmed);
   if (fraction) {


### PR DESCRIPTION
## Summary
- ensure resolveStatusClass normalizes certificate statuses and maps "Válido" to the success variant (green)
- return the danger variant for "Vencido" statuses so badges render red instead of warning orange

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e80d52e124832686e0996e6fb5f032