### PR TITLE
Restrict quick actions and certificate entries by availability

### DIFF
--- a/frontend/src/components/ui/dropdown-menu.jsx
+++ b/frontend/src/components/ui/dropdown-menu.jsx
@@ -196,6 +196,9 @@ export const DropdownMenuItemFancy = React.forwardRef(
         "group relative flex cursor-pointer select-none items-center gap-3 rounded-lg px-2 py-2 outline-none",
         "transition-colors duration-150",
         "focus:ring-2 focus:ring-sky-200 focus:bg-sky-50/60 hover:bg-slate-50",
+        "data-[disabled]:pointer-events-none data-[disabled]:opacity-40",
+        "data-[disabled]:hover:bg-transparent data-[disabled]:focus:bg-transparent",
+        "data-[disabled]:text-slate-400 data-[disabled]:ring-0",
         className
       )}
       {...props}

--- a/frontend/src/features/empresas/EmpresasScreen.jsx
+++ b/frontend/src/features/empresas/EmpresasScreen.jsx
@@ -284,6 +284,11 @@ export default function EmpresasScreen({
               : "?";
 
           const cnpjDigits = onlyDigits(empresa.cnpj || "");
+          const hasValidCnpj = cnpjDigits.length === 14;
+          const municipioInformado = Boolean((empresa.municipio || "").trim());
+          const municipioAnapolis = isMunicipioAnapolis(empresa.municipio);
+          const inscricaoMunicipalRaw = empresa.inscricaoMunicipal || empresa.im || "";
+          const hasValidIM = Boolean(normalizeIM(inscricaoMunicipalRaw));
           const cndEntry = cndCache[cnpjDigits] || {};
           const cndLoading = Boolean(cndEntry.loading);
           const cndItems = Array.isArray(cndEntry.items) ? cndEntry.items : [];
@@ -292,7 +297,6 @@ export default function EmpresasScreen({
             item?.name?.startsWith("CAE - ")
           );
           const lastCAE = caeFiles[0];
-          const municipioInformado = Boolean((empresa.municipio || "").trim());
 
           return (
             <Card key={empresa.id} className="shadow-sm overflow-hidden border border-white/60">
@@ -411,6 +415,7 @@ export default function EmpresasScreen({
                         }
                         description="Ir para site da RFB."
                         hint={<Kbd>Ctrl</Kbd>}
+                        disabled={!hasValidCnpj}
                         onClick={() => openCartaoCNPJ(empresa.cnpj, toast)}
                       />
 
@@ -423,7 +428,7 @@ export default function EmpresasScreen({
                         }
                         description="Emitir a partir do portal da Prefeitura."
                         hint={<Kbd>Ctrl</Kbd>}
-                        disabled={!municipioInformado}
+                        disabled={!municipioInformado || !hasValidCnpj}
                         onClick={(event) => {
                           const originalEvent = event?.detail?.originalEvent;
                           const abrirPortal = Boolean(
@@ -442,7 +447,9 @@ export default function EmpresasScreen({
                         }
                         description="Emitir a CAE/FIC de Anápolis."
                         hint={<Kbd>Ctrl</Kbd>}
-                        disabled={!isMunicipioAnapolis(empresa.municipio)}
+                        disabled={
+                          !municipioAnapolis || !hasValidIM || !hasValidCnpj
+                        }
                         onClick={(event) => handleEmitirCAE(event, empresa)}
                       />
 


### PR DESCRIPTION
## Summary
- gate quick action shortcuts by verifying municipality, CNPJ, and inscrição municipal availability per company
- reuse computed availability flags when rendering certificate menu entries
- improve `DropdownMenuItemFancy` disabled styling so unavailable actions are visibly inactive

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa1366138083269a5523d9b4dece17