### PR TITLE
Add Anápolis municipal CND quick action

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -8,6 +8,8 @@ Ajustes aplicados:
 from __future__ import annotations
 
 import os
+import sys
+import asyncio
 import logging
 from datetime import datetime, date, timedelta
 from typing import List, Optional, Dict, Any
@@ -34,10 +36,17 @@ from services import (
     contar_processos_empresa, calcular_kpis_globais,
 )
 from routes_certificados import router as certificados_router
+from routes_cnds import router as cnds_router
 
 from dotenv import load_dotenv
 from pathlib import Path
 load_dotenv(dotenv_path=Path(__file__).parent / ".env")
+
+if sys.platform.startswith("win"):
+    try:
+        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+    except Exception:
+        pass
 
 
 # ----------------------------------------------------------------------------
@@ -68,6 +77,7 @@ app.add_middleware(
 )
 
 app.include_router(certificados_router, prefix="/api")
+app.include_router(cnds_router, prefix="/api")
 
 # Cache em memória (simples)
 cache: Dict[str, object] = {

--- a/backend/cnds_worker_anapolis.py
+++ b/backend/cnds_worker_anapolis.py
@@ -1,0 +1,212 @@
+import sys
+import asyncio
+import base64
+import time
+import requests
+import os
+import re
+from datetime import datetime
+from typing import Optional, Tuple
+
+from playwright.async_api import async_playwright
+
+MODO_HEADLESS = os.getenv("CND_HEADLESS", "false").lower() == "true"
+EXECUTABLE_PATH = os.getenv("CND_CHROME_PATH")
+SAIDA_BASE = os.getenv("CND_DIR_BASE", "certidoes")
+CAPTCHA_MODE = (os.getenv("CAPTCHA_MODE") or "manual").lower().strip()
+API_KEY_2CAPTCHA = os.getenv("API_KEY_2CAPTCHA", "").strip()
+
+if sys.platform.startswith("win"):
+    try:
+        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+    except Exception:
+        pass
+
+
+def only_digits(s: str) -> str:
+    return re.sub(r"\D+", "", s or "")
+
+
+def _nome_arquivo_destino() -> str:
+    return f"CND - {datetime.now().strftime('%d.%m.%Y')}.pdf"
+
+
+async def _abrir_portal(page) -> None:
+    await page.goto(
+        "https://portaldocidadao.anapolis.go.gov.br/processos/",
+        wait_until="domcontentloaded",
+    )
+    await page.wait_for_load_state("networkidle")
+
+
+async def _preencher_cnpj(page, cnpj: str) -> bool:
+    candidatos = [
+        "input[name*='cnpj']",
+        "input[id*='cnpj']",
+        "input[placeholder*='CNPJ' i]",
+        "input[type='text']",
+    ]
+    for css in candidatos:
+        loc = page.locator(css)
+        if await loc.count():
+            try:
+                await loc.first.fill(cnpj)
+                await loc.first.dispatch_event("input")
+                await loc.first.dispatch_event("change")
+                return True
+            except Exception:
+                pass
+    return False
+
+
+async def _clicar_consultar(page) -> None:
+    ok = await page.evaluate(
+        """
+      () => {
+        const btns = [...document.querySelectorAll('button,input[type="button"],input[type="submit"]')];
+        const b = btns.find(b => (b.value||b.textContent||'').toLowerCase().includes('consultar'));
+        if (b) { b.click(); return true; }
+        return false;
+      }
+    """
+    )
+    if not ok:
+        await page.keyboard.press("Enter")
+
+
+def _solve_image_captcha_2captcha(image_b64: str) -> str:
+    if not API_KEY_2CAPTCHA:
+        raise RuntimeError("API_KEY_2CAPTCHA ausente.")
+    response = requests.post(
+        "http://2captcha.com/in.php",
+        data={"method": "base64", "key": API_KEY_2CAPTCHA, "body": image_b64, "json": 1},
+        timeout=30,
+    ).json()
+    if response.get("status") != 1:
+        raise RuntimeError(f"2Captcha falhou (in): {response}")
+    captcha_id = response["request"]
+    for _ in range(24):
+        time.sleep(5)
+        result = requests.get(
+            "http://2captcha.com/res.php",
+            params={"key": API_KEY_2CAPTCHA, "action": "get", "id": captcha_id, "json": 1},
+            timeout=30,
+        ).json()
+        if result.get("status") == 1:
+            return result["request"]
+    raise TimeoutError("Timeout 2Captcha (imagem).")
+
+
+async def emitir_cnd_anapolis(cnpj: str) -> Tuple[bool, str, Optional[str]]:
+    cnpj = only_digits(cnpj)
+    os.makedirs(SAIDA_BASE, exist_ok=True)
+    destino_dir = os.path.join(SAIDA_BASE, cnpj)
+    os.makedirs(destino_dir, exist_ok=True)
+    destino = os.path.join(destino_dir, _nome_arquivo_destino())
+
+    try:
+        async with async_playwright() as p:
+            launch_args = {
+                "headless": MODO_HEADLESS,
+                "args": [
+                    "--disable-gpu",
+                    "--disable-dev-shm-usage",
+                    "--no-first-run",
+                    "--no-default-browser-check",
+                ],
+            }
+            if EXECUTABLE_PATH:
+                launch_args["executable_path"] = EXECUTABLE_PATH
+            try:
+                browser = await p.chromium.launch(**launch_args)
+            except Exception as exc:
+                return False, f"Falha ao iniciar Chromium ({type(exc).__name__}): {exc}", None
+            context = await browser.new_context(ignore_https_errors=True)
+            page = await context.new_page()
+            try:
+                await _abrir_portal(page)
+                try:
+                    await page.locator(
+                        "span.select2-chosen, .select2-selection__rendered, [class*='select2']"
+                    ).first.click()
+                    await page.wait_for_timeout(500)
+                    for sel in [
+                        "li:has-text(\"CNPJ\")",
+                        ".select2-results__option:has-text(\"CNPJ\")",
+                    ]:
+                        if await page.locator(sel).count():
+                            await page.locator(sel).first.click()
+                            break
+                except Exception:
+                    pass
+
+                if not await _preencher_cnpj(page, cnpj):
+                    return False, "Campo de CNPJ não encontrado.", None
+
+                solved = False
+                try:
+                    img = page.locator('img[src*="captcha"]').first
+                    if await img.count():
+                        if CAPTCHA_MODE == "image_2captcha" and API_KEY_2CAPTCHA:
+                            png_bytes = await img.screenshot(type="png")
+                            b64 = base64.b64encode(png_bytes).decode()
+                            answer = _solve_image_captcha_2captcha(b64)
+                            candidatos = [
+                                "input[name*='captcha']",
+                                "input[id*='captcha']",
+                                "input[placeholder*='captcha' i]",
+                                "input[type='text']",
+                            ]
+                            for css in candidatos:
+                                loc = page.locator(css)
+                                if await loc.count():
+                                    try:
+                                        await loc.first.fill(answer)
+                                        await loc.first.dispatch_event("input")
+                                        await loc.first.dispatch_event("change")
+                                        solved = True
+                                        break
+                                    except Exception:
+                                        continue
+                except Exception:
+                    pass
+
+                if not solved:
+                    await page.bring_to_front()
+
+                await _clicar_consultar(page)
+                await page.wait_for_load_state("networkidle", timeout=30000)
+                await page.wait_for_timeout(1000)
+
+                tried = await page.evaluate(
+                    """
+                  () => {
+                    const Q = (s)=>[...document.querySelectorAll(s)];
+                    const hits = [...Q('a[href$=".pdf"]'), ...Q('a[href*="download"]'),
+                                  ...Q('button[title*="Download" i]'), ...Q('i[class*="download" i]')];
+                    if (hits.length) { hits[0].click(); return true; }
+                    const any = [...Q('a,button')].find(el => /pdf|imprimir|gerar/i.test(el.textContent||''));
+                    if (any) { any.click(); return true; }
+                    return false;
+                  }
+                """
+                )
+                if not tried:
+                    return False, "Botão/link de PDF não identificado.", None
+
+                async with page.expect_download(timeout=30000) as di:
+                    download = await di.value
+                    await download.save_as(destino)
+                return True, "CND emitida com sucesso.", destino
+            finally:
+                await context.close()
+                await browser.close()
+    except NotImplementedError:
+        return (
+            False,
+            "Automação indisponível neste sistema (Playwright não suportado). Utilize o fallback manual.",
+            None,
+        )
+    except Exception as exc:  # pragma: no cover - proteção defensiva
+        return False, f"Falha inesperada na automação: {exc}", None
+

--- a/backend/routes_cnds.py
+++ b/backend/routes_cnds.py
@@ -1,0 +1,29 @@
+import re
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from cnds_worker_anapolis import emitir_cnd_anapolis
+
+router = APIRouter(tags=["cnds"])
+
+
+class EmitirPedido(BaseModel):
+    cidade: str = Field(..., description="Por enquanto, apenas 'anapolis'")
+    cnpj: str
+
+
+def only_digits(s: str) -> str:
+    return re.sub(r"\D+", "", s or "")
+
+
+@router.post("/cnds/emitir")
+async def cnds_emitir(ped: EmitirPedido):
+    if ped.cidade.lower() != "anapolis":
+        raise HTTPException(400, "Cidade não suportada nesta etapa.")
+    cnpj = only_digits(ped.cnpj)
+    if len(cnpj) != 14:
+        raise HTTPException(400, "CNPJ inválido (14 dígitos).")
+    ok, info, path = await emitir_cnd_anapolis(cnpj)
+    return {"ok": ok, "info": info, "path": path}
+

--- a/frontend/src/features/empresas/EmpresasScreen.jsx
+++ b/frontend/src/features/empresas/EmpresasScreen.jsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuItem,
   DropdownMenuItemFancy,
   MiniBadge,
   Kbd,
@@ -24,7 +25,7 @@ import {
   isAlertStatus,
   isProcessStatusInactive,
 } from "@/lib/status";
-import { openCartaoCNPJ } from "@/lib/quickLinks";
+import { openCartaoCNPJ, openCNDAnapolis } from "@/lib/quickLinks";
 
 export default function EmpresasScreen({
   filteredEmpresas,
@@ -38,6 +39,54 @@ export default function EmpresasScreen({
   enqueueToast,
 }) {
   const toast = (msg) => enqueueToast?.(msg);
+
+  const isMunicipioAnapolis = React.useCallback((municipio) => {
+    const normalized = (municipio || "")
+      .normalize("NFD")
+      .replace(/\p{Diacritic}/gu, "")
+      .toLowerCase();
+    const sanitized = normalized.replace(/[^a-z/\s]/g, " ");
+    return sanitized
+      .split(/[\\/]/)
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .some((part) => part === "anapolis");
+  }, []);
+
+  const emitirCNDMunicipal = React.useCallback(
+    async (cnpj, municipio, abrirPortal = false) => {
+      const ehAnapolis = isMunicipioAnapolis(municipio);
+      if (!ehAnapolis || abrirPortal) {
+        await openCNDAnapolis(cnpj, toast);
+        return;
+      }
+
+      try {
+        toast?.("Iniciando emissão da CND (Anápolis)...");
+        const baseUrl = (import.meta.env.VITE_API_BASE_URL || "").replace(/\/$/, "");
+        const resp = await fetch(`${baseUrl}/api/cnds/emitir`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cidade: "anapolis", cnpj }),
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          throw new Error(data?.detail || "Falha ao emitir a CND.");
+        }
+        if (data?.ok) {
+          toast?.("CND emitida com sucesso.");
+          if (data?.path) {
+            console.info("CND Anápolis salva em:", data.path);
+          }
+        } else {
+          toast?.(`Não foi possível emitir: ${data?.info || "verifique os dados."}`);
+        }
+      } catch (error) {
+        toast?.(error?.message || "Erro inesperado ao emitir a CND.");
+      }
+    },
+    [isMunicipioAnapolis, toast]
+  );
 
   return (
     <>
@@ -76,6 +125,8 @@ export default function EmpresasScreen({
             rawId !== undefined && rawId !== null && `${rawId}`.toString().trim() !== ""
               ? `${rawId}`
               : "?";
+
+          const municipioEhAnapolis = isMunicipioAnapolis(empresa.municipio);
 
           return (
             <Card key={empresa.id} className="shadow-sm overflow-hidden border border-white/60">
@@ -196,6 +247,19 @@ export default function EmpresasScreen({
                         hint={<Kbd>Ctrl</Kbd>}
                         onClick={() => openCartaoCNPJ(empresa.cnpj, toast)}
                       />
+
+                      <DropdownMenuItem
+                        disabled={!municipioEhAnapolis}
+                        onSelect={(event) => {
+                          const originalEvent = event?.detail?.originalEvent;
+                          const abrirPortal = Boolean(
+                            originalEvent?.ctrlKey || originalEvent?.metaKey
+                          );
+                          emitirCNDMunicipal(empresa.cnpj, empresa.municipio, abrirPortal);
+                        }}
+                      >
+                        CND Municipal (Anápolis)
+                      </DropdownMenuItem>
 
                       {/* próximos itens: CND Goiânia, CND Megasoft/Centi etc. */}
                     </DropdownMenuContent>

--- a/frontend/src/lib/quickLinks.ts
+++ b/frontend/src/lib/quickLinks.ts
@@ -30,3 +30,25 @@ export async function openCartaoCNPJ(
   onToast?.(`CNPJ copiado — abrindo Cartão CNPJ`);
   window.open(url.toString(), "_blank", "noopener,noreferrer");
 }
+
+export async function openCNDAnapolis(
+  cnpjRaw: string,
+  onToast?: (msg: string) => void,
+) {
+  const cnpj = onlyDigits(cnpjRaw || "");
+  if (!cnpj || cnpj.length !== 14) {
+    onToast?.("CNPJ inválido.");
+    return;
+  }
+  try {
+    await navigator.clipboard?.writeText(cnpj);
+  } catch {
+    /* ignore */
+  }
+  onToast?.("CNPJ copiado — abrindo Portal do Cidadão (Anápolis).");
+  window.open(
+    "https://portaldocidadao.anapolis.go.gov.br/processos/",
+    "_blank",
+    "noopener,noreferrer",
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated Playwright worker and FastAPI route to emit CNDs for Anápolis
- expose the new municipal CND action in the Empresas quick actions menu
- centralize the Anápolis portal fallback helper in the shared quickLinks module
- gracefully handle unsupported Playwright environments so the API surfaces a manual fallback message instead of a 500 error
- configure the Windows Proactor event loop, hardened Chromium launch flags, and optional 2Captcha image solving for the Anápolis automation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e96b1e0b6c832690d786463cc7d992