### PR TITLE
feat: add professional header and menu

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,20 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@/components/ui/tabs";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
 import EmpresasScreen from "@/features/empresas/EmpresasScreen";
 import LicencasScreen from "@/features/licencas/LicencasScreen";
 import TaxasScreen from "@/features/taxas/TaxasScreen";
@@ -23,18 +8,7 @@ import UteisScreen from "@/features/uteis/UteisScreen";
 import PainelScreen from "@/features/painel/PainelScreen";
 import CertificadosScreen from "@/features/certificados/CertificadosScreen";
 import ToastProvider, { useToast } from "@/providers/ToastProvider.jsx";
-import {
-  Building2,
-  CheckCircle2,
-  Clock,
-  FileText,
-  MessageSquare,
-  Search,
-  ShieldCheck,
-  Sparkles,
-  TrendingUp,
-  X,
-} from "lucide-react";
+import { Sparkles, X } from "lucide-react";
 import { normalizeIdentifier, normalizeText, normalizeTextLower } from "@/lib/text";
 import {
   PROCESS_DIVERSOS_LABEL,
@@ -55,6 +29,7 @@ import {
   isCertificadoSituacaoAlert,
   resolveEmpresaCertificadoSituacao,
 } from "@/lib/certificados";
+import HeaderMenuPro from "@/components/HeaderMenuPro";
 
 const toFiniteNumber = (value) => {
   if (typeof value === "number" && Number.isFinite(value)) {
@@ -121,7 +96,7 @@ function AppContent() {
   const [tab, setTab] = useState("painel");
   const [query, setQuery] = useState("");
   const [municipio, setMunicipio] = useState();
-  const [soAlertas, setSoAlertas] = useState(false);
+  const [somenteAlertas, setSomenteAlertas] = useState(false);
   const [modoFoco, setModoFoco] = useState(true);
   const normalizedQueryValue = useMemo(() => normalizeTextLower(query).trim(), [query]);
   const municipioKey = useMemo(() => normalizeTextLower(municipio).trim(), [municipio]);
@@ -208,6 +183,18 @@ function AppContent() {
       return acc;
     }, []);
   }, [municipios]);
+
+  const municipiosOptions = useMemo(
+    () => Array.from(new Set(["Todos", ...sanitizedMunicipios])),
+    [sanitizedMunicipios],
+  );
+
+  if (import.meta.env.DEV) {
+    console.assert(
+      Array.isArray(municipiosOptions) && municipiosOptions.includes("Todos"),
+      "[App] municipios deve conter 'Todos'",
+    );
+  }
 
   useEffect(() => {
     let mounted = true;
@@ -438,11 +425,11 @@ function AppContent() {
           empresa.im,
         ]);
         const matchesMunicipio = matchesMunicipioFilter(empresa);
-        const matchesAlert = !soAlertas || companyHasAlert(empresa);
+        const matchesAlert = !somenteAlertas || companyHasAlert(empresa);
         return matchesQueryEmpresa && matchesMunicipio && matchesAlert;
       });
     },
-    [companyHasAlert, matchesMunicipioFilter, matchesQuery, soAlertas],
+    [companyHasAlert, matchesMunicipioFilter, matchesQuery, somenteAlertas],
   );
 
   const filteredEmpresas = useMemo(
@@ -452,8 +439,14 @@ function AppContent() {
 
 
   const handleMunicipioChange = (value) => {
-    setMunicipio(value === MUNICIPIO_ALL ? undefined : value);
+    if (value === "Todos" || value === MUNICIPIO_ALL) {
+      setMunicipio(undefined);
+      return;
+    }
+    setMunicipio(value);
   };
+
+  const municipioSelectValue = municipio ?? "Todos";
 
   const handleCopy = useCallback(
     async (content, successMessage) => {
@@ -484,190 +477,127 @@ function AppContent() {
     [enqueueToast],
   );
 
-  const selectMunicipioValue = municipio ?? MUNICIPIO_ALL;
-
-  if (loading) {
-    return <div className="p-6 text-center">Carregando dados...</div>;
-  }
-
   return (
-    <div className={`p-4 md:p-6 max-w-[1400px] mx-auto rounded-2xl ${TAB_BACKGROUNDS[tab]}`}>
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight bg-gradient-to-r from-indigo-600 via-sky-500 to-emerald-500 bg-clip-text text-transparent drop-shadow-sm">
-          eControle
-        </h1>
-        <span className="hidden md:block text-xs md:text-sm text-slate-500">
-          Gestão de Empresas • Licenças • Processos
-        </span>
-      </div>
+    <>
+      <HeaderMenuPro
+        tab={tab}
+        onTabChange={setTab}
+        query={query}
+        onQueryChange={setQuery}
+        municipio={municipioSelectValue}
+        municipios={municipiosOptions}
+        onMunicipioChange={handleMunicipioChange}
+        somenteAlertas={somenteAlertas}
+        onSomenteAlertasChange={setSomenteAlertas}
+        modoFoco={modoFoco}
+        onModoFocoChange={setModoFoco}
+      />
+      <div className={`p-4 md:p-6 max-w-[1400px] mx-auto rounded-2xl ${TAB_BACKGROUNDS[tab]}`}>
+        {loading ? (
+          <div className="p-6 text-center">Carregando dados...</div>
+        ) : (
+          <Tabs value={tab} onValueChange={setTab}>
+            <TabsContent value="painel">
+              <PainelScreen
+                query={query}
+                municipio={municipio}
+                soAlertas={somenteAlertas}
+                kpis={kpis}
+                empresas={empresasComCertificados}
+                licencas={licencas}
+                taxas={taxas}
+                filteredLicencas={filteredLicencas}
+                processosNormalizados={processosNormalizados}
+                filterEmpresas={filterEmpresas}
+                companyHasAlert={companyHasAlert}
+                licencasByEmpresa={licencasByEmpresa}
+                extractEmpresaId={extractEmpresaId}
+              />
+            </TabsContent>
 
-      <div className="flex flex-col md:flex-row md:items-end gap-3 mb-4">
-        <div className="flex-1">
-          <Label className="text-xs uppercase">Pesquisa</Label>
-          <div className="relative">
-            <Search className="absolute left-2 top-2.5 h-4 w-4 text-slate-400" />
-            <Input
-              placeholder="Empresa, CNPJ, palavra-chave…"
-              className="pl-8"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-            />
+            <TabsContent value="empresas" className="mt-4 space-y-3">
+              <EmpresasScreen
+                filteredEmpresas={filteredEmpresas}
+                empresas={empresasComCertificados}
+                soAlertas={somenteAlertas}
+                extractEmpresaId={extractEmpresaId}
+                licencasByEmpresa={licencasByEmpresa}
+                taxasByEmpresa={taxasByEmpresa}
+                processosByEmpresa={processosByEmpresa}
+                handleCopy={handleCopy}
+                enqueueToast={enqueueToast}
+              />
+            </TabsContent>
+
+            <TabsContent value="licencas" className="mt-4">
+              <LicencasScreen licencas={licencas} filteredLicencas={filteredLicencas} modoFoco={modoFoco} />
+            </TabsContent>
+
+            <TabsContent value="taxas" className="mt-4">
+              <TaxasScreen
+                taxas={taxas}
+                modoFoco={modoFoco}
+                matchesMunicipioFilter={matchesMunicipioFilter}
+                matchesQuery={matchesQuery}
+              />
+            </TabsContent>
+
+            <TabsContent value="processos">
+              <ProcessosScreen
+                processosNormalizados={processosNormalizados}
+                modoFoco={modoFoco}
+                matchesMunicipioFilter={matchesMunicipioFilter}
+                matchesQuery={matchesQuery}
+                handleCopy={handleCopy}
+              />
+            </TabsContent>
+
+            <TabsContent value="uteis">
+              <UteisScreen
+                query={query}
+                municipio={municipio}
+                soAlertas={somenteAlertas}
+                contatos={contatos}
+                modelos={modelos}
+                matchesMunicipioFilter={matchesMunicipioFilter}
+                handleCopy={handleCopy}
+              />
+            </TabsContent>
+
+            <TabsContent value="certificados" className="mt-4">
+              <CertificadosScreen
+                certificados={certificados}
+                agendamentos={agendamentos}
+                soAlertas={somenteAlertas}
+              />
+            </TabsContent>
+          </Tabs>
+        )}
+
+        <div className="pointer-events-none fixed inset-x-0 bottom-4 flex justify-center sm:justify-end px-4">
+          <div className="w-full sm:max-w-sm space-y-2">
+            {toasts.map((toast) => (
+              <div
+                key={toast.id}
+                className="pointer-events-auto rounded-xl border border-slate-200 bg-white shadow-lg px-4 py-3 flex items-start gap-3"
+              >
+                <div className="mt-0.5">
+                  <Sparkles className="h-4 w-4 text-amber-500" />
+                </div>
+                <div className="text-sm text-slate-700 flex-1">{toast.message}</div>
+                <button
+                  type="button"
+                  className="text-slate-400 hover:text-slate-600"
+                  onClick={() => dismissToast(toast.id)}
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
           </div>
         </div>
-        <div className="w-full md:w-56">
-          <Label className="text-xs uppercase">Município</Label>
-          <Select value={selectMunicipioValue} onValueChange={handleMunicipioChange}>
-            <SelectTrigger>
-              <SelectValue placeholder="Todos" />
-            </SelectTrigger>
-            <SelectContent
-              position="popper"
-              className="max-h-80 overflow-y-auto overscroll-contain"
-              onWheel={(e) => e.stopPropagation()}
-            >
-              <SelectItem value={MUNICIPIO_ALL}>Todos</SelectItem>
-              {sanitizedMunicipios.map((item) => (
-                <SelectItem key={item} value={item}>
-                  {item}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex items-center gap-2">
-          <Switch checked={soAlertas} onCheckedChange={setSoAlertas} />
-          <span className="text-sm">Somente alertas</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <Switch checked={modoFoco} onCheckedChange={setModoFoco} />
-          <span className="text-sm">Modo foco</span>
-        </div>
       </div>
-
-      <Tabs value={tab} onValueChange={setTab}>
-        <TabsList className="grid w-full grid-cols-7">
-          <TabsTrigger value="painel" data-tab-target="painel" title="Alt+1">
-            <TrendingUp className="h-4 w-4 mr-2" /> Painel
-          </TabsTrigger>
-          <TabsTrigger value="empresas" data-tab-target="empresas" title="Alt+2">
-            <Building2 className="h-4 w-4 mr-2" /> Empresas
-          </TabsTrigger>
-          <TabsTrigger value="licencas" data-tab-target="licencas" title="Alt+3">
-            <FileText className="h-4 w-4 mr-2" /> Licenças
-          </TabsTrigger>
-          <TabsTrigger value="taxas" data-tab-target="taxas" title="Alt+4">
-            <Clock className="h-4 w-4 mr-2" /> Taxas
-          </TabsTrigger>
-          <TabsTrigger value="processos" data-tab-target="processos" title="Alt+5">
-            <CheckCircle2 className="h-4 w-4 mr-2" /> Processos
-          </TabsTrigger>
-          <TabsTrigger value="uteis" data-tab-target="uteis" title="Alt+6">
-            <MessageSquare className="h-4 w-4 mr-2" /> Úteis
-          </TabsTrigger>
-          <TabsTrigger value="certificados" data-tab-target="certificados" title="Alt+7">
-            <ShieldCheck className="h-4 w-4 mr-2" /> Certificados
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="painel">
-          <PainelScreen
-            query={query}
-            municipio={municipio}
-            soAlertas={soAlertas}
-            kpis={kpis}
-            empresas={empresasComCertificados}
-            licencas={licencas}
-            taxas={taxas}
-            filteredLicencas={filteredLicencas}
-            processosNormalizados={processosNormalizados}
-            filterEmpresas={filterEmpresas}
-            companyHasAlert={companyHasAlert}
-            licencasByEmpresa={licencasByEmpresa}
-            extractEmpresaId={extractEmpresaId}
-          />
-        </TabsContent>
-
-        <TabsContent value="empresas" className="mt-4 space-y-3">
-          <EmpresasScreen
-            filteredEmpresas={filteredEmpresas}
-            empresas={empresasComCertificados}
-            soAlertas={soAlertas}
-            extractEmpresaId={extractEmpresaId}
-            licencasByEmpresa={licencasByEmpresa}
-            taxasByEmpresa={taxasByEmpresa}
-            processosByEmpresa={processosByEmpresa}
-            handleCopy={handleCopy}
-            enqueueToast={enqueueToast}
-          />
-        </TabsContent>
-
-        <TabsContent value="licencas" className="mt-4">
-          <LicencasScreen licencas={licencas} filteredLicencas={filteredLicencas} modoFoco={modoFoco} />
-        </TabsContent>
-
-        <TabsContent value="taxas" className="mt-4">
-          <TaxasScreen
-            taxas={taxas}
-            modoFoco={modoFoco}
-            matchesMunicipioFilter={matchesMunicipioFilter}
-            matchesQuery={matchesQuery}
-          />
-        </TabsContent>
-
-        <TabsContent value="processos">
-          <ProcessosScreen
-            processosNormalizados={processosNormalizados}
-            modoFoco={modoFoco}
-            matchesMunicipioFilter={matchesMunicipioFilter}
-            matchesQuery={matchesQuery}
-            handleCopy={handleCopy}
-          />
-        </TabsContent>
-
-        <TabsContent value="uteis">
-          <UteisScreen
-            query={query}
-            municipio={municipio}
-            soAlertas={soAlertas}
-            contatos={contatos}
-            modelos={modelos}
-            matchesMunicipioFilter={matchesMunicipioFilter}
-            handleCopy={handleCopy}
-          />
-        </TabsContent>
-
-        <TabsContent value="certificados" className="mt-4">
-          <CertificadosScreen
-            certificados={certificados}
-            agendamentos={agendamentos}
-            soAlertas={soAlertas}
-          />
-        </TabsContent>
-      </Tabs>
-
-      <div className="pointer-events-none fixed inset-x-0 bottom-4 flex justify-center sm:justify-end px-4">
-        <div className="w-full sm:max-w-sm space-y-2">
-          {toasts.map((toast) => (
-            <div
-              key={toast.id}
-              className="pointer-events-auto rounded-xl border border-slate-200 bg-white shadow-lg px-4 py-3 flex items-start gap-3"
-            >
-              <div className="mt-0.5">
-                <Sparkles className="h-4 w-4 text-amber-500" />
-              </div>
-              <div className="text-sm text-slate-700 flex-1">{toast.message}</div>
-              <button
-                type="button"
-                className="text-slate-400 hover:text-slate-600"
-                onClick={() => dismissToast(toast.id)}
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
+    </>
   );
 }
 

--- a/frontend/src/components/HeaderMenuPro.jsx
+++ b/frontend/src/components/HeaderMenuPro.jsx
@@ -1,0 +1,209 @@
+import React, { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import {
+  Bell,
+  Building2,
+  CheckCircle2,
+  ChevronsUpDown,
+  FileText,
+  LayoutDashboard,
+  MessageSquareText,
+  Search,
+  ShieldAlert,
+  ShieldCheck,
+  Star,
+  TimerReset,
+  Crown,
+} from "lucide-react";
+
+const NAV_ITEMS = [
+  { key: "painel", label: "Painel", icon: LayoutDashboard },
+  { key: "empresas", label: "Empresas", icon: Building2 },
+  { key: "certificados", label: "Certificados", icon: ShieldCheck },
+  { key: "licencas", label: "Licenças", icon: FileText },
+  { key: "taxas", label: "Taxas", icon: TimerReset },
+  { key: "processos", label: "Processos", icon: CheckCircle2 },
+  { key: "uteis", label: "Úteis", icon: MessageSquareText },
+];
+
+function Brand() {
+  const [failed, setFailed] = React.useState(false);
+  return (
+    <div className="flex items-center gap-2">
+      {failed ? (
+        <Crown aria-label="eControle" className="h-8 w-8 text-indigo-600" />
+      ) : (
+        <img
+          src="/favicons/crown/favicon-coroa-gradient.svg"
+          alt="eControle"
+          className="h-8 w-8"
+          onError={() => setFailed(true)}
+        />
+      )}
+      <div className="text-xl md:text-2xl font-extrabold tracking-tight">
+        <span className="bg-gradient-to-r from-indigo-600 via-sky-500 to-emerald-500 bg-clip-text text-transparent">
+          eControle
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** Props esperadas:
+ * tab, onTabChange
+ * query, onQueryChange
+ * municipio, municipios, onMunicipioChange
+ * somenteAlertas, onSomenteAlertasChange
+ * modoFoco, onModoFocoChange
+ */
+export default function HeaderMenuPro({
+  tab,
+  onTabChange,
+  query,
+  onQueryChange,
+  municipio,
+  municipios,
+  onMunicipioChange,
+  somenteAlertas,
+  onSomenteAlertasChange,
+  modoFoco,
+  onModoFocoChange,
+}) {
+  // Atalho Ctrl/Cmd + K para focar no input
+  useEffect(() => {
+    const onKey = (e) => {
+      if ((e.ctrlKey || e.metaKey) && String(e.key).toLowerCase() === "k") {
+        e.preventDefault();
+        document.getElementById("global-search-input")?.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    if (import.meta.env.DEV) {
+      const keys = NAV_ITEMS.map(n => n.key);
+      console.assert(JSON.stringify(keys) === JSON.stringify(["painel","empresas","certificados","licencas","taxas","processos","uteis"]), "[HeaderMenuPro] Ordem inesperada");
+      console.assert(Array.isArray(municipios) && municipios.includes("Todos"), "[HeaderMenuPro] municipios deve conter 'Todos'");
+    }
+    return () => window.removeEventListener("keydown", onKey);
+  }, [municipios]);
+
+  // Botão “+ Novo” é decorativo por enquanto
+  const handleNew = (type) => console.log(`[Novo] criar ${type}`);
+
+  return (
+    <header className="sticky top-0 z-40 w-full border-b bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+      <div className="max-w-[1400px] mx-auto px-4">
+        {/* Linha 1: marca + busca + ações + perfil */}
+        <div className="h-16 flex items-center gap-3">
+          <Brand />
+
+          {/* Busca global */}
+          <div className="flex-1">
+            <div className="relative">
+              <Search className="absolute left-2 top-2.5 h-4 w-4 text-slate-400" />
+              <Input
+                id="global-search-input"
+                placeholder="Buscar: Empresa, CNPJ, palavra-chave…  (Ctrl/Cmd + K)"
+                value={query}
+                onChange={(e) => onQueryChange?.(e.target.value)}
+                className="pl-8"
+              />
+            </div>
+          </div>
+
+          {/* Ações rápidas */}
+          <div className="flex items-center gap-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button size="sm" variant="secondary" title="Criar novo">+ Novo</Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                <DropdownMenuItem onSelect={() => handleNew("empresa")}>
+                  <Building2 className="h-4 w-4 mr-2" /> Empresa
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => handleNew("processo")}>
+                  <FileText className="h-4 w-4 mr-2" /> Processo
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <Button size="icon" variant="secondary" title="Notificações"><Bell className="h-4 w-4" /></Button>
+            <Button size="icon" variant="secondary" title="Favoritos"><Star className="h-4 w-4" /></Button>
+          </div>
+
+          {/* Perfil */}
+          <div className="flex items-center gap-2 rounded-xl border bg-white/70 backdrop-blur px-2 py-1">
+            <div className="h-7 w-7 rounded-full bg-gradient-to-tr from-indigo-500 to-sky-500 grid place-items-center text-white text-xs font-semibold">MC</div>
+            <div className="hidden md:block leading-tight">
+              <div className="text-xs font-medium">Maria Clara</div>
+              <div className="text-[10px] text-slate-500">Neto Contabilidade</div>
+            </div>
+            <ChevronsUpDown className="h-4 w-4 text-slate-500" />
+          </div>
+        </div>
+
+        {/* Linha 2: navegação + filtros */}
+        <div className="pb-3 -mt-1">
+          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-3">
+            <Tabs value={tab} onValueChange={onTabChange} className="w-full lg:w-auto">
+              <TabsList className="grid grid-cols-3 sm:grid-cols-7 w-full lg:w-auto">
+                {NAV_ITEMS.map(({ key, label, icon: Icon }, index) => (
+                  <TabsTrigger key={key} value={key} className="gap-2" data-tab-target={key} title={`Alt+${index + 1}`}>
+                    <Icon className="h-4 w-4" /> {label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+              {NAV_ITEMS.map(({ key }) => <TabsContent key={key} value={key} />)}
+            </Tabs>
+
+            <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+              {/* Município */}
+              <div className="sm:w-56">
+                <Label className="text-[11px] text-slate-500">Município</Label>
+                <Select value={municipio} onValueChange={onMunicipioChange}>
+                  <SelectTrigger className="h-9"><SelectValue placeholder="Todos" /></SelectTrigger>
+                  <SelectContent>
+                    {municipios?.map((m) => (<SelectItem key={m} value={m}>{m}</SelectItem>))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Somente alertas */}
+              <div className="flex items-center gap-2 rounded-xl border px-3 py-1.5 bg-white/60">
+                <Switch checked={!!somenteAlertas} onCheckedChange={onSomenteAlertasChange} />
+                <span className="text-sm">Somente alertas</span>
+                {somenteAlertas ? (
+                  <span className="ml-1 inline-flex items-center rounded-md bg-red-100 px-1.5 py-0 text-[11px] text-red-700">
+                    <ShieldAlert className="h-3.5 w-3.5 mr-1" /> ON
+                  </span>
+                ) : (
+                  <span className="ml-1 inline-flex items-center rounded-md bg-slate-100 px-1.5 py-0 text-[11px] text-slate-700">
+                    OFF
+                  </span>
+                )}
+              </div>
+
+              {/* Modo foco */}
+              <div className="flex items-center gap-2 rounded-xl border px-3 py-1.5 bg-white/60">
+                <Switch checked={!!modoFoco} onCheckedChange={onModoFocoChange} />
+                <span className="text-sm">Modo foco</span>
+                {modoFoco ? (
+                  <span className="ml-1 inline-flex items-center rounded-md bg-emerald-100 px-1.5 py-0 text-[11px] text-emerald-700">ON</span>
+                ) : (
+                  <span className="ml-1 inline-flex items-center rounded-md bg-slate-100 px-1.5 py-0 text-[11px] text-slate-700">OFF</span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <Separator />
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -4,21 +4,21 @@ export const PROCESS_ALL = "__PROCESS_ALL__";
 export const TAB_BACKGROUNDS = {
   painel: "bg-sky-50",
   empresas: "bg-indigo-50",
+  certificados: "bg-teal-50",
   licencas: "bg-emerald-50",
   taxas: "bg-amber-50",
   processos: "bg-violet-50",
   uteis: "bg-slate-50",
-  certificados: "bg-lime-50",
 };
 
 export const TAB_SHORTCUTS = {
   1: "painel",
   2: "empresas",
-  3: "licencas",
-  4: "taxas",
-  5: "processos",
-  6: "uteis",
-  7: "certificados",
+  3: "certificados",
+  4: "licencas",
+  5: "taxas",
+  6: "processos",
+  7: "uteis",
 };
 
 export const DEFAULT_LICENCA_TIPOS = [


### PR DESCRIPTION
## Summary
- add a reusable `HeaderMenuPro` component providing the new sticky header with navigation, filters, and quick actions
- integrate the header into `App.jsx`, wiring existing state, refining municipality options, and keeping tab content rendering intact
- update tab background colors and keyboard shortcuts in constants to reflect the new certificados ordering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa8e2368508326a2f6e7c8691a1bb1