### PR TITLE
Handle Playwright automation under Windows selector event loops

### DIFF
--- a/backend/cnds_worker_anapolis.py
+++ b/backend/cnds_worker_anapolis.py
@@ -14,8 +14,15 @@ from playwright.async_api import async_playwright
 
 # CORREÇÃO: Configurar event loop ANTES de qualquer import do FastAPI
 if sys.platform.startswith("win"):
-    # Força o uso do SelectorEventLoop no Windows, que é compatível com Playwright
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    proactor_policy_cls = getattr(asyncio, "WindowsProactorEventLoopPolicy", None)
+    if proactor_policy_cls is not None:
+        try:
+            policy = asyncio.get_event_loop_policy()
+        except Exception:
+            policy = None
+        if not isinstance(policy, proactor_policy_cls):
+            # Playwright exige ProactorEventLoop no Windows moderno
+            asyncio.set_event_loop_policy(proactor_policy_cls())
 
 MODO_HEADLESS = os.getenv("CND_HEADLESS", "false").lower() == "true"
 EXECUTABLE_PATH = os.getenv("CND_CHROME_PATH")
@@ -132,6 +139,27 @@ if platform.system() == "Windows":
 
 
 async def emitir_cnd_anapolis(cnpj: str) -> Tuple[bool, str, Optional[str]]:
+    if sys.platform.startswith("win"):
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        else:
+            # FastAPI/Uvicorn força WindowsSelectorEventLoopPolicy por compatibilidade,
+            # mas o Playwright precisa do ProactorEventLoop para spawnar o Chromium.
+            if running_loop.__class__.__name__ == "SelectorEventLoop":
+                loop = running_loop
+
+                def _runner() -> Tuple[bool, str, Optional[str]]:
+                    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+                    return asyncio.run(_emitir_cnd_anapolis_impl(cnpj))
+
+                return await loop.run_in_executor(None, _runner)
+
+    return await _emitir_cnd_anapolis_impl(cnpj)
+
+
+async def _emitir_cnd_anapolis_impl(cnpj: str) -> Tuple[bool, str, Optional[str]]:
     # Verificar dependências primeiro
     if not _check_playwright_deps():
         return False, "Playwright não instalado corretamente.", None


### PR DESCRIPTION
## Summary
- detect when the Anápolis CND worker is running under the Windows selector event loop used by FastAPI/Uvicorn
- offload the automation to a separate Proactor-based loop so Playwright can spawn Chromium reliably on Windows

## Testing
- not run (tests not provided)

------
https://chatgpt.com/codex/tasks/task_e_68ed5c570084832689f6b3a21598bd35