### PR TITLE
Improve Receita Federal automation stealth

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -48,6 +48,7 @@ from services import (
 )
 from routes_certificados import router as certificados_router
 from cnds.municipal.routes import router as cnds_router
+from cnds.federal.routes import router as cnds_federal_router
 from caes.routes import router as cae_router
 
 # ----------------------------------------------------------------------------
@@ -79,6 +80,7 @@ app.add_middleware(
 
 app.include_router(certificados_router, prefix="/api")
 app.include_router(cnds_router, prefix="/api")
+app.include_router(cnds_federal_router)
 app.include_router(cae_router, prefix="/api")
 
 # Expor diretório de CNDs como estático para consumo pelo frontend

--- a/backend/cnds/federal/__init__.py
+++ b/backend/cnds/federal/__init__.py
@@ -1,0 +1,3 @@
+"""Federal (RFB) CND automation routes."""
+
+__all__: list[str] = []

--- a/backend/cnds/federal/cnds_worker_rfb.py
+++ b/backend/cnds/federal/cnds_worker_rfb.py
@@ -1,0 +1,683 @@
+"""Worker Playwright para emissão da CND Federal (RFB)."""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import random
+import re
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Awaitable, Callable, Optional
+
+from playwright.async_api import (
+    TimeoutError as PlaywrightTimeoutError,
+    Download,
+    Page,
+    Response,
+    async_playwright,
+)
+
+URL_RFB = "https://servicos.receitafederal.gov.br/servico/certidoes/#/home/cnpj"
+NAVIGATION_TIMEOUT_MS = 60_000
+SELECTOR_TIMEOUT_MS = 30_000
+DOWNLOAD_TIMEOUT_MS = 60_000
+MAX_INITIAL_ATTEMPTS = 2
+
+logger = logging.getLogger(__name__)
+
+CND_DIR_BASE = Path(os.getenv("CND_DIR_BASE", "certidoes"))
+CND_DIR_BASE.mkdir(parents=True, exist_ok=True)
+
+CND_HEADLESS = (
+    os.getenv("CND_HEADLESS", "false").strip().lower() in {"1", "true", "yes", "on"}
+)
+CND_CHROME_PATH = os.getenv("CND_CHROME_PATH") or None
+CND_PROXY = os.getenv("CND_PROXY") or os.getenv("CND_PROXY_URL") or None
+
+STEALTH_INIT_SCRIPT = """
+Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+
+const origQuery = window.navigator.permissions && window.navigator.permissions.query;
+if (origQuery) {
+  window.navigator.permissions.query = (parameters) => (
+    parameters.name === 'notifications'
+      ? Promise.resolve({ state: Notification.permission })
+      : origQuery(parameters)
+  );
+}
+
+Object.defineProperty(navigator, 'plugins', { get: () => [1,2,3] });
+Object.defineProperty(navigator, 'languages', { get: () => ['pt-BR','pt'] });
+Object.defineProperty(navigator, 'platform', { get: () => 'Win32' });
+Object.defineProperty(navigator, 'hardwareConcurrency', { get: () => 8 });
+Object.defineProperty(navigator, 'deviceMemory', { get: () => 8 });
+
+(() => { // WebGL vendor/renderer
+  const getParameter = WebGLRenderingContext.prototype.getParameter;
+  WebGLRenderingContext.prototype.getParameter = function(param) {
+    if (param === 37445) return 'Intel Inc.';            // UNMASKED_VENDOR_WEBGL
+    if (param === 37446) return 'Intel(R) UHD Graphics'; // UNMASKED_RENDERER_WEBGL
+    return getParameter.call(this, param);
+  };
+})();
+
+Object.defineProperty(window, 'chrome', { get: () => ({ runtime: {} }) });
+"""
+
+
+def _build_proxy_config() -> Optional[dict[str, str]]:
+    if not CND_PROXY:
+        return None
+    return {"server": CND_PROXY}
+
+
+def _human_delay(base_ms: float = 300.0, jitter_ms: float = 400.0) -> float:
+    return base_ms + random.random() * jitter_ms
+
+
+def _extract_chrome_major(user_agent: str) -> str:
+    match = re.search(r"Chrome/(\d+)", user_agent or "")
+    if match:
+        return match.group(1)
+    return "120"
+
+
+def _build_sec_ch_ua(major: str) -> str:
+    major = major or "120"
+    if not major.isdigit():
+        major = "120"
+    return f'"Chromium";v="{major}", "Google Chrome";v="{major}", "Not(A:Brand";v="24"'
+
+
+def _only_digits(value: str) -> str:
+    return re.sub(r"\D+", "", value or "")
+
+
+def _build_filename() -> str:
+    today = datetime.now().strftime("%d.%m.%Y")
+    return f"CND Federal - {today}.pdf"
+
+
+def _parse_date(value: Optional[str]) -> Optional[date]:
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    for fmt in ("%d/%m/%Y", "%d-%m-%Y", "%d.%m.%Y"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+async def _fill_cnpj_input(page: Page, cnpj_digits: str) -> None:
+    # monta máscara 00.000.000/0001-00
+    cnpj_masked = f"{cnpj_digits[:2]}.{cnpj_digits[2:5]}.{cnpj_digits[5:8]}/{cnpj_digits[8:12]}-{cnpj_digits[12:]}"
+    selectors = (
+        'input[name="niContribuinte"]',
+        'input[formcontrolname="niContribuinte"]',
+        'input[id*="niContribuinte" i]',
+    )
+    target = None
+    for s in selectors:
+        loc = page.locator(s).first
+        if await loc.count():
+            try:
+                await loc.wait_for(state="visible", timeout=SELECTOR_TIMEOUT_MS)
+                target = loc
+                break
+            except Exception:
+                continue
+    if not target:
+        raise RuntimeError("Campo de CNPJ não encontrado no portal da RFB.")
+
+    with contextlib.suppress(Exception):
+        await target.scroll_into_view_if_needed(timeout=3000)
+    await target.click()
+    # Usa type com delay para acionar máscara e validadores
+    try:
+        await target.fill("")
+    except Exception:
+        pass
+    await target.type(cnpj_masked, delay=70)  # simula digitação humana
+    # força blur para o Angular validar
+    await page.keyboard.press("Tab")
+    # espera o formulário ficar válido
+    await page.wait_for_function(
+        """() => {
+            const el = document.querySelector('input[name="niContribuinte"]') 
+                      || document.querySelector('input[formcontrolname="niContribuinte"]');
+            if (!el) return false;
+            const form = el.closest('form');
+            return form && form.classList.contains('ng-valid');
+        }""",
+        timeout=SELECTOR_TIMEOUT_MS,
+    )
+    await page.wait_for_timeout(300)
+
+
+async def _click_consultar(page: Page) -> None:
+    # primeiro botão (secondary)
+    primeiro = page.locator(
+        'button.br-button.secondary.btn-acao.btn-acao-3:has-text("Consultar Certidão"):not([disabled])'
+    ).first
+    if await primeiro.count():
+        with contextlib.suppress(Exception):
+            await primeiro.scroll_into_view_if_needed(timeout=3000)
+        await primeiro.wait_for(state="visible", timeout=SELECTOR_TIMEOUT_MS)
+        await page.wait_for_timeout(_human_delay())
+        await primeiro.click(timeout=SELECTOR_TIMEOUT_MS)
+        await page.wait_for_timeout(_human_delay())
+
+    # segundo (submit)
+    segundo = page.locator(
+        'button.br-button.primary.btn-acao[type="submit"]:has-text("Consultar Certidão"):not([disabled])'
+    ).first
+    with contextlib.suppress(Exception):
+        await segundo.scroll_into_view_if_needed(timeout=3000)
+    await segundo.wait_for(state="visible", timeout=SELECTOR_TIMEOUT_MS)
+    await page.wait_for_timeout(_human_delay())
+    await segundo.click(timeout=SELECTOR_TIMEOUT_MS)
+
+    # espera angular/requests estabilizarem
+    with contextlib.suppress(Exception):
+        await page.wait_for_load_state("networkidle", timeout=NAVIGATION_TIMEOUT_MS)
+    await page.wait_for_timeout(_human_delay(800.0, 500.0))
+
+
+async def _prepare_initial_consulta(page: Page, cnpj_digits: str) -> None:
+    last_error: Optional[Exception] = None
+    for attempt in range(1, MAX_INITIAL_ATTEMPTS + 1):
+        try:
+            logger.info(
+                "[CND Federal] Acessando portal da RFB (tentativa %s/%s)",
+                attempt,
+                MAX_INITIAL_ATTEMPTS,
+            )
+            await page.goto(URL_RFB, wait_until="load", timeout=NAVIGATION_TIMEOUT_MS)
+            await _fill_cnpj_input(page, cnpj_digits)
+            await _click_consultar(page)
+            return
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            logger.warning(
+                "[CND Federal] Falha na tentativa %s de consulta inicial: %s",
+                attempt,
+                exc,
+            )
+            with contextlib.suppress(Exception):
+                await page.wait_for_timeout(1500)
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("Falha desconhecida ao iniciar a consulta da CND Federal.")
+
+
+async def _extract_validade(page: Page) -> tuple[Optional[str], Optional[date]]:
+    script = """
+        () => {
+            const headers = Array.from(document.querySelectorAll('datatable-header-cell'));
+            if (!headers.length) {
+                return null;
+            }
+            let index = -1;
+            headers.forEach((cell, idx) => {
+                const text = (cell.textContent || '').toLowerCase();
+                if (text.includes('data de validade')) {
+                    index = idx;
+                }
+            });
+            if (index < 0) {
+                return null;
+            }
+            const row = document.querySelector('datatable-body-row');
+            if (!row) {
+                return null;
+            }
+            const cells = row.querySelectorAll('datatable-body-cell');
+            const target = cells[index];
+            if (!target) {
+                return null;
+            }
+            const span = target.querySelector('.datatable-body-cell-label span[title]');
+            if (span) {
+                return span.getAttribute('title') || span.textContent || '';
+            }
+            const label = target.querySelector('.datatable-body-cell-label');
+            if (label) {
+                return label.textContent || '';
+            }
+            return target.textContent || '';
+        }
+    """
+    try:
+        raw_value = await page.evaluate(script)
+    except Exception:
+        return None, None
+
+    if not raw_value:
+        return None, None
+
+    text = str(raw_value).strip()
+    return text or None, _parse_date(text)
+
+
+async def _capture_pdf(
+    page: Page,
+    trigger: Callable[[], Awaitable[object]],
+    *,
+    out_path: Path,
+    timeout_ms: int,
+    source_description: str,
+) -> bool:
+    loop = asyncio.get_running_loop()
+    response_future: asyncio.Future[Response] = loop.create_future()
+
+    def handle_response(response: Response) -> None:
+        if response_future.done():
+            return
+        content_type = (response.headers.get("content-type") or "").lower()
+        if "application/pdf" in content_type:
+            response_future.set_result(response)
+
+    page.on("response", handle_response)
+    download_task = asyncio.create_task(
+        page.wait_for_event("download", timeout=timeout_ms)
+    )
+
+    try:
+        await trigger()
+    except Exception:
+        download_task.cancel()
+        with contextlib.suppress(Exception):
+            page.off("response", handle_response)
+        raise
+
+    download: Optional[Download] = None
+    pdf_response: Optional[Response] = None
+
+    try:
+        done, pending = await asyncio.wait(
+            {download_task, response_future},
+            timeout=max(timeout_ms / 1000, 1),
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        if download_task in done:
+            try:
+                download = await download_task
+            except PlaywrightTimeoutError:
+                download = None
+            except Exception:
+                download = None
+        if response_future in done and response_future.done():
+            try:
+                pdf_response = response_future.result()
+            except Exception:
+                pdf_response = None
+
+        for pending_task in pending:
+            pending_task.cancel()
+            with contextlib.suppress(Exception):
+                await pending_task
+    finally:
+        if not response_future.done():
+            response_future.cancel()
+        with contextlib.suppress(Exception):
+            page.off("response", handle_response)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if out_path.exists():
+        with contextlib.suppress(Exception):
+            out_path.unlink()
+
+    if download is not None:
+        try:
+            await download.save_as(str(out_path))
+            logger.info(
+                "[CND Federal] PDF salvo (%s) via evento de download (%s).",
+                out_path,
+                download.suggested_filename,
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[CND Federal] Falha ao salvar download (%s): %s",
+                source_description,
+                exc,
+            )
+
+    if pdf_response is not None:
+        try:
+            content = await pdf_response.body()
+            out_path.write_bytes(content)
+            logger.info(
+                "[CND Federal] PDF salvo (%s) a partir da resposta HTTP.",
+                out_path,
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[CND Federal] Falha ao salvar PDF da resposta (%s): %s",
+                source_description,
+                exc,
+            )
+
+    logger.warning(
+        "[CND Federal] Nenhum PDF foi capturado após acionar %s.",
+        source_description,
+    )
+    return False
+
+
+async def _download_existing_certificate(page: Page, out_path: Path) -> bool:
+    row = page.locator("datatable-body-row").first
+    if not await row.count():
+        logger.info("[CND Federal] Nenhuma linha de certidão encontrada na tabela.")
+        return False
+
+    button = row.locator(".row-actions button.br-button.small.circle").first
+    if not await button.count():
+        logger.warning("[CND Federal] Botão de download da certidão não localizado.")
+        return False
+
+    with contextlib.suppress(Exception):
+        await button.scroll_into_view_if_needed(timeout=3000)
+
+    logger.info("[CND Federal] Baixando certidão vigente disponível na tabela.")
+    return await _capture_pdf(
+        page,
+        lambda: button.click(timeout=SELECTOR_TIMEOUT_MS),
+        out_path=out_path,
+        timeout_ms=DOWNLOAD_TIMEOUT_MS,
+        source_description="download existente",
+    )
+
+
+async def _click_nova_consulta(page: Page) -> None:
+    botao = page.locator(
+        'button.br-button.secondary.btn-acao.btn-acao-3:has-text("Nova Consulta")'
+    ).first
+    if await botao.count():
+        logger.info("[CND Federal] Acionando 'Nova Consulta'.")
+        try:
+            await botao.click(timeout=SELECTOR_TIMEOUT_MS)
+            await page.wait_for_timeout(600)
+        except PlaywrightTimeoutError:
+            logger.warning("[CND Federal] Timeout ao clicar em 'Nova Consulta'.")
+
+
+async def _acionar_nova_certidao(page: Page, out_path: Path) -> bool:
+    selectors = [
+        'div.br-modal button.br-button.primary.btn-acao:has(i.fa.fa-plus):has-text("Nova Certidão")',
+        'div.br-modal button.br-button.primary.btn-acao:has-text("Nova Certidão")',
+        'button.br-button.primary.btn-acao:has(i.fa.fa-plus):has-text("Nova Certidão")',
+        'button.br-button.primary.btn-acao:has-text("Nova Certidão")',
+    ]
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + DOWNLOAD_TIMEOUT_MS / 1000
+
+    while loop.time() < deadline:
+        for selector in selectors:
+            locator = page.locator(selector).first
+            if not await locator.count():
+                continue
+            try:
+                await locator.wait_for(state="visible", timeout=2000)
+            except PlaywrightTimeoutError:
+                continue
+            with contextlib.suppress(Exception):
+                await locator.scroll_into_view_if_needed(timeout=2000)
+            logger.info("[CND Federal] Clicando em 'Nova Certidão' (%s).", selector)
+            success = await _capture_pdf(
+                page,
+                lambda: locator.click(timeout=SELECTOR_TIMEOUT_MS),
+                out_path=out_path,
+                timeout_ms=DOWNLOAD_TIMEOUT_MS,
+                source_description="nova certidão",
+            )
+            if success:
+                return True
+        await page.wait_for_timeout(500)
+
+    return False
+
+
+async def _check_known_errors(page: Page) -> Optional[str]:
+    try:
+        messages = await page.locator("div.msg-resultado > p").all_text_contents()
+    except Exception:
+        messages = []
+    for raw in messages:
+        text = (raw or "").strip()
+        if text and "insuficientes" in text.lower():
+            return text
+
+    try:
+        alert = page.locator("#alert-content .description").first
+        if await alert.count():
+            text = (await alert.inner_text()).strip()
+            if text:
+                return text
+    except Exception:
+        pass
+
+    return None
+
+
+async def _emitir_nova_certidao(page: Page, cnpj_digits: str, out_path: Path) -> tuple[bool, str]:
+    await _click_nova_consulta(page)
+    await _fill_cnpj_input(page, cnpj_digits)
+    await page.wait_for_timeout(400)
+
+    # 1ª tentativa
+    if await _acionar_nova_certidao(page, out_path):
+        return True, "CND Federal emitida com sucesso."
+
+    mensagem = await _check_known_errors(page)
+    if mensagem and (
+        "106 -" in mensagem
+        or "Não foi possível concluir" in mensagem
+        or " 023 " in mensagem
+    ):
+        logger.warning("[CND Federal] Portal retornou mensagem crítica: %s", mensagem)
+        # Soft refresh + retry único
+        await page.goto(URL_RFB, wait_until="load", timeout=NAVIGATION_TIMEOUT_MS)
+        await _fill_cnpj_input(page, cnpj_digits)
+        await page.wait_for_timeout(400)
+        if await _acionar_nova_certidao(page, out_path):
+            return True, "CND Federal emitida com sucesso (2ª tentativa)."
+        mensagem2 = await _check_known_errors(page)
+        if mensagem2:
+            logger.warning("[CND Federal] Portal retornou mensagem após retry: %s", mensagem2)
+        return False, (mensagem2 or mensagem)
+
+    if mensagem:
+        logger.warning("[CND Federal] Portal retornou mensagem: %s", mensagem)
+        return False, mensagem
+
+    return False, "Não foi possível emitir a CND Federal no portal da RFB."
+
+
+async def _emitir_cnd_federal_impl(cnpj_digits: str) -> dict:
+    logger.info("[CND Federal] Iniciando emissão para o CNPJ %s", cnpj_digits)
+    filename = _build_filename()
+    out_dir = CND_DIR_BASE / cnpj_digits
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / filename
+    url = f"/cnds/{cnpj_digits}/{filename}"
+
+    try:
+        async with async_playwright() as pw:
+            user_data_dir = Path(".pw-user-data") / "rfb"
+            user_data_dir.parent.mkdir(parents=True, exist_ok=True)
+
+            proxy_cfg = _build_proxy_config()
+            if proxy_cfg:
+                logger.info("[CND Federal] Utilizando proxy configurado para a sessão Playwright.")
+
+            launch_kwargs: dict[str, object] = {
+                "user_data_dir": str(user_data_dir.absolute()),
+                "headless": CND_HEADLESS,
+                "accept_downloads": True,
+                "viewport": {"width": 1366, "height": 900},
+                "locale": "pt-BR",
+                "timezone_id": "America/Sao_Paulo",
+                "args": [
+                    "--disable-blink-features=AutomationControlled",
+                    "--lang=pt-BR,pt",
+                    "--window-position=20,20",
+                    "--start-maximized",
+                ],
+            }
+            if proxy_cfg:
+                launch_kwargs["proxy"] = proxy_cfg
+            if CND_CHROME_PATH:
+                launch_kwargs["executable_path"] = CND_CHROME_PATH
+            else:
+                launch_kwargs["channel"] = "chrome"
+
+            ctx = await pw.chromium.launch_persistent_context(**launch_kwargs)
+
+            try:
+                ctx.set_default_timeout(SELECTOR_TIMEOUT_MS)
+                ctx.set_default_navigation_timeout(NAVIGATION_TIMEOUT_MS)
+                await ctx.add_init_script(STEALTH_INIT_SCRIPT)
+
+                pages = ctx.pages
+                page = pages[0] if pages else await ctx.new_page()
+                pages = ctx.pages
+
+                user_agent = await page.evaluate("navigator.userAgent")
+                major = _extract_chrome_major(user_agent)
+                await ctx.set_extra_http_headers(
+                    {
+                        "Sec-CH-UA": _build_sec_ch_ua(major),
+                        "Sec-CH-UA-Platform": '"Windows"',
+                        "Sec-CH-UA-Mobile": "?0",
+                    }
+                )
+
+                if len(pages) > 1:
+                    for extra in pages:
+                        if extra is page:
+                            continue
+                        with contextlib.suppress(Exception):
+                            await extra.close()
+
+                if not page.is_closed() and page.url not in ("about:blank", "chrome://newtab/"):
+                    with contextlib.suppress(Exception):
+                        await page.close()
+                    page = await ctx.new_page()
+
+                if page.is_closed():
+                    page = await ctx.new_page()
+
+                page.set_default_timeout(SELECTOR_TIMEOUT_MS)
+                page.set_default_navigation_timeout(NAVIGATION_TIMEOUT_MS)
+                with contextlib.suppress(Exception):
+                    await page.bring_to_front()
+
+                await _prepare_initial_consulta(page, cnpj_digits)
+                with contextlib.suppress(Exception):
+                    await page.wait_for_timeout(1000)
+
+                validade_text, validade_date = await _extract_validade(page)
+                limite = datetime.now().date() + timedelta(days=30)
+                if validade_date:
+                    logger.info(
+                        "[CND Federal] Certidão vigente com validade em %s (limite %s).",
+                        validade_date,
+                        limite,
+                    )
+                else:
+                    logger.info("[CND Federal] Nenhuma certidão vigente encontrada.")
+
+                if validade_date and validade_date > limite:
+                    if await _download_existing_certificate(page, out_path):
+                        info = "CND Federal vigente baixada com sucesso."
+                        return {
+                            "ok": True,
+                            "info": info,
+                            "path": str(out_path),
+                            "url": url,
+                        }
+                    logger.warning(
+                        "[CND Federal] Falha ao baixar certidão vigente; tentando nova emissão."
+                    )
+                else:
+                    logger.info(
+                        "[CND Federal] Será solicitada uma nova certidão (validade atual: %s)",
+                        validade_text or "não informada",
+                    )
+
+                sucesso, mensagem = await _emitir_nova_certidao(page, cnpj_digits, out_path)
+                if sucesso:
+                    return {
+                        "ok": True,
+                        "info": mensagem,
+                        "path": str(out_path),
+                        "url": url,
+                    }
+                return {"ok": False, "info": mensagem, "path": None, "url": None}
+            finally:
+                with contextlib.suppress(Exception):
+                    await ctx.close()
+    except PlaywrightTimeoutError:
+        logger.exception("[CND Federal] Timeout durante a emissão da certidão.")
+        return {
+            "ok": False,
+            "info": "Timeout ao emitir a CND Federal.",
+            "path": None,
+            "url": None,
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("[CND Federal] Erro inesperado: %s", exc)
+        return {
+            "ok": False,
+            "info": f"Erro ao emitir a CND Federal: {exc}",
+            "path": None,
+            "url": None,
+        }
+
+
+def _run_in_worker_thread(cnpj_digits: str) -> dict:
+    if sys.platform.startswith("win") and hasattr(asyncio, "WindowsProactorEventLoopPolicy"):
+        policy = asyncio.WindowsProactorEventLoopPolicy()
+    else:
+        policy = asyncio.DefaultEventLoopPolicy()
+
+    loop = policy.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        return loop.run_until_complete(_emitir_cnd_federal_impl(cnpj_digits))
+    finally:
+        with contextlib.suppress(Exception):
+            loop.run_until_complete(loop.shutdown_asyncgens())
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+async def emitir_cnd_federal(cnpj: str) -> dict:
+    """Executa a emissão da CND Federal em thread com Proactor quando necessário."""
+
+    cnpj_digits = _only_digits(cnpj)
+    if len(cnpj_digits) != 14:
+        return {
+            "ok": False,
+            "info": "CNPJ inválido (14 dígitos).",
+            "path": None,
+            "url": None,
+        }
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # Sem loop ativo → executa diretamente usando a infraestrutura síncrona
+        return _run_in_worker_thread(cnpj_digits)
+
+    return await asyncio.to_thread(_run_in_worker_thread, cnpj_digits)

--- a/backend/cnds/federal/routes.py
+++ b/backend/cnds/federal/routes.py
@@ -1,0 +1,60 @@
+"""Rotas para emissão de CND Federal (Receita Federal do Brasil)."""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from .cnds_worker_rfb import emitir_cnd_federal
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/cnds/federal", tags=["cnds"])
+
+
+class EmitirCNDRequest(BaseModel):
+    """Requisição para emissão da CND Federal."""
+
+    cnpj: str = Field(..., description="CNPJ da empresa")
+
+
+def _only_digits(value: str) -> str:
+    return re.sub(r"\D+", "", value or "")
+
+
+@router.post("/emitir")
+async def emitir_cnd_federal_api(req: EmitirCNDRequest) -> Dict[str, Any]:
+    """Endpoint para emitir a CND Federal e retornar o resultado padronizado."""
+
+    cnpj_digits = _only_digits(req.cnpj)
+    if len(cnpj_digits) != 14:
+        raise HTTPException(400, "CNPJ inválido (14 dígitos).")
+
+    logger.info("[CND Federal] Solicitação recebida para o CNPJ %s", cnpj_digits)
+
+    try:
+        result = await emitir_cnd_federal(cnpj_digits)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("[CND Federal] Erro inesperado durante a emissão: %s", exc)
+        return {
+            "ok": False,
+            "info": "Erro inesperado ao emitir a CND Federal.",
+            "path": None,
+            "url": None,
+        }
+
+    if not isinstance(result, dict):
+        logger.warning(
+            "[CND Federal] Retorno inesperado do worker: %r", result
+        )
+        return {
+            "ok": False,
+            "info": "Resposta inválida ao emitir a CND Federal.",
+            "path": None,
+            "url": None,
+        }
+
+    return result

--- a/frontend/src/features/empresas/EmpresasScreen.jsx
+++ b/frontend/src/features/empresas/EmpresasScreen.jsx
@@ -26,6 +26,7 @@ import {
 } from "@/lib/status";
 import {
   openCartaoCNPJ,
+  openCNDFederal,
   openCNDAnapolis,
   openCAEAnapolis,
   onlyDigits,
@@ -191,6 +192,55 @@ export default function EmpresasScreen({
     [ensureCNDs, isMunicipioAnapolis, toast]
   );
 
+  const handleEmitirCNDFederal = React.useCallback(
+    async (event, empresaInfo) => {
+      const originalEvent = event?.detail?.originalEvent;
+      const abrirPortal = Boolean(originalEvent?.ctrlKey || originalEvent?.metaKey);
+      const cnpjRaw = empresaInfo?.cnpj || "";
+      const digits = onlyDigits(cnpjRaw);
+
+      if (abrirPortal) {
+        await openCNDFederal(cnpjRaw, toast);
+        return;
+      }
+
+      if (!digits || digits.length !== 14) {
+        toast?.("CNPJ inválido para emissão da CND Federal.");
+        return;
+      }
+
+      try {
+        toast?.("Iniciando emissão da CND Federal (RFB).");
+        const resp = await fetch(`${API_BASE_URL}/api/cnds/federal/emitir`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cnpj: cnpjRaw }),
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          throw new Error(data?.detail || data?.info || "Falha ao emitir a CND Federal.");
+        }
+        if (data?.ok) {
+          toast?.("CND Federal emitida com sucesso.");
+          if (data?.url) {
+            console.info(
+              "CND Federal disponível em:",
+              ensureAbsoluteUrl(data.url)
+            );
+          } else if (data?.path) {
+            console.info("CND Federal salva em:", data.path);
+          }
+          await ensureCNDs(cnpjRaw, { force: true });
+        } else {
+          toast?.(data?.info || "Não foi possível emitir a CND Federal.");
+        }
+      } catch (error) {
+        toast?.(error?.message || "Erro inesperado ao emitir a CND Federal.");
+      }
+    },
+    [ensureCNDs, toast]
+  );
+
   const handleEmitirCAE = React.useCallback(
     async (event, empresaInfo) => {
       const originalEvent = event?.detail?.originalEvent;
@@ -293,6 +343,10 @@ export default function EmpresasScreen({
           const cndLoading = Boolean(cndEntry.loading);
           const cndItems = Array.isArray(cndEntry.items) ? cndEntry.items : [];
           const hasCND = cndItems.length > 0;
+          const federalFiles = cndItems.filter((item) =>
+            item?.name?.startsWith("CND Federal - ")
+          );
+          const lastCNDFederal = federalFiles[0];
           const caeFiles = cndItems.filter((item) =>
             item?.name?.startsWith("CAE - ")
           );
@@ -442,6 +496,19 @@ export default function EmpresasScreen({
                         icon={ExternalLink}
                         title={
                           <span className="inline-flex items-center">
+                            CND Federal <MiniBadge>RFB</MiniBadge>
+                          </span>
+                        }
+                        description="Emitir pelo portal da Receita Federal."
+                        hint={<Kbd>Ctrl</Kbd>}
+                        disabled={!hasValidCnpj}
+                        onClick={(event) => handleEmitirCNDFederal(event, empresa)}
+                      />
+
+                      <DropdownMenuItemFancy
+                        icon={ExternalLink}
+                        title={
+                          <span className="inline-flex items-center">
                             CAE/FIC <MiniBadge>IM</MiniBadge>
                           </span>
                         }
@@ -500,6 +567,44 @@ export default function EmpresasScreen({
                             window.open(ensureAbsoluteUrl(url), "_blank", "noopener,noreferrer");
                           } else {
                             toast?.("Não foi possível localizar o arquivo da CND.");
+                          }
+                        }}
+                      />
+
+                      <DropdownMenuItemFancy
+                        icon={File}
+                        title="CND Federal (RFB)"
+                        description="Abrir a última CND Federal baixada."
+                        disabled={cndLoading || !lastCNDFederal}
+                        hint={
+                          cndLoading ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin text-slate-400" />
+                          ) : undefined
+                        }
+                        onClick={async () => {
+                          let lista = cndEntry.items;
+                          if (!Array.isArray(lista) || lista.length === 0) {
+                            lista = await ensureCNDs(empresa.cnpj, { force: true });
+                          }
+
+                          const arquivosFederal = Array.isArray(lista)
+                            ? lista.filter((item) => item?.name?.startsWith("CND Federal - "))
+                            : [];
+
+                          if (!arquivosFederal.length) {
+                            toast?.("Nenhuma CND Federal encontrada para esta empresa.");
+                            return;
+                          }
+
+                          const arquivo = arquivosFederal[0];
+                          if (arquivo?.url) {
+                            window.open(
+                              ensureAbsoluteUrl(arquivo.url),
+                              "_blank",
+                              "noopener,noreferrer"
+                            );
+                          } else {
+                            toast?.("Não foi possível localizar o arquivo da CND Federal.");
                           }
                         }}
                       />

--- a/frontend/src/lib/quickLinks.ts
+++ b/frontend/src/lib/quickLinks.ts
@@ -36,6 +36,28 @@ export async function openCartaoCNPJ(
   window.open(url.toString(), "_blank", "noopener,noreferrer");
 }
 
+export async function openCNDFederal(
+  cnpjRaw: string,
+  onToast?: (msg: string) => void,
+) {
+  const cnpj = onlyDigits(cnpjRaw || "");
+  if (!cnpj || cnpj.length !== 14) {
+    onToast?.("CNPJ inválido para abrir a CND Federal.");
+    return;
+  }
+  try {
+    await navigator.clipboard?.writeText(cnpj);
+  } catch {
+    /* silencioso */
+  }
+  onToast?.("CNPJ copiado — abrindo CND Federal (RFB).");
+  window.open(
+    "https://servicos.receitafederal.gov.br/servico/certidoes/#/home/cnpj",
+    "_blank",
+    "noopener,noreferrer",
+  );
+}
+
 export async function openCNDAnapolis(
   cnpjRaw: string,
   onToast?: (msg: string) => void,


### PR DESCRIPTION
## Summary
- launch the Receita Federal worker with a persistent Chrome profile, stealth init scripts, and UA-CH headers to better match a real browser fingerprint
- add optional proxy support, humanized delays, and scrolling tweaks before consulting to reduce RFB anti-bot triggers

## Testing
- python -m compileall backend/cnds/federal


------
https://chatgpt.com/codex/tasks/task_e_68fa322127e083269b920f7bee30fef4