### PR TITLE
Expose saved CND PDFs and add Empresas certidões menu

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -33,6 +33,7 @@ from typing import List, Optional, Dict, Any
 
 from fastapi import FastAPI, HTTPException, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from repo_excel import ExcelRepo
@@ -77,6 +78,11 @@ app.add_middleware(
 
 app.include_router(certificados_router, prefix="/api")
 app.include_router(cnds_router, prefix="/api")
+
+# Expor diretório de CNDs como estático para consumo pelo frontend
+CND_DIR_BASE = os.getenv("CND_DIR_BASE", "certidoes")
+os.makedirs(CND_DIR_BASE, exist_ok=True)
+app.mount("/cnds", StaticFiles(directory=CND_DIR_BASE), name="cnds")
 
 # Cache em memória (simples)
 cache: Dict[str, object] = {

--- a/backend/cnds_worker_anapolis.py
+++ b/backend/cnds_worker_anapolis.py
@@ -217,7 +217,7 @@ if platform.system() == "Windows":
         asyncio.set_event_loop(loop)
 
 
-async def emitir_cnd_anapolis(cnpj: str) -> Tuple[bool, str, Optional[str]]:
+async def emitir_cnd_anapolis(cnpj: str) -> Tuple[bool, str, Optional[str], Optional[str]]:
     if sys.platform.startswith("win"):
         selector_loop_cls = getattr(asyncio, "SelectorEventLoop", None)
         proactor_policy_cls = getattr(asyncio, "WindowsProactorEventLoopPolicy", None)
@@ -232,7 +232,7 @@ async def emitir_cnd_anapolis(cnpj: str) -> Tuple[bool, str, Optional[str]]:
                 if isinstance(running_loop, selector_loop_cls):
                     loop = running_loop
 
-                    def _runner() -> Tuple[bool, str, Optional[str]]:
+                    def _runner() -> Tuple[bool, str, Optional[str], Optional[str]]:
                         previous_policy = None
                         try:
                             previous_policy = asyncio.get_event_loop_policy()
@@ -250,17 +250,19 @@ async def emitir_cnd_anapolis(cnpj: str) -> Tuple[bool, str, Optional[str]]:
     return await _emitir_cnd_anapolis_impl(cnpj)
 
 
-async def _emitir_cnd_anapolis_impl(cnpj: str) -> Tuple[bool, str, Optional[str]]:
+async def _emitir_cnd_anapolis_impl(cnpj: str) -> Tuple[bool, str, Optional[str], Optional[str]]:
     """Implementação da emissão de CND - VERSÃO CORRIGIDA"""
     # Verificar dependências primeiro
     if not _check_playwright_deps():
-        return False, "Playwright não instalado corretamente.", None
+        return False, "Playwright não instalado corretamente.", None, None
 
     cnpj = only_digits(cnpj)
     os.makedirs(SAIDA_BASE, exist_ok=True)
     destino_dir = os.path.join(SAIDA_BASE, cnpj)
     os.makedirs(destino_dir, exist_ok=True)
-    destino = os.path.join(destino_dir, _nome_arquivo_destino())
+    filename = _nome_arquivo_destino()
+    destino = os.path.join(destino_dir, filename)
+    url_relativo = f"/cnds/{cnpj}/{filename}"
 
     try:
         async with async_playwright() as p:
@@ -283,7 +285,7 @@ async def _emitir_cnd_anapolis_impl(cnpj: str) -> Tuple[bool, str, Optional[str]
             try:
                 browser = await p.chromium.launch(**launch_args)
             except Exception as exc:
-                return False, f"Falha ao iniciar Chromium ({type(exc).__name__}): {exc}", None
+                return False, f"Falha ao iniciar Chromium ({type(exc).__name__}): {exc}", None, None
             
             context = await browser.new_context(ignore_https_errors=True)
             page = await context.new_page()
@@ -307,7 +309,7 @@ async def _emitir_cnd_anapolis_impl(cnpj: str) -> Tuple[bool, str, Optional[str]
 
                 # Preencher CNPJ
                 if not await _preencher_cnpj(page, cnpj):
-                    return False, "Campo de CNPJ não encontrado ou não preenchido.", None
+                    return False, "Campo de CNPJ não encontrado ou não preenchido.", None, None
 
                 # Resolver captcha
                 solved = False
@@ -392,7 +394,7 @@ async def _emitir_cnd_anapolis_impl(cnpj: str) -> Tuple[bool, str, Optional[str]
                             await page.click('.swal2-confirm')
                         except Exception:
                             pass
-                        return False, "Captcha inválido: o código de verificação não confere.", None
+                        return False, "Captcha inválido: o código de verificação não confere.", None, None
                 except Exception:
                     pass
 
@@ -440,7 +442,7 @@ async def _emitir_cnd_anapolis_impl(cnpj: str) -> Tuple[bool, str, Optional[str]
                             download = await download_info.value
                             await download.save_as(destino)
                             print(f"[DOWNLOAD] Certidão salva em: {destino}")
-                            return True, "CND emitida com sucesso.", destino
+                            return True, "CND emitida com sucesso.", destino, url_relativo
                     except Exception as e:
                         print(f"[AVISO] Erro ao aguardar download: {e}")
                         # Continua para tentar métodos alternativos
@@ -464,7 +466,7 @@ async def _emitir_cnd_anapolis_impl(cnpj: str) -> Tuple[bool, str, Optional[str]
                             os.makedirs(os.path.dirname(destino), exist_ok=True)
                             with open(destino, "wb") as f:
                                 f.write(content)
-                            return True, "CND emitida com sucesso (inline).", destino
+                            return True, "CND emitida com sucesso (inline).", destino, url_relativo
                     except Exception:
                         pass
 
@@ -485,11 +487,11 @@ async def _emitir_cnd_anapolis_impl(cnpj: str) -> Tuple[bool, str, Optional[str]
                             os.makedirs(os.path.dirname(destino), exist_ok=True)
                             with open(destino, "wb") as f:
                                 f.write(content)
-                            return True, "CND emitida com sucesso (iframe).", destino
+                            return True, "CND emitida com sucesso (iframe).", destino, url_relativo
                 except Exception:
                     pass
 
-                return False, "Botão/link de PDF não identificado (nem inline/nova aba).", None
+                return False, "Botão/link de PDF não identificado (nem inline/nova aba).", None, None
                 
             finally:
                 await context.close()
@@ -500,6 +502,7 @@ async def _emitir_cnd_anapolis_impl(cnpj: str) -> Tuple[bool, str, Optional[str]
             False,
             "Automação indisponível neste sistema (Playwright não suportado). Utilize o fallback manual.",
             None,
+            None,
         )
     except Exception as exc:
-        return False, f"Falha inesperada na automação: {exc}", None
+        return False, f"Falha inesperada na automação: {exc}", None, None

--- a/backend/routes_cnds.py
+++ b/backend/routes_cnds.py
@@ -24,6 +24,37 @@ async def cnds_emitir(ped: EmitirPedido):
     cnpj = only_digits(ped.cnpj)
     if len(cnpj) != 14:
         raise HTTPException(400, "CNPJ inválido (14 dígitos).")
-    ok, info, path = await emitir_cnd_anapolis(cnpj)
-    return {"ok": ok, "info": info, "path": path}
+    ok, info, path, url = await emitir_cnd_anapolis(cnpj)
+    return {"ok": ok, "info": info, "path": path, "url": url}
+
+
+@router.get("/cnds/{cnpj}/list")
+async def cnds_list(cnpj: str):
+    from pathlib import Path
+    import os
+
+    digits = only_digits(cnpj)
+    base = Path(os.getenv("CND_DIR_BASE", "certidoes")) / digits
+    if not digits or not base.exists():
+        return []
+
+    arquivos = sorted(
+        base.glob("*.pdf"),
+        key=lambda arquivo: arquivo.stat().st_mtime,
+        reverse=True,
+    )
+
+    itens = []
+    for arquivo in arquivos:
+        stat = arquivo.stat()
+        itens.append(
+            {
+                "name": arquivo.name,
+                "size": stat.st_size,
+                "mtime": stat.st_mtime,
+                "url": f"/cnds/{digits}/{arquivo.name}",
+            }
+        )
+
+    return itens
 

--- a/frontend/src/features/empresas/EmpresasScreen.jsx
+++ b/frontend/src/features/empresas/EmpresasScreen.jsx
@@ -16,7 +16,7 @@ import {
 import InlineBadge from "@/components/InlineBadge";
 import StatusBadge from "@/components/StatusBadge";
 import CopyableIdentifier from "@/components/CopyableIdentifier";
-import { Mail, Phone, Clipboard, ExternalLink } from "lucide-react";
+import { Mail, Phone, Clipboard, ExternalLink, Loader2 } from "lucide-react";
 import { TAXA_TYPE_KEYS } from "@/lib/constants";
 import { DEFAULT_CERTIFICADO_SITUACAO } from "@/lib/certificados";
 import {
@@ -25,7 +25,17 @@ import {
   isAlertStatus,
   isProcessStatusInactive,
 } from "@/lib/status";
-import { openCartaoCNPJ, openCNDAnapolis } from "@/lib/quickLinks";
+import { openCartaoCNPJ, openCNDAnapolis, onlyDigits } from "@/lib/quickLinks";
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || "").replace(/\/$/, "");
+
+const ensureAbsoluteUrl = (url) => {
+  if (!url) return url;
+  if (/^https?:/i.test(url)) {
+    return url;
+  }
+  return `${API_BASE_URL}${url}`;
+};
 
 export default function EmpresasScreen({
   filteredEmpresas,
@@ -39,6 +49,56 @@ export default function EmpresasScreen({
   enqueueToast,
 }) {
   const toast = (msg) => enqueueToast?.(msg);
+
+  const [cndCache, setCndCache] = React.useState({});
+  const cndCacheRef = React.useRef(cndCache);
+
+  React.useEffect(() => {
+    cndCacheRef.current = cndCache;
+  }, [cndCache]);
+
+  const ensureCNDs = React.useCallback(
+    async (cnpjRaw, { force = false } = {}) => {
+      const digits = onlyDigits(cnpjRaw || "");
+      if (!digits) {
+        return [];
+      }
+
+      const cached = cndCacheRef.current[digits];
+      if (!force) {
+        if (cached?.loading) {
+          return cached.items || [];
+        }
+        if (cached?.items) {
+          return cached.items;
+        }
+      }
+
+      setCndCache((prev) => ({
+        ...prev,
+        [digits]: { ...(prev[digits] || {}), loading: true },
+      }));
+
+      try {
+        const response = await fetch(`${API_BASE_URL}/api/cnds/${digits}/list`);
+        const items = response.ok ? await response.json() : [];
+        setCndCache((prev) => ({
+          ...prev,
+          [digits]: { items, loading: false },
+        }));
+        return items;
+      } catch (error) {
+        console.error("[CND] Falha ao listar PDFs:", error);
+        setCndCache((prev) => ({
+          ...prev,
+          [digits]: { items: [], loading: false, error: true },
+        }));
+        toast?.("Não foi possível verificar as CNDs desta empresa.");
+        return [];
+      }
+    },
+    [toast]
+  );
 
   const isMunicipioAnapolis = React.useCallback((municipio) => {
     const normalized = (municipio || "")
@@ -63,8 +123,7 @@ export default function EmpresasScreen({
 
       try {
         toast?.("Iniciando emissão da CND (Anápolis)...");
-        const baseUrl = (import.meta.env.VITE_API_BASE_URL || "").replace(/\/$/, "");
-        const resp = await fetch(`${baseUrl}/api/cnds/emitir`, {
+        const resp = await fetch(`${API_BASE_URL}/api/cnds/emitir`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ cidade: "anapolis", cnpj }),
@@ -75,7 +134,9 @@ export default function EmpresasScreen({
         }
         if (data?.ok) {
           toast?.("CND emitida com sucesso.");
-          if (data?.path) {
+          if (data?.url) {
+            console.info("CND Anápolis disponível em:", ensureAbsoluteUrl(data.url));
+          } else if (data?.path) {
             console.info("CND Anápolis salva em:", data.path);
           }
         } else {
@@ -127,6 +188,10 @@ export default function EmpresasScreen({
               : "?";
 
           const municipioEhAnapolis = isMunicipioAnapolis(empresa.municipio);
+          const cnpjDigits = onlyDigits(empresa.cnpj || "");
+          const cndEntry = cndCache[cnpjDigits] || {};
+          const cndLoading = Boolean(cndEntry.loading);
+          const hasCND = Array.isArray(cndEntry.items) && cndEntry.items.length > 0;
 
           return (
             <Card key={empresa.id} className="shadow-sm overflow-hidden border border-white/60">
@@ -262,6 +327,53 @@ export default function EmpresasScreen({
                       </DropdownMenuItem>
 
                       {/* próximos itens: CND Goiânia, CND Megasoft/Centi etc. */}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+
+                  <DropdownMenu
+                    onOpenChange={(open) => {
+                      if (open) {
+                        ensureCNDs(empresa.cnpj);
+                      }
+                    }}
+                  >
+                    <DropdownMenuTrigger asChild>
+                      <Button size="sm" variant="outline" className="text-xs">
+                        Certidões
+                      </Button>
+                    </DropdownMenuTrigger>
+
+                    <DropdownMenuContent align="end" className="w-72">
+                      <DropdownMenuLabel>Certidões</DropdownMenuLabel>
+                      <DropdownMenuSeparator />
+
+                      <DropdownMenuItem
+                        disabled={cndLoading || !hasCND}
+                        onSelect={async () => {
+                          let lista = cndEntry.items;
+                          if (!Array.isArray(lista) || lista.length === 0) {
+                            lista = await ensureCNDs(empresa.cnpj, { force: true });
+                          }
+
+                          if (!lista || lista.length === 0) {
+                            toast?.("Nenhuma CND encontrada para esta empresa.");
+                            return;
+                          }
+
+                          const url = lista[0]?.url;
+                          if (url) {
+                            window.open(ensureAbsoluteUrl(url), "_blank", "noopener,noreferrer");
+                          } else {
+                            toast?.("Não foi possível localizar o arquivo da CND.");
+                          }
+                        }}
+                        className="flex items-center justify-between"
+                      >
+                        <span>Abrir CND (mais recente)</span>
+                        {cndLoading && (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin text-slate-400" />
+                        )}
+                      </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </div>


### PR DESCRIPTION
## Summary
- serve saved CND PDFs via FastAPI static files and propagate file URLs from the automation worker
- expose a listing endpoint for company CNDs and return download URLs with emission responses
- add a Certidões dropdown on the Empresas screen that opens the latest available CND PDF in a new tab

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eff593040483268e3106fe6752e1d1