### PR TITLE
Atualiza URL do Portal do Cidadão de Anápolis

### DIFF
--- a/backend/caes/cae_worker_anapolis.py
+++ b/backend/caes/cae_worker_anapolis.py
@@ -138,7 +138,7 @@ async def _resolver_captcha(page: Page) -> bool:
 
 
 async def _navegar_para_formulario(page: Page) -> None:
-    await page.goto("https://portaldocidadao.anapolis.go.gov.br/processos/", wait_until="domcontentloaded")
+    await page.goto("https://portaldocidadao.anapolis.go.gov.br/", wait_until="domcontentloaded")
     try:
         await page.wait_for_load_state("networkidle", timeout=15000)
     except PlaywrightTimeoutError:
@@ -156,8 +156,15 @@ async def _navegar_para_formulario(page: Page) -> None:
         await opcao_cae.click()
         await page.wait_for_load_state("networkidle", timeout=15000)
     except Exception:
-        # Como fallback, permanecer na página atual
-        pass
+        # Como fallback, tenta recarregar a página inicial do portal
+        try:
+            await page.goto(
+                "https://portaldocidadao.anapolis.go.gov.br/",
+                wait_until="domcontentloaded",
+            )
+            await page.wait_for_load_state("networkidle", timeout=15000)
+        except Exception:
+            pass
 
     await page.wait_for_selector("#106266", state="visible", timeout=15000)
 

--- a/backend/cnds/cnds_worker_anapolis.py
+++ b/backend/cnds/cnds_worker_anapolis.py
@@ -62,7 +62,7 @@ async def _abrir_portal(page) -> None:
         await page.wait_for_load_state("networkidle")
     except Exception:
         # fallback, se o menu mudar temporariamente
-        await page.goto("https://portaldocidadao.anapolis.go.gov.br/processos/", wait_until="domcontentloaded")
+        await page.goto("https://portaldocidadao.anapolis.go.gov.br/", wait_until="domcontentloaded")
         await page.wait_for_load_state("networkidle")
 
 

--- a/frontend/src/lib/quickLinks.ts
+++ b/frontend/src/lib/quickLinks.ts
@@ -52,7 +52,7 @@ export async function openCNDAnapolis(
   }
   onToast?.("CNPJ copiado — abrindo Portal do Cidadão (Anápolis).");
   window.open(
-    "https://portaldocidadao.anapolis.go.gov.br/processos/",
+    "https://portaldocidadao.anapolis.go.gov.br/",
     "_blank",
     "noopener,noreferrer",
   );
@@ -74,7 +74,7 @@ export async function openCAEAnapolis(
   }
   onToast?.("IM copiada — abrindo Portal do Cidadão (Anápolis).");
   window.open(
-    "https://portaldocidadao.anapolis.go.gov.br/processos/",
+    "https://portaldocidadao.anapolis.go.gov.br/",
     "_blank",
     "noopener,noreferrer",
   );


### PR DESCRIPTION
## Resumo
- ajusta o acesso ao Portal do Cidadão de Anápolis para utilizar a URL raiz
- atualiza os fluxos de automação de CAE e CND para navegar pelo endereço correto

## Testes
- não foram adicionados testes automatizados

------
https://chatgpt.com/codex/tasks/task_e_68f92e581f348326ab940d9bb3b01c19