### PR TITLE
Add CAE/FIC automation and frontend entry for Anápolis

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -48,6 +48,7 @@ from services import (
 )
 from routes_certificados import router as certificados_router
 from cnds.routes import router as cnds_router
+from caes.routes import router as cae_router
 
 # ----------------------------------------------------------------------------
 # Config
@@ -78,6 +79,7 @@ app.add_middleware(
 
 app.include_router(certificados_router, prefix="/api")
 app.include_router(cnds_router, prefix="/api")
+app.include_router(cae_router, prefix="/api")
 
 # Expor diretório de CNDs como estático para consumo pelo frontend
 CND_DIR_BASE = os.getenv("CND_DIR_BASE", "certidoes")

--- a/backend/caes/__init__.py
+++ b/backend/caes/__init__.py
@@ -1,0 +1,1 @@
+"""Automação de Certidão de Atividade Econômica (CAE/FIC)."""

--- a/backend/caes/cae_worker_anapolis.py
+++ b/backend/caes/cae_worker_anapolis.py
@@ -1,0 +1,371 @@
+"""Rotina Playwright para emissão da CAE/FIC no portal de Anápolis."""
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import platform
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+import requests
+from dotenv import find_dotenv, load_dotenv
+from playwright.async_api import (
+    Page,
+    TimeoutError as PlaywrightTimeoutError,
+    async_playwright,
+)
+
+# ---------------------------------------------------------------------------
+# Carregamento antecipado do .env e ajuste de event loop (Windows)
+# ---------------------------------------------------------------------------
+_DOTENV_PATH = find_dotenv(filename=".env", raise_error_if_not_found=False)
+if not _DOTENV_PATH:
+    base_dir = Path(__file__).resolve().parent
+    for candidate in (base_dir / ".env", base_dir.parent / ".env"):
+        if candidate.exists():
+            _DOTENV_PATH = str(candidate)
+            break
+load_dotenv(dotenv_path=_DOTENV_PATH or None)
+
+if sys.platform.startswith("win"):
+    proactor_policy_cls = getattr(asyncio, "WindowsProactorEventLoopPolicy", None)
+    if proactor_policy_cls is not None:
+        try:
+            current_policy = asyncio.get_event_loop_policy()
+        except Exception:  # pragma: no cover - defensive
+            current_policy = None
+        if not isinstance(current_policy, proactor_policy_cls):
+            asyncio.set_event_loop_policy(proactor_policy_cls())
+
+# ---------------------------------------------------------------------------
+# Configurações de ambiente compartilhadas com os workers de CND
+# ---------------------------------------------------------------------------
+EXECUTABLE_PATH = os.getenv("CND_CHROME_PATH")
+SAIDA_BASE = Path(os.getenv("CND_DIR_BASE", "certidoes"))
+CAPTCHA_MODE = (os.getenv("CAPTCHA_MODE") or "manual").strip().lower()
+API_KEY_2CAPTCHA = (os.getenv("API_KEY_2CAPTCHA") or "").strip()
+
+
+def only_digits(s: str) -> str:
+    """Retorna apenas os dígitos de uma string."""
+    return re.sub(r"\D+", "", s or "")
+
+
+def normalize_im(raw: str) -> str:
+    """Normaliza a inscrição municipal (IM) removendo sufixos e não dígitos."""
+    base = (raw or "").split(" - ")[0]
+    return only_digits(base)
+
+
+# ---------------------------------------------------------------------------
+# Utilidades internas
+# ---------------------------------------------------------------------------
+
+def _nome_arquivo_destino() -> str:
+    return f"CAE - {datetime.now().strftime('%d.%m.%Y')}.pdf"
+
+
+def _check_playwright_deps() -> bool:
+    """Garante que o Playwright e o Chromium estejam instalados."""
+    try:
+        import playwright  # noqa: F401
+    except ImportError:
+        return False
+
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "playwright", "install", "chromium"],
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        # Caso já esteja instalado ou não seja necessário reinstalar
+        pass
+    return True
+
+
+def _solve_image_captcha_2captcha(image_b64: str) -> str:
+    if not API_KEY_2CAPTCHA:
+        raise RuntimeError("API_KEY_2CAPTCHA não configurada para resolução automática do captcha.")
+
+    response = requests.post(
+        "http://2captcha.com/in.php",
+        data={"method": "base64", "key": API_KEY_2CAPTCHA, "body": image_b64, "json": 1},
+        timeout=30,
+    ).json()
+    if response.get("status") != 1:
+        raise RuntimeError(f"2Captcha falhou ao receber imagem: {response}")
+
+    captcha_id = response["request"]
+    for _ in range(24):
+        time.sleep(5)
+        result = requests.get(
+            "http://2captcha.com/res.php",
+            params={"key": API_KEY_2CAPTCHA, "action": "get", "id": captcha_id, "json": 1},
+            timeout=30,
+        ).json()
+        if result.get("status") == 1:
+            return result["request"]
+    raise TimeoutError("Timeout aguardando resposta do 2Captcha.")
+
+
+async def _resolver_captcha(page: Page) -> bool:
+    """Tenta resolver o captcha automaticamente. Retorna True se preenchido."""
+    img = page.locator("img.step-img[src*='captcha.action']").first
+    if not await img.count():
+        return True
+
+    try:
+        await page.locator("#106270").wait_for(state="visible", timeout=10000)
+    except PlaywrightTimeoutError:
+        pass
+
+    if CAPTCHA_MODE == "image_2captcha" and API_KEY_2CAPTCHA:
+        png_bytes = await img.screenshot(type="png")
+        b64 = base64.b64encode(png_bytes).decode()
+        resposta = _solve_image_captcha_2captcha(b64)
+        input_captcha = page.locator("#106270")
+        await input_captcha.fill(resposta)
+        return True
+
+    return False
+
+
+async def _navegar_para_formulario(page: Page) -> None:
+    await page.goto("https://portaldocidadao.anapolis.go.gov.br/processos/", wait_until="domcontentloaded")
+    try:
+        await page.wait_for_load_state("networkidle", timeout=15000)
+    except PlaywrightTimeoutError:
+        pass
+
+    try:
+        menu_certidoes = page.locator("a.pure-menu-link", has_text="Certidões").first
+        if await menu_certidoes.count():
+            try:
+                await menu_certidoes.hover()
+            except Exception:
+                pass
+        opcao_cae = page.locator("a.pure-menu-link[data-navigation='7023']").first
+        await opcao_cae.wait_for(state="visible", timeout=10000)
+        await opcao_cae.click()
+        await page.wait_for_load_state("networkidle", timeout=15000)
+    except Exception:
+        # Como fallback, permanecer na página atual
+        pass
+
+    await page.wait_for_selector("#106266", state="visible", timeout=15000)
+
+
+async def _preencher_im(page: Page, im: str) -> None:
+    campo_im = page.locator("#106266")
+    await campo_im.fill("")
+    await campo_im.type(im)
+
+
+async def _clicar_emitir(page: Page) -> None:
+    botao_emitir = page.locator("input.botao[acao='106274']").first
+    await botao_emitir.wait_for(state="visible", timeout=15000)
+    await botao_emitir.click()
+
+
+async def _aguardar_download(page: Page, destino: Path) -> None:
+    anexos = page.locator("#anexos-linhas-arquivos-106272 a[href*='downloadanexo.action']").first
+    await anexos.wait_for(state="visible", timeout=30000)
+    if destino.exists():
+        destino.unlink()
+    async with page.expect_download(timeout=30000) as download_info:
+        await anexos.click()
+    download = await download_info.value
+    await download.save_as(str(destino))
+
+
+async def _emitir_cae_anapolis_impl(cnpj: str, im: str) -> Dict:
+    if not _check_playwright_deps():
+        return {
+            "ok": False,
+            "info": "Playwright/Chromium não instalados. Configure o ambiente antes de emitir a CAE.",
+            "path": None,
+            "url": None,
+        }
+
+    cnpj_digits = only_digits(cnpj)
+    im_digits = normalize_im(im)
+    if len(cnpj_digits) != 14:
+        return {
+            "ok": False,
+            "info": "CNPJ inválido (14 dígitos).",
+            "path": None,
+            "url": None,
+        }
+    if not im_digits:
+        return {
+            "ok": False,
+            "info": "Inscrição Municipal inválida.",
+            "path": None,
+            "url": None,
+        }
+
+    SAIDA_BASE.mkdir(parents=True, exist_ok=True)
+    destino_dir = SAIDA_BASE / cnpj_digits
+    destino_dir.mkdir(parents=True, exist_ok=True)
+    filename = _nome_arquivo_destino()
+    destino = destino_dir / filename
+    url_relativo = f"/cnds/{cnpj_digits}/{filename}"
+
+    headless = (os.getenv("CND_HEADLESS", "false").strip().lower() in {"1", "true", "yes", "on"})
+
+    try:
+        async with async_playwright() as p:
+            launch_args = {
+                "headless": headless,
+                "args": [
+                    "--disable-gpu",
+                    "--disable-dev-shm-usage",
+                    "--no-first-run",
+                    "--no-default-browser-check",
+                    "--no-sandbox",
+                ],
+            }
+            if EXECUTABLE_PATH:
+                launch_args["executable_path"] = EXECUTABLE_PATH
+            try:
+                browser = await p.chromium.launch(**launch_args)
+            except Exception as exc:
+                return {
+                    "ok": False,
+                    "info": f"Falha ao iniciar Chromium ({type(exc).__name__}): {exc}",
+                    "path": None,
+                    "url": None,
+                }
+
+            context = await browser.new_context(ignore_https_errors=True, accept_downloads=True)
+            page = await context.new_page()
+
+            try:
+                await _navegar_para_formulario(page)
+                await _preencher_im(page, im_digits)
+
+                captcha_preenchido = await _resolver_captcha(page)
+                if not captcha_preenchido:
+                    if headless:
+                        return {
+                            "ok": False,
+                            "info": "Captcha não resolvido automaticamente. Configure o 2Captcha para execução headless.",
+                            "path": None,
+                            "url": None,
+                        }
+                    try:
+                        await page.wait_for_function(
+                            "document.querySelector('#106270') && document.querySelector('#106270').value.trim().length > 0",
+                            timeout=120000,
+                        )
+                    except PlaywrightTimeoutError:
+                        return {
+                            "ok": False,
+                            "info": "Captcha não foi preenchido manualmente a tempo.",
+                            "path": None,
+                            "url": None,
+                        }
+
+                await _clicar_emitir(page)
+
+                try:
+                    await page.wait_for_load_state("networkidle", timeout=30000)
+                except PlaywrightTimeoutError:
+                    pass
+
+                try:
+                    popup = page.locator("div.swal2-popup:has-text('não confere')")
+                    if await popup.count():
+                        try:
+                            await page.locator(".swal2-confirm").click()
+                        except Exception:
+                            pass
+                        return {
+                            "ok": False,
+                            "info": "Captcha inválido informado no portal.",
+                            "path": None,
+                            "url": None,
+                        }
+                except Exception:
+                    pass
+
+                try:
+                    await _aguardar_download(page, destino)
+                except PlaywrightTimeoutError:
+                    return {
+                        "ok": False,
+                        "info": "Aguardando disponibilidade do arquivo da CAE (timeout).",
+                        "path": None,
+                        "url": None,
+                    }
+                except Exception as exc:
+                    return {
+                        "ok": False,
+                        "info": f"Falha ao baixar a CAE: {exc}",
+                        "path": None,
+                        "url": None,
+                    }
+
+                return {
+                    "ok": True,
+                    "info": "CAE emitida com sucesso.",
+                    "path": str(destino),
+                    "url": url_relativo,
+                }
+            finally:
+                await context.close()
+                await browser.close()
+    except NotImplementedError:
+        return {
+            "ok": False,
+            "info": "Automação indisponível neste sistema (Playwright não suportado).",
+            "path": None,
+            "url": None,
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "info": f"Falha inesperada na automação: {exc}",
+            "path": None,
+            "url": None,
+        }
+
+
+async def emitir_cae_anapolis(cnpj: str, im: str) -> Dict:
+    """Emite e baixa a CAE/FIC no portal de Anápolis usando a IM."""
+    if sys.platform.startswith("win"):
+        selector_loop_cls = getattr(asyncio, "SelectorEventLoop", None)
+        proactor_policy_cls = getattr(asyncio, "WindowsProactorEventLoopPolicy", None)
+        if selector_loop_cls is not None and proactor_policy_cls is not None:
+            try:
+                running_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                running_loop = None
+            else:
+                if isinstance(running_loop, selector_loop_cls):
+                    loop = running_loop
+
+                    def _runner() -> Dict:
+                        previous_policy: Optional[asyncio.AbstractEventLoopPolicy] = None
+                        try:
+                            previous_policy = asyncio.get_event_loop_policy()
+                        except Exception:
+                            pass
+                        asyncio.set_event_loop_policy(proactor_policy_cls())
+                        try:
+                            return asyncio.run(_emitir_cae_anapolis_impl(cnpj, im))
+                        finally:
+                            if previous_policy is not None:
+                                asyncio.set_event_loop_policy(previous_policy)
+
+                    return await loop.run_in_executor(None, _runner)
+
+    return await _emitir_cae_anapolis_impl(cnpj, im)
+

--- a/backend/caes/routes.py
+++ b/backend/caes/routes.py
@@ -1,0 +1,78 @@
+"""Rotas FastAPI para emissão da CAE/FIC."""
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Dict
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from .cae_worker_anapolis import emitir_cae_anapolis, normalize_im, only_digits
+
+router = APIRouter(prefix="/api/cae", tags=["cae"])
+
+
+class EmitirCAEBody(BaseModel):
+    municipio: str = Field(..., description="Município da empresa")
+    cnpj: str
+    im: str
+
+
+def _normalize_municipio(value: str) -> str:
+    if not value:
+        return ""
+    normalized = unicodedata.normalize("NFD", value)
+    normalized = "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
+    normalized = normalized.lower().strip()
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized
+
+
+def _response(content: Dict, status_code: int) -> JSONResponse:
+    return JSONResponse(status_code=status_code, content=content)
+
+
+@router.post("/emitir")
+async def emitir_cae(body: EmitirCAEBody):
+    municipio_norm = _normalize_municipio(body.municipio)
+    if municipio_norm != "anapolis":
+        return _response(
+            {
+                "ok": False,
+                "info": "Emissão disponível apenas para Anápolis.",
+                "path": None,
+                "url": None,
+            },
+            status_code=400,
+        )
+
+    cnpj_digits = only_digits(body.cnpj)
+    if len(cnpj_digits) != 14:
+        return _response(
+            {
+                "ok": False,
+                "info": "CNPJ inválido (14 dígitos).",
+                "path": None,
+                "url": None,
+            },
+            status_code=400,
+        )
+
+    im_normalizada = normalize_im(body.im)
+    if not im_normalizada:
+        return _response(
+            {
+                "ok": False,
+                "info": "Inscrição Municipal inválida.",
+                "path": None,
+                "url": None,
+            },
+            status_code=400,
+        )
+
+    resultado = await emitir_cae_anapolis(cnpj_digits, im_normalizada)
+    status = 200 if resultado.get("ok") else 500
+    return _response(resultado, status_code=status)
+

--- a/frontend/src/features/empresas/EmpresasScreen.jsx
+++ b/frontend/src/features/empresas/EmpresasScreen.jsx
@@ -24,7 +24,13 @@ import {
   isAlertStatus,
   isProcessStatusInactive,
 } from "@/lib/status";
-import { openCartaoCNPJ, openCNDAnapolis, onlyDigits } from "@/lib/quickLinks";
+import {
+  openCartaoCNPJ,
+  openCNDAnapolis,
+  openCAEAnapolis,
+  onlyDigits,
+  normalizeIM,
+} from "@/lib/quickLinks";
 
 const resolveApiBaseUrl = () => {
   const fromEnv = (import.meta.env.VITE_API_BASE_URL || "").replace(/\/$/, "");
@@ -185,6 +191,60 @@ export default function EmpresasScreen({
     [ensureCNDs, isMunicipioAnapolis, toast]
   );
 
+  const handleEmitirCAE = React.useCallback(
+    async (event, empresaInfo) => {
+      const originalEvent = event?.detail?.originalEvent;
+      const isCtrl = Boolean(originalEvent?.ctrlKey || originalEvent?.metaKey);
+      const imRaw =
+        empresaInfo?.inscricaoMunicipal || empresaInfo?.im || "";
+      const im = normalizeIM(imRaw);
+
+      if (!isMunicipioAnapolis(empresaInfo?.municipio)) {
+        toast?.("Disponível apenas para Anápolis.");
+        return;
+      }
+
+      if (!im) {
+        toast?.("Inscrição Municipal não informada.");
+        return;
+      }
+
+      if (isCtrl) {
+        await openCAEAnapolis(imRaw, toast);
+        return;
+      }
+
+      try {
+        toast?.("Iniciando emissão da CAE (Anápolis).");
+        const resp = await fetch(`${API_BASE_URL}/api/cae/emitir`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            municipio: "Anápolis",
+            cnpj: empresaInfo?.cnpj,
+            im,
+          }),
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          const detail =
+            (data?.detail && (data?.detail?.info || data?.detail)) ||
+            data?.info;
+          throw new Error(detail || "Falha ao emitir a CAE.");
+        }
+        if (data?.ok) {
+          toast?.("CAE emitida com sucesso.");
+          await ensureCNDs(empresaInfo?.cnpj, { force: true });
+        } else {
+          toast?.(data?.info || "Não foi possível emitir a CAE.");
+        }
+      } catch (error) {
+        toast?.(error?.message || "Erro inesperado ao emitir a CAE.");
+      }
+    },
+    [ensureCNDs, isMunicipioAnapolis, toast]
+  );
+
   return (
     <>
       <div className="flex items-center justify-between text-sm text-slate-600">
@@ -226,7 +286,12 @@ export default function EmpresasScreen({
           const cnpjDigits = onlyDigits(empresa.cnpj || "");
           const cndEntry = cndCache[cnpjDigits] || {};
           const cndLoading = Boolean(cndEntry.loading);
-          const hasCND = Array.isArray(cndEntry.items) && cndEntry.items.length > 0;
+          const cndItems = Array.isArray(cndEntry.items) ? cndEntry.items : [];
+          const hasCND = cndItems.length > 0;
+          const caeFiles = cndItems.filter((item) =>
+            item?.name?.startsWith("CAE - ")
+          );
+          const lastCAE = caeFiles[0];
           const municipioInformado = Boolean((empresa.municipio || "").trim());
 
           return (
@@ -368,6 +433,19 @@ export default function EmpresasScreen({
                         }}
                       />
 
+                      <DropdownMenuItemFancy
+                        icon={ExternalLink}
+                        title={
+                          <span className="inline-flex items-center">
+                            CAE/FIC <MiniBadge>IM</MiniBadge>
+                          </span>
+                        }
+                        description="Emitir a CAE/FIC de Anápolis."
+                        hint={<Kbd>Ctrl</Kbd>}
+                        disabled={!isMunicipioAnapolis(empresa.municipio)}
+                        onClick={(event) => handleEmitirCAE(event, empresa)}
+                      />
+
                       {/* próximos itens: CND Goiânia, CND Megasoft/Centi etc. */}
                     </DropdownMenuContent>
                   </DropdownMenu>
@@ -415,6 +493,44 @@ export default function EmpresasScreen({
                             window.open(ensureAbsoluteUrl(url), "_blank", "noopener,noreferrer");
                           } else {
                             toast?.("Não foi possível localizar o arquivo da CND.");
+                          }
+                        }}
+                      />
+
+                      <DropdownMenuItemFancy
+                        icon={File}
+                        title="CAE (Anápolis)"
+                        description="Abrir a última CAE emitida."
+                        disabled={cndLoading || !lastCAE}
+                        hint={
+                          cndLoading ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin text-slate-400" />
+                          ) : undefined
+                        }
+                        onClick={async () => {
+                          let lista = cndEntry.items;
+                          if (!Array.isArray(lista) || lista.length === 0) {
+                            lista = await ensureCNDs(empresa.cnpj, { force: true });
+                          }
+
+                          const arquivosCAE = Array.isArray(lista)
+                            ? lista.filter((item) => item?.name?.startsWith("CAE - "))
+                            : [];
+
+                          if (!arquivosCAE.length) {
+                            toast?.("Nenhuma CAE encontrada para esta empresa.");
+                            return;
+                          }
+
+                          const arquivo = arquivosCAE[0];
+                          if (arquivo?.url) {
+                            window.open(
+                              ensureAbsoluteUrl(arquivo.url),
+                              "_blank",
+                              "noopener,noreferrer"
+                            );
+                          } else {
+                            toast?.("Não foi possível localizar o arquivo da CAE.");
                           }
                         }}
                       />

--- a/frontend/src/lib/quickLinks.ts
+++ b/frontend/src/lib/quickLinks.ts
@@ -3,6 +3,11 @@ export function onlyDigits(v: string = ""): string {
   return v.replace(/\D+/g, "");
 }
 
+export function normalizeIM(raw: string = ""): string {
+  const base = (raw || "").split(" - ")[0];
+  return onlyDigits(base);
+}
+
 /**
  * Abre a página do Cartão CNPJ já com ?cnpj=<digits> e copia o número.
  * Não bloqueia a UI; abre em nova aba.
@@ -46,6 +51,28 @@ export async function openCNDAnapolis(
     /* ignore */
   }
   onToast?.("CNPJ copiado — abrindo Portal do Cidadão (Anápolis).");
+  window.open(
+    "https://portaldocidadao.anapolis.go.gov.br/processos/",
+    "_blank",
+    "noopener,noreferrer",
+  );
+}
+
+export async function openCAEAnapolis(
+  imRaw: string,
+  onToast?: (msg: string) => void,
+) {
+  const im = normalizeIM(imRaw);
+  if (!im) {
+    onToast?.("Inscrição Municipal inválida.");
+    return;
+  }
+  try {
+    await navigator.clipboard?.writeText(im);
+  } catch {
+    /* silencioso */
+  }
+  onToast?.("IM copiada — abrindo Portal do Cidadão (Anápolis).");
   window.open(
     "https://portaldocidadao.anapolis.go.gov.br/processos/",
     "_blank",


### PR DESCRIPTION
## Summary
- add a dedicated Playwright worker and FastAPI routes to emit the CAE/FIC for Anápolis
- expose the CAE router in the backend API and reuse the existing certidões storage
- extend quick links and the Empresas screen with CAE actions and downloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f91b69f1e08326aa3514b3e916e381