### PR TITLE
Improve Anápolis CND automation reliability

### DIFF
--- a/backend/cnds_worker_anapolis.py
+++ b/backend/cnds_worker_anapolis.py
@@ -14,8 +14,15 @@ from playwright.async_api import async_playwright
 
 # CORREÇÃO: Configurar event loop ANTES de qualquer import do FastAPI
 if sys.platform.startswith("win"):
-    # Força o uso do SelectorEventLoop no Windows, que é compatível com Playwright
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    proactor_policy_cls = getattr(asyncio, "WindowsProactorEventLoopPolicy", None)
+    if proactor_policy_cls is not None:
+        try:
+            policy = asyncio.get_event_loop_policy()
+        except Exception:
+            policy = None
+        if not isinstance(policy, proactor_policy_cls):
+            # Playwright exige ProactorEventLoop no Windows moderno
+            asyncio.set_event_loop_policy(proactor_policy_cls())
 
 MODO_HEADLESS = os.getenv("CND_HEADLESS", "false").lower() == "true"
 EXECUTABLE_PATH = os.getenv("CND_CHROME_PATH")
@@ -33,11 +40,18 @@ def _nome_arquivo_destino() -> str:
 
 
 async def _abrir_portal(page) -> None:
-    await page.goto(
-        "https://portaldocidadao.anapolis.go.gov.br/processos/",
-        wait_until="domcontentloaded",
-    )
+    # navega pela HOME + menu, garantindo a tela certa (como no script base)
+    await page.goto("https://portaldocidadao.anapolis.go.gov.br/", wait_until="domcontentloaded")
     await page.wait_for_load_state("networkidle")
+    try:
+        await page.hover("a.pure-menu-link:text('Certidões')")
+        await page.wait_for_selector("a.pure-menu-link[data-navigation='7021']", timeout=10000)
+        await page.click("a.pure-menu-link[data-navigation='7021']")
+        await page.wait_for_load_state("networkidle")
+    except Exception:
+        # fallback: se o menu mudar, ainda assim tenta a rota /processos/
+        await page.goto("https://portaldocidadao.anapolis.go.gov.br/processos/", wait_until="domcontentloaded")
+        await page.wait_for_load_state("networkidle")
 
 
 async def _preencher_cnpj(page, cnpj: str) -> bool:
@@ -132,6 +146,39 @@ if platform.system() == "Windows":
 
 
 async def emitir_cnd_anapolis(cnpj: str) -> Tuple[bool, str, Optional[str]]:
+    if sys.platform.startswith("win"):
+        selector_loop_cls = getattr(asyncio, "SelectorEventLoop", None)
+        proactor_policy_cls = getattr(asyncio, "WindowsProactorEventLoopPolicy", None)
+        if selector_loop_cls is not None and proactor_policy_cls is not None:
+            try:
+                running_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                running_loop = None
+            else:
+                # FastAPI/Uvicorn força WindowsSelectorEventLoopPolicy por compatibilidade,
+                # mas o Playwright precisa do ProactorEventLoop para spawnar o Chromium.
+                if isinstance(running_loop, selector_loop_cls):
+                    loop = running_loop
+
+                    def _runner() -> Tuple[bool, str, Optional[str]]:
+                        previous_policy = None
+                        try:
+                            previous_policy = asyncio.get_event_loop_policy()
+                        except Exception:
+                            pass
+                        asyncio.set_event_loop_policy(proactor_policy_cls())
+                        try:
+                            return asyncio.run(_emitir_cnd_anapolis_impl(cnpj))
+                        finally:
+                            if previous_policy is not None:
+                                asyncio.set_event_loop_policy(previous_policy)
+
+                    return await loop.run_in_executor(None, _runner)
+
+    return await _emitir_cnd_anapolis_impl(cnpj)
+
+
+async def _emitir_cnd_anapolis_impl(cnpj: str) -> Tuple[bool, str, Optional[str]]:
     # Verificar dependências primeiro
     if not _check_playwright_deps():
         return False, "Playwright não instalado corretamente.", None
@@ -215,8 +262,21 @@ async def emitir_cnd_anapolis(cnpj: str) -> Tuple[bool, str, Optional[str]]:
 
                 await _clicar_consultar(page)
                 await page.wait_for_load_state("networkidle", timeout=30000)
-                await page.wait_for_timeout(1000)
+                await page.wait_for_timeout(1500)
 
+                # --- SweetAlert de erro de captcha (igual ao script base) ---
+                try:
+                    popup = page.locator("div.swal2-popup:has-text('O código de verificação não confere')")
+                    if await popup.count() > 0:
+                        try:
+                            await page.click(".swal2-confirm")
+                        except Exception:
+                            pass
+                        return False, "Captcha inválido: o código de verificação não confere.", None
+                except Exception:
+                    pass
+
+                # 1) Tenta clicar em elementos de download/imprimir/gerar
                 tried = await page.evaluate(
                     """
                   () => {
@@ -230,13 +290,62 @@ async def emitir_cnd_anapolis(cnpj: str) -> Tuple[bool, str, Optional[str]]:
                   }
                 """
                 )
-                if not tried:
-                    return False, "Botão/link de PDF não identificado.", None
+                if tried:
+                    # 2) Se clicar disparar um "download event", ótimo:
+                    try:
+                        async with page.expect_download(timeout=15000) as di:
+                            download = await di.value
+                            await download.save_as(destino)
+                        return True, "CND emitida com sucesso.", destino
+                    except Exception:
+                        # 3) Se NÃO houve 'download', pode ter aberto em NOVA ABA ou inline (PDF viewer)
+                        pass
 
-                async with page.expect_download(timeout=30000) as di:
-                    download = await di.value
-                    await download.save_as(destino)
-                return True, "CND emitida com sucesso.", destino
+                # 4) Captura de NOVA PÁGINA com PDF (target=_blank)
+                new_page = None
+                try:
+                    new_page = await page.context.wait_for_event("page", timeout=5000)
+                    await new_page.wait_for_load_state("domcontentloaded", timeout=10000)
+                except Exception:
+                    new_page = None
+
+                candidate_page = new_page or page
+                url_now = candidate_page.url or ""
+                if url_now.lower().endswith(".pdf"):
+                    try:
+                        # Baixa usando a própria API de requests do Playwright (mantém cookies/sessão)
+                        resp = await candidate_page.request.get(url_now)
+                        if resp.ok:
+                            content = await resp.body()
+                            os.makedirs(os.path.dirname(destino), exist_ok=True)
+                            with open(destino, "wb") as f:
+                                f.write(content)
+                            return True, "CND emitida com sucesso (inline).", destino
+                    except Exception:
+                        pass
+
+                # 5) Às vezes o PDF está embedado em <iframe>/<embed>
+                try:
+                    pdf_src = await candidate_page.evaluate("""
+                      () => {
+                        const fr = document.querySelector('iframe, embed');
+                        if (!fr) return null;
+                        const src = fr.getAttribute('src') || fr.src;
+                        return (src && /\.pdf(\?|$)/i.test(src)) ? src : null;
+                      }
+                    """)
+                    if pdf_src:
+                        resp = await candidate_page.request.get(pdf_src)
+                        if resp.ok:
+                            content = await resp.body()
+                            os.makedirs(os.path.dirname(destino), exist_ok=True)
+                            with open(destino, "wb") as f:
+                                f.write(content)
+                            return True, "CND emitida com sucesso (iframe).", destino
+                except Exception:
+                    pass
+
+                return False, "Botão/link de PDF não identificado (nem inline/nova aba).", None
             finally:
                 await context.close()
                 await browser.close()


### PR DESCRIPTION
## Summary
- detect when the current Windows event loop derives from SelectorEventLoop before offloading the Playwright automation
- restore the original loop policy after running the automation on a Proactor-based loop
- navigate through the portal home menu before accessing the Anápolis CND form and add fallbacks for SweetAlert errors and inline/new-tab PDF rendering

## Testing
- not run (tests not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ed5c570084832689f6b3a21598bd35