### PR TITLE
Add Megasoft municipal CND automation

### DIFF
--- a/backend/cnds_worker_megasoft.py
+++ b/backend/cnds_worker_megasoft.py
@@ -1,0 +1,192 @@
+import os
+import re
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+from playwright.async_api import (
+    TimeoutError as PlaywrightTimeoutError,
+    async_playwright,
+)
+
+
+def _only_digits(value: str) -> str:
+    return re.sub(r"\D+", "", value or "")
+
+
+def _normalize_city(value: str) -> str:
+    import unicodedata
+
+    if not value:
+        return ""
+
+    normalized = (
+        unicodedata.normalize("NFD", value)
+        .encode("ascii", "ignore")
+        .decode("ascii")
+        .lower()
+    )
+    normalized = re.sub(r"[^a-z0-9]+", " ", normalized)
+    return " ".join(normalized.split())
+
+
+def _ensure_https(url: str) -> str:
+    if not url:
+        return url
+    url = url.strip()
+    if url.startswith("http://"):
+        url = "https://" + url[len("http://") :]
+    if not url.startswith("https://"):
+        url = f"https://{url.lstrip('/')}"
+    return url
+
+
+def _resolve_slug(base_url: str, cidade: str) -> str:
+    hostname = ""
+    try:
+        parsed = urlparse(base_url)
+        hostname = parsed.hostname or ""
+    except Exception:
+        hostname = ""
+
+    if hostname:
+        candidate = hostname.split(".")[0]
+        candidate = re.sub(r"[^a-z0-9]+", "", candidate.lower())
+        if candidate:
+            return candidate
+
+    normalized = _normalize_city(cidade)
+    fallback = normalized.replace(" ", "")
+    return fallback or "municipio"
+
+
+def _build_filename(slug: str) -> str:
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+    return f"{timestamp}_CND_Municipal_{slug}.pdf"
+
+
+def _static_url(cnpj: str, filename: str) -> str:
+    return f"/cnds/{cnpj}/{filename}"
+
+
+async def _wait_for_toast_message(page, timeout: int = 5000) -> Optional[str]:
+    try:
+        toast = await page.wait_for_selector(".toast-message", timeout=timeout)
+        message = (await toast.inner_text() or "").strip()
+        if message:
+            print(f"[MEGASOFT] Toast exibido: {message}")
+            return message
+    except PlaywrightTimeoutError:
+        return None
+    except Exception as exc:
+        print(f"[MEGASOFT] Falha ao ler toast: {exc}")
+    return None
+
+
+async def emitir_cnd_megasoft(
+    cnpj: str,
+    base_url: str,
+    cidade: str,
+    *,
+    download_dir: Path,
+    headless: bool = True,
+) -> Dict[str, object]:
+    """Emite CND no portal Megasoft e retorna o resultado padronizado."""
+
+    cnpj_digits = _only_digits(cnpj)
+    if len(cnpj_digits) != 14:
+        return {"ok": False, "info": "CNPJ inválido (14 dígitos).", "path": None, "url": None}
+
+    url = _ensure_https(base_url)
+    slug = _resolve_slug(url, cidade)
+    destino_base = Path(download_dir)
+    destino_dir = destino_base / cnpj_digits
+    destino_dir.mkdir(parents=True, exist_ok=True)
+    filename = _build_filename(slug)
+    destino = destino_dir / filename
+
+    print(f"[MEGASOFT] Iniciando emissão para {cidade} ({slug}) em {url}")
+
+    try:
+        async with async_playwright() as p:
+            launch_args: Dict[str, object] = {
+                "headless": headless,
+                "args": [
+                    "--disable-gpu",
+                    "--disable-dev-shm-usage",
+                    "--no-first-run",
+                    "--no-default-browser-check",
+                    "--no-sandbox",
+                ],
+            }
+            executable_path = os.getenv("CND_CHROME_PATH")
+            if executable_path:
+                launch_args["executable_path"] = executable_path
+
+            browser = await p.chromium.launch(**launch_args)
+            context = await browser.new_context(accept_downloads=True, ignore_https_errors=True)
+            page = await context.new_page()
+
+            try:
+                await page.goto(url, wait_until="networkidle")
+                await page.wait_for_selector(".ng-select-container", timeout=20000)
+                await page.locator(".ng-select-container").first.click()
+                await page.wait_for_selector(
+                    "span.ng-option-label:has-text(\"1 - Contribuinte\")",
+                    timeout=20000,
+                )
+                await page.locator("span.ng-option-label:has-text(\"1 - Contribuinte\")").click()
+
+                cnpj_input = page.locator("#cpfCnpj")
+                await cnpj_input.wait_for(state="visible", timeout=20000)
+                await cnpj_input.fill(cnpj_digits)
+                await cnpj_input.press("Enter")
+
+                botao = page.locator("button.btn.btn-mega:has-text(\"GERAR CERTIDÃO\")")
+                await botao.wait_for(state="visible", timeout=20000)
+                download_future = page.wait_for_event("download")
+                await botao.click()
+
+                try:
+                    download = await download_future
+                except PlaywrightTimeoutError:
+                    mensagem = await _wait_for_toast_message(page, timeout=8000)
+                    if mensagem:
+                        return {"ok": False, "info": mensagem, "path": None, "url": None}
+                    return {
+                        "ok": False,
+                        "info": "Não foi possível gerar a certidão (timeout).",
+                        "path": None,
+                        "url": None,
+                    }
+
+                await download.save_as(str(destino))
+                caminho_absoluto = str(destino.resolve())
+                url_publica = _static_url(cnpj_digits, filename)
+                print(f"[MEGASOFT] Certidão salva em {caminho_absoluto}")
+                return {
+                    "ok": True,
+                    "info": "Certidão emitida com sucesso.",
+                    "path": caminho_absoluto,
+                    "url": url_publica,
+                }
+            finally:
+                await context.close()
+                await browser.close()
+    except PlaywrightTimeoutError:
+        return {
+            "ok": False,
+            "info": "Tempo excedido durante a navegação no portal Megasoft.",
+            "path": None,
+            "url": None,
+        }
+    except Exception as exc:
+        print(f"[MEGASOFT] Erro inesperado: {exc}")
+        return {
+            "ok": False,
+            "info": f"Falha ao emitir CND ({type(exc).__name__}).",
+            "path": None,
+            "url": None,
+        }

--- a/backend/megasoft_map.json
+++ b/backend/megasoft_map.json
@@ -1,0 +1,13 @@
+[
+  {"municipio": "Abadia de Goiás", "slug": "abadiadegoias", "base_url": "https://abadiadegoias.megasoftservicos.com.br/cidadao/emissao-certidao-negat"},
+  {"municipio": "Abadiânia", "slug": "abadiania", "base_url": "https://abadiania.megasoftservicos.com.br/cidadao/emissao-certidao-negat"},
+  {"municipio": "Corumbá de Goiás", "slug": "corumbadegoias", "base_url": "https://corumbadegoias.megasoftservicos.com.br/cidadao/emissao-certidao-negat"},
+  {"municipio": "Goianápolis", "slug": "goianapolis", "base_url": "https://goianapolis.megasoftservicos.com.br/cidadao/emissao-certidao-negat"},
+  {"municipio": "Itapaci", "slug": "itapaci", "base_url": "https://itapaci.megasoftservicos.com.br/cidadao/emissao-certidao-negat"},
+  {"municipio": "Jaraguá", "slug": "jaragua", "base_url": "https://jaragua.megasoftservicos.com.br/cidadao/autent-certidao-negat"},
+  {"municipio": "Rubiataba", "slug": "rubiataba", "base_url": "https://rubiataba.megasoftservicos.com.br/cidadao/emissao-certidao-negat"},
+  {"municipio": "Silvânia", "slug": "silvania", "base_url": "https://silvania.megasoftservicos.com.br/cidadao/emissao-certidao-negat"},
+  {"municipio": "Uruaçu", "slug": "uruacu", "base_url": "https://uruacu.megasoftservicos.com.br/cidadao/emissao-certidao-negat"},
+  {"municipio": "Uruana", "slug": "uruana", "base_url": "https://uruana.megasoftservicos.com.br/cidadao/emissao-certidao-negat"},
+  {"municipio": "Vila Propício", "slug": "vilapropicio", "base_url": "https://vilapropicio.megasoftservicos.com.br/cidadao/emissao-certidao-negat"}
+]

--- a/backend/routes_cnds.py
+++ b/backend/routes_cnds.py
@@ -1,15 +1,22 @@
+import json
+import os
 import re
+import unicodedata
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Optional
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from cnds_worker_anapolis import emitir_cnd_anapolis
+from cnds_worker_megasoft import emitir_cnd_megasoft
 
 router = APIRouter(tags=["cnds"])
 
 
 class EmitirPedido(BaseModel):
-    cidade: str = Field(..., description="Por enquanto, apenas 'anapolis'")
+    municipio: str = Field(..., description="Município da empresa")
     cnpj: str
 
 
@@ -17,25 +24,124 @@ def only_digits(s: str) -> str:
     return re.sub(r"\D+", "", s or "")
 
 
+def _normalize_text(value: str) -> str:
+    if not value:
+        return ""
+    normalized = (
+        unicodedata.normalize("NFD", value)
+        .encode("ascii", "ignore")
+        .decode("ascii")
+        .lower()
+    )
+    normalized = re.sub(r"[^a-z0-9]+", " ", normalized)
+    return " ".join(normalized.split())
+
+
+def _is_anapolis(value: str) -> bool:
+    normalized = _normalize_text(value)
+    if not normalized:
+        return False
+    parts = normalized.replace("/", " ").split()
+    return any(part == "anapolis" for part in parts)
+
+
+def _ensure_https(url: str) -> str:
+    if not url:
+        return url
+    url = url.strip()
+    if url.startswith("http://"):
+        url = "https://" + url[len("http://") :]
+    if not url.startswith("https://"):
+        url = f"https://{url.lstrip('/')}"
+    return url
+
+
+MEGASOFT_MAP_PATH = Path(__file__).parent / "megasoft_map.json"
+CND_DIR_BASE = Path(os.getenv("CND_DIR_BASE", "certidoes"))
+CND_HEADLESS = (os.getenv("CND_HEADLESS", "true").strip().lower() in {"1", "true", "yes", "on"})
+
+CND_DIR_BASE.mkdir(parents=True, exist_ok=True)
+
+
+@lru_cache()
+def _load_megasoft_map() -> Dict[str, Dict[str, str]]:
+    if not MEGASOFT_MAP_PATH.exists():
+        return {}
+    try:
+        entries = json.loads(MEGASOFT_MAP_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+    mapping: Dict[str, Dict[str, str]] = {}
+    for item in entries:
+        municipio = item.get("municipio", "")
+        base_url = _ensure_https(item.get("base_url", ""))
+        if not municipio or not base_url:
+            continue
+        normalized = _normalize_text(municipio)
+        if not normalized:
+            continue
+        mapping[normalized] = {
+            "municipio": municipio,
+            "base_url": base_url,
+            "slug": item.get("slug") or "",
+        }
+    return mapping
+
+
 @router.post("/cnds/emitir")
 async def cnds_emitir(ped: EmitirPedido):
-    if ped.cidade.lower() != "anapolis":
-        raise HTTPException(400, "Cidade não suportada nesta etapa.")
+    municipio_raw = ped.municipio or ""
+    municipio_norm = _normalize_text(municipio_raw)
+    if not municipio_norm:
+        raise HTTPException(400, "Município é obrigatório.")
+
     cnpj = only_digits(ped.cnpj)
     if len(cnpj) != 14:
         raise HTTPException(400, "CNPJ inválido (14 dígitos).")
-    ok, info, path, url = await emitir_cnd_anapolis(cnpj)
-    return {"ok": ok, "info": info, "path": path, "url": url}
+
+    if _is_anapolis(municipio_raw):
+        ok, info, path, url = await emitir_cnd_anapolis(cnpj)
+        return {"ok": ok, "info": info, "path": path, "url": url}
+
+    megasoft_map = _load_megasoft_map()
+    info: Optional[Dict[str, str]] = megasoft_map.get(municipio_norm)
+    if not info:
+        for key, data in megasoft_map.items():
+            if key in municipio_norm or municipio_norm in key:
+                info = data
+                break
+    if info:
+        result = await emitir_cnd_megasoft(
+            cnpj=cnpj,
+            base_url=info["base_url"],
+            cidade=info["municipio"],
+            download_dir=CND_DIR_BASE,
+            headless=CND_HEADLESS,
+        )
+        return {
+            "ok": result.get("ok", False),
+            "info": result.get("info"),
+            "path": result.get("path"),
+            "url": result.get("url"),
+        }
+
+    return {
+        "ok": False,
+        "info": "Município não suportado para emissão automática de CND.",
+        "path": None,
+        "url": None,
+    }
 
 
 @router.get("/cnds/{cnpj}/list")
 async def cnds_list(cnpj: str):
-    from pathlib import Path
-    import os
-
     digits = only_digits(cnpj)
-    base = Path(os.getenv("CND_DIR_BASE", "certidoes")) / digits
-    if not digits or not base.exists():
+    if not digits:
+        return []
+
+    base = CND_DIR_BASE / digits
+    if not base.exists():
         return []
 
     arquivos = sorted(

--- a/frontend/src/features/empresas/EmpresasScreen.jsx
+++ b/frontend/src/features/empresas/EmpresasScreen.jsx
@@ -138,38 +138,51 @@ export default function EmpresasScreen({
 
   const emitirCNDMunicipal = React.useCallback(
     async (cnpj, municipio, abrirPortal = false) => {
-      const ehAnapolis = isMunicipioAnapolis(municipio);
-      if (!ehAnapolis || abrirPortal) {
-        await openCNDAnapolis(cnpj, toast);
+      const digits = onlyDigits(cnpj || "");
+      if (!digits || digits.length !== 14) {
+        toast?.("CNPJ inválido para emissão da CND.");
         return;
       }
 
+      if (abrirPortal) {
+        if (isMunicipioAnapolis(municipio)) {
+          await openCNDAnapolis(cnpj, toast);
+        } else {
+          toast?.("Abertura manual disponível apenas para Anápolis no momento.");
+        }
+        return;
+      }
+
+      const municipioNome = (municipio || "").trim();
+
       try {
-        toast?.("Iniciando emissão da CND (Anápolis)...");
+        const destinoLabel = municipioNome || "município informado";
+        toast?.(`Iniciando emissão da CND (${destinoLabel}).`);
         const resp = await fetch(`${API_BASE_URL}/api/cnds/emitir`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ cidade: "anapolis", cnpj }),
+          body: JSON.stringify({ cnpj, municipio: municipioNome }),
         });
         const data = await resp.json().catch(() => ({}));
         if (!resp.ok) {
-          throw new Error(data?.detail || "Falha ao emitir a CND.");
+          throw new Error(data?.detail || data?.info || "Falha ao emitir a CND.");
         }
         if (data?.ok) {
           toast?.("CND emitida com sucesso.");
           if (data?.url) {
-            console.info("CND Anápolis disponível em:", ensureAbsoluteUrl(data.url));
+            console.info("CND Municipal disponível em:", ensureAbsoluteUrl(data.url));
           } else if (data?.path) {
-            console.info("CND Anápolis salva em:", data.path);
+            console.info("CND Municipal salva em:", data.path);
           }
+          await ensureCNDs(cnpj, { force: true });
         } else {
-          toast?.(`Não foi possível emitir: ${data?.info || "verifique os dados."}`);
+          toast?.(data?.info || "Não foi possível emitir a CND.");
         }
       } catch (error) {
         toast?.(error?.message || "Erro inesperado ao emitir a CND.");
       }
     },
-    [isMunicipioAnapolis, toast]
+    [ensureCNDs, isMunicipioAnapolis, toast]
   );
 
   return (
@@ -210,11 +223,11 @@ export default function EmpresasScreen({
               ? `${rawId}`
               : "?";
 
-          const municipioEhAnapolis = isMunicipioAnapolis(empresa.municipio);
           const cnpjDigits = onlyDigits(empresa.cnpj || "");
           const cndEntry = cndCache[cnpjDigits] || {};
           const cndLoading = Boolean(cndEntry.loading);
           const hasCND = Array.isArray(cndEntry.items) && cndEntry.items.length > 0;
+          const municipioInformado = Boolean((empresa.municipio || "").trim());
 
           return (
             <Card key={empresa.id} className="shadow-sm overflow-hidden border border-white/60">
@@ -345,7 +358,7 @@ export default function EmpresasScreen({
                         }
                         description="Emitir a partir do portal da Prefeitura."
                         hint={<Kbd>Ctrl</Kbd>}
-                        disabled={!municipioEhAnapolis}
+                        disabled={!municipioInformado}
                         onClick={(event) => {
                           const originalEvent = event?.detail?.originalEvent;
                           const abrirPortal = Boolean(


### PR DESCRIPTION
## Summary
- add the Megasoft municipality map and dedicated Playwright worker for municipal CNDs
- route CND emission requests by municipality, preserving the Anápolis flow and delegating Megasoft cities
- reuse the existing frontend CND button to call the new backend endpoint without exposing providers

## Testing
- python -m compileall backend
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68f27d397cb883268c807fba44a1463d