### PR TITLE
Atualiza situação de certificados nas empresas

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -50,6 +50,11 @@ import {
 } from "@/lib/constants";
 import { fetchJson } from "@/lib/api";
 import { isAlertStatus, isProcessStatusInactive } from "@/lib/status";
+import {
+  buildCertificadoIndex,
+  isCertificadoSituacaoAlert,
+  resolveEmpresaCertificadoSituacao,
+} from "@/lib/certificados";
 
 const toFiniteNumber = (value) => {
   if (typeof value === "number" && Number.isFinite(value)) {
@@ -132,6 +137,21 @@ function AppContent() {
   const [modelos, setModelos] = useState([]);
   const [loading, setLoading] = useState(true);
   const { dismissToast, enqueueToast, toasts } = useToast();
+
+  const certificadoIndex = useMemo(() => buildCertificadoIndex(certificados), [certificados]);
+
+  const empresasComCertificados = useMemo(
+    () =>
+      empresas.map((empresa) => {
+        const situacao = resolveEmpresaCertificadoSituacao(empresa, certificadoIndex);
+        return {
+          ...empresa,
+          certificadoSituacao: situacao,
+          certificado: situacao,
+        };
+      }),
+    [certificadoIndex, empresas],
+  );
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -253,13 +273,13 @@ function AppContent() {
 
   const empresasById = useMemo(() => {
     const map = new Map();
-    empresas.forEach((empresa) => {
+    empresasComCertificados.forEach((empresa) => {
       const empresaId = extractEmpresaId(empresa);
       if (empresaId === undefined) return;
       map.set(empresaId, empresa);
     });
     return map;
-  }, [empresas]);
+  }, [empresasComCertificados]);
 
   const licencasByEmpresa = useMemo(() => {
     const map = new Map();
@@ -381,8 +401,11 @@ function AppContent() {
       const empresaId = extractEmpresaId(empresa);
       if (empresaId === undefined) return false;
       const debitoLower = normalizeTextLower(empresa.debito);
-      const certificadoLower = normalizeTextLower(empresa.certificado);
-      if (debitoLower === "sim" || certificadoLower === "não") {
+      if (debitoLower === "sim") {
+        return true;
+      }
+      const situacaoCertificado = empresa.certificadoSituacao ?? empresa.certificado;
+      if (isCertificadoSituacaoAlert(situacaoCertificado)) {
         return true;
       }
       const licList = licencasByEmpresa.get(empresaId) || [];
@@ -423,8 +446,8 @@ function AppContent() {
   );
 
   const filteredEmpresas = useMemo(
-    () => filterEmpresas(empresas),
-    [empresas, filterEmpresas],
+    () => filterEmpresas(empresasComCertificados),
+    [empresasComCertificados, filterEmpresas],
   );
 
 
@@ -548,7 +571,7 @@ function AppContent() {
             municipio={municipio}
             soAlertas={soAlertas}
             kpis={kpis}
-            empresas={empresas}
+            empresas={empresasComCertificados}
             licencas={licencas}
             taxas={taxas}
             filteredLicencas={filteredLicencas}
@@ -563,7 +586,7 @@ function AppContent() {
         <TabsContent value="empresas" className="mt-4 space-y-3">
           <EmpresasScreen
             filteredEmpresas={filteredEmpresas}
-            empresas={empresas}
+            empresas={empresasComCertificados}
             soAlertas={soAlertas}
             extractEmpresaId={extractEmpresaId}
             licencasByEmpresa={licencasByEmpresa}

--- a/frontend/src/features/certificados/CertificadosScreen.jsx
+++ b/frontend/src/features/certificados/CertificadosScreen.jsx
@@ -11,7 +11,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import InlineBadge from "@/components/InlineBadge";
 import CertificadoCard from "@/features/certificados/CertificadoCard";
 import AgendamentosTable from "@/features/certificados/AgendamentosTable";
-import { normalizeTextLower, removeDiacritics } from "@/lib/text";
+import { categorizeCertificadoSituacao } from "@/lib/certificados";
+import { normalizeTextLower } from "@/lib/text";
 
 const DATE_REGEX = /(\d{2}\/\d{2}\/\d{4})/;
 
@@ -24,23 +25,6 @@ const extractDate = (value) => {
     return match[1];
   }
   return value.trim();
-};
-
-const categorizeSituacao = (situacao) => {
-  const key = removeDiacritics(normalizeTextLower(situacao)).trim();
-  if (!key) {
-    return "Outros";
-  }
-  if (key.includes("vencid")) {
-    return "Vencido";
-  }
-  if (key.includes("vencend") || key.includes("vence")) {
-    return "Vencendo em breve";
-  }
-  if (key.includes("valido") || key.includes("vigent") || key.includes("ativo")) {
-    return "Válido";
-  }
-  return "Outros";
 };
 
 const SITUACAO_OPTIONS = ["Todos", "Válido", "Vencendo em breve", "Vencido"];
@@ -64,7 +48,7 @@ export default function CertificadosScreen({ certificados, agendamentos, soAlert
     const query = normalizeTextLower(search).trim();
     return certificadosLista.filter((item) => {
       const titular = normalizeTextLower(item?.titular ?? "");
-      const categoria = categorizeSituacao(item?.situacao ?? "");
+      const categoria = categorizeCertificadoSituacao(item?.situacao ?? "");
       if (situacao !== "Todos" && categoria !== situacao) {
         return false;
       }

--- a/frontend/src/features/empresas/EmpresasScreen.jsx
+++ b/frontend/src/features/empresas/EmpresasScreen.jsx
@@ -7,6 +7,7 @@ import StatusBadge from "@/components/StatusBadge";
 import CopyableIdentifier from "@/components/CopyableIdentifier";
 import { Mail, Phone, Clipboard } from "lucide-react";
 import { TAXA_TYPE_KEYS } from "@/lib/constants";
+import { DEFAULT_CERTIFICADO_SITUACAO } from "@/lib/certificados";
 import {
   getStatusKey,
   hasRelevantStatus,
@@ -92,7 +93,7 @@ export default function EmpresasScreen({
                         Categoria: {empresa.categoria || "—"}
                       </InlineBadge>
                       <InlineBadge variant="outline" className="bg-white">
-                        Certificado: {empresa.certificado}
+                        Certificado: {empresa.certificado || DEFAULT_CERTIFICADO_SITUACAO}
                       </InlineBadge>
                       <InlineBadge variant="outline" className="bg-white">
                         Débito: {empresa.debito}

--- a/frontend/src/features/painel/PainelScreen.jsx
+++ b/frontend/src/features/painel/PainelScreen.jsx
@@ -25,6 +25,7 @@ import {
   YAxis,
 } from "recharts";
 import { normalizeTextLower, parsePtDate } from "@/lib/text";
+import { DEFAULT_CERTIFICADO_SITUACAO, isCertificadoSituacaoAlert } from "@/lib/certificados";
 import {
   getStatusKey,
   hasRelevantStatus,
@@ -303,6 +304,8 @@ export default function PainelScreen(props) {
                 const empresaId = extractEmpresaId(empresa);
                 const licencasPendentes =
                   empresaId !== undefined ? licencasByEmpresa.get(empresaId) || [] : [];
+                const situacaoCertificado = empresa.certificado || DEFAULT_CERTIFICADO_SITUACAO;
+                const mostrarCertificado = isCertificadoSituacaoAlert(situacaoCertificado);
                 return (
                   <li key={empresa.id} className="px-4 py-3 text-sm">
                     <div className="flex items-start justify-between gap-4">
@@ -316,7 +319,7 @@ export default function PainelScreen(props) {
                         {normalizeTextLower(empresa.debito) === "sim" && (
                           <StatusBadge status="Não pago" />
                         )}
-                        {normalizeTextLower(empresa.certificado) === "não" && <StatusBadge status="NÃO" />}
+                        {mostrarCertificado && <StatusBadge status={situacaoCertificado} />}
                         {licencasPendentes
                           .filter((lic) => isAlertStatus(lic.status))
                           .slice(0, 2)

--- a/frontend/src/lib/certificados.js
+++ b/frontend/src/lib/certificados.js
@@ -1,0 +1,123 @@
+import {
+  buildNormalizedSearchKey,
+  normalizeDocumentDigits,
+  normalizeIdentifier,
+  normalizeTextLower,
+  removeDiacritics,
+} from "@/lib/text";
+
+const MIN_DOCUMENT_LENGTH = 11;
+
+export const DEFAULT_CERTIFICADO_SITUACAO = "Não Possui";
+
+const getDocumentKey = (value) => {
+  const digits = normalizeDocumentDigits(value);
+  if (!digits) {
+    return undefined;
+  }
+  return digits.length >= MIN_DOCUMENT_LENGTH ? digits : undefined;
+};
+
+const getNameKey = (value) => buildNormalizedSearchKey(value);
+
+const getEmpresaDocumentCandidates = (empresa) => {
+  if (!empresa || typeof empresa !== "object") {
+    return [];
+  }
+  return [
+    getDocumentKey(empresa.cnpj),
+    getDocumentKey(empresa.cpfCnpj),
+    getDocumentKey(empresa.cpf_cnpj),
+    getDocumentKey(empresa.cpf),
+    getDocumentKey(empresa.documento),
+    getDocumentKey(empresa.document),
+    getDocumentKey(empresa.titular),
+  ].filter(Boolean);
+};
+
+const getEmpresaNameCandidates = (empresa) => {
+  if (!empresa || typeof empresa !== "object") {
+    return [];
+  }
+  return [
+    getNameKey(empresa.empresa),
+    getNameKey(empresa.razaoSocial),
+    getNameKey(empresa.razao_social),
+    getNameKey(empresa.nome),
+    getNameKey(empresa.nomeFantasia),
+    getNameKey(empresa.fantasia),
+  ].filter(Boolean);
+};
+
+export const buildCertificadoIndex = (certificados) => {
+  const lista = Array.isArray(certificados) ? certificados : [];
+  const byDocument = new Map();
+  const byName = new Map();
+
+  lista.forEach((certificado) => {
+    const docKey = getDocumentKey(certificado?.titular);
+    if (docKey && !byDocument.has(docKey)) {
+      byDocument.set(docKey, certificado);
+    }
+    const nameKey = getNameKey(certificado?.titular);
+    if (nameKey && !byName.has(nameKey)) {
+      byName.set(nameKey, certificado);
+    }
+  });
+
+  return { byDocument, byName };
+};
+
+const findCertificadoForEmpresa = (empresa, index) => {
+  if (!index) {
+    return undefined;
+  }
+  const { byDocument, byName } = index;
+  for (const docKey of getEmpresaDocumentCandidates(empresa)) {
+    if (byDocument.has(docKey)) {
+      return byDocument.get(docKey);
+    }
+  }
+  for (const nameKey of getEmpresaNameCandidates(empresa)) {
+    if (byName.has(nameKey)) {
+      return byName.get(nameKey);
+    }
+  }
+  return undefined;
+};
+
+export const resolveEmpresaCertificadoSituacao = (empresa, index) => {
+  const match = findCertificadoForEmpresa(empresa, index);
+  const situacao = normalizeIdentifier(match?.situacao);
+  return situacao ?? DEFAULT_CERTIFICADO_SITUACAO;
+};
+
+export const categorizeCertificadoSituacao = (situacao) => {
+  const key = removeDiacritics(normalizeTextLower(situacao)).trim();
+  if (!key) {
+    return "Outros";
+  }
+  if (key.includes("vencid")) {
+    return "Vencido";
+  }
+  if (key.includes("vencend") || key.includes("vence")) {
+    return "Vencendo em breve";
+  }
+  if (key.includes("valido") || key.includes("vigent") || key.includes("ativo")) {
+    return "Válido";
+  }
+  return "Outros";
+};
+
+export const isCertificadoSituacaoAlert = (situacao) => {
+  const key = removeDiacritics(normalizeTextLower(situacao)).trim();
+  if (!key) {
+    return true;
+  }
+  if (key === "naopossui" || key === "semcertificado" || key === "naotem") {
+    return true;
+  }
+  const categoria = categorizeCertificadoSituacao(situacao);
+  return categoria === "Vencido" || categoria === "Vencendo em breve";
+};
+

--- a/frontend/src/lib/text.js
+++ b/frontend/src/lib/text.js
@@ -1,4 +1,6 @@
 const isNil = (value) => value === null || value === undefined;
+const NON_DIGIT_REGEX = /\D+/g;
+const NON_ALPHANUMERIC_REGEX = /[^a-z0-9]/g;
 
 export const normalizeText = (value) => {
   if (isNil(value)) {
@@ -12,6 +14,17 @@ export const normalizeTextLower = (value) => normalizeText(value).toLowerCase();
 export const removeDiacritics = (value) => {
   if (typeof value !== "string") return "";
   return value.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+};
+
+export const normalizeDocumentDigits = (value) => {
+  const digits = normalizeText(value).replace(NON_DIGIT_REGEX, "");
+  return digits === "" ? undefined : digits;
+};
+
+export const buildNormalizedSearchKey = (value) => {
+  const normalized = removeDiacritics(normalizeTextLower(value));
+  const sanitized = normalized.replace(NON_ALPHANUMERIC_REGEX, "");
+  return sanitized === "" ? undefined : sanitized;
 };
 
 export const normalizeIdentifier = (value) => {


### PR DESCRIPTION
## Summary
- cria utilitário para indexar certificados, normalizando documentos e nomes para reaproveitamento
- utiliza o índice para anexar a situação real de certificados às empresas e atualizar alertas e badges
- reutiliza a categorização de situações dos certificados em toda a interface

## Testing
- npm test -- --watch=false *(falha: script "test" não definido)*

------
https://chatgpt.com/codex/tasks/task_e_68e813cfc7b88326a2301b335850926c