### PR TITLE
Handle Megasoft toast when CNPJ not found

### DIFF
--- a/backend/cnds_worker_megasoft.py
+++ b/backend/cnds_worker_megasoft.py
@@ -143,18 +143,88 @@ async def _emitir_cnd_megasoft_impl(
 
                 botao = page.locator("button.btn.btn-mega:has-text(\"GERAR CERTIDÃO\")")
                 await botao.wait_for(state="visible", timeout=20000)
-                download_future = page.wait_for_event("download")
+                download_task = asyncio.create_task(page.wait_for_event("download"))
                 await botao.click()
 
-                try:
-                    download = await download_future
-                except PlaywrightTimeoutError:
-                    mensagem = await _wait_for_toast_message(page, timeout=8000)
-                    if mensagem:
-                        return {"ok": False, "info": mensagem, "path": None, "url": None}
+                toast_task = asyncio.create_task(_wait_for_toast_message(page, timeout=8000))
+                done, pending = await asyncio.wait(
+                    {download_task, toast_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                    timeout=20000,
+                )
+
+                if not done:
+                    for task in pending:
+                        task.cancel()
+                    await asyncio.gather(*pending, return_exceptions=True)
                     return {
                         "ok": False,
                         "info": "Não foi possível gerar a certidão (timeout).",
+                        "path": None,
+                        "url": None,
+                    }
+
+                download = None
+
+                if download_task in done:
+                    try:
+                        download = await download_task
+                    except PlaywrightTimeoutError:
+                        mensagem = None
+                        if not toast_task.done():
+                            try:
+                                mensagem = await toast_task
+                            except Exception:
+                                mensagem = None
+                        else:
+                            mensagem = await toast_task
+
+                        if mensagem:
+                            return {
+                                "ok": False,
+                                "info": mensagem,
+                                "path": None,
+                                "url": None,
+                            }
+                        return {
+                            "ok": False,
+                            "info": "Não foi possível gerar a certidão (timeout).",
+                            "path": None,
+                            "url": None,
+                        }
+                    finally:
+                        if not toast_task.done():
+                            toast_task.cancel()
+                            try:
+                                await toast_task
+                            except Exception:
+                                pass
+                else:
+                    mensagem = await toast_task
+                    if mensagem:
+                        if not download_task.done():
+                            download_task.cancel()
+                            try:
+                                await download_task
+                            except Exception:
+                                pass
+                        return {"ok": False, "info": mensagem, "path": None, "url": None}
+
+                    # Se nenhum toast específico apareceu, aguarda o download normalmente
+                    try:
+                        download = await download_task
+                    except PlaywrightTimeoutError:
+                        return {
+                            "ok": False,
+                            "info": "Não foi possível gerar a certidão (timeout).",
+                            "path": None,
+                            "url": None,
+                        }
+
+                if not download:
+                    return {
+                        "ok": False,
+                        "info": "Não foi possível gerar a certidão (resultado indefinido).",
                         "path": None,
                         "url": None,
                     }


### PR DESCRIPTION
## Summary
- handle Megasoft CNPJ-not-found toast by racing download and toast detection tasks
- ensure pending async tasks are cancelled to avoid leaks and surface clear timeout results

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f63369b6c48326ad017f41b236cede