### PR TITLE
Ensure header tabs render on a single line

### DIFF
--- a/frontend/src/components/HeaderMenuPro.jsx
+++ b/frontend/src/components/HeaderMenuPro.jsx
@@ -151,12 +151,12 @@ export default function HeaderMenuPro({
 <div className="pb-3 -mt-1">
   <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-y-3 lg:gap-y-2 gap-x-2">
     <Tabs value={tab} onValueChange={onTabChange} className="w-full lg:w-auto">
-      <TabsList className="grid grid-cols-3 sm:grid-cols-7 w-full lg:w-auto">
+      <TabsList className="flex w-full lg:w-auto flex-nowrap items-stretch gap-1 overflow-x-auto">
         {NAV_ITEMS.map(({ key, label, icon: Icon }, index) => (
           <TabsTrigger
             key={key}
             value={key}
-            className="gap-2"
+            className="gap-2 whitespace-nowrap"
             data-tab-target={key}
             title={`Alt+${index + 1}`}
           >


### PR DESCRIPTION
## Summary
- update the header TabsList to use a single-line flex layout
- prevent tab labels from wrapping by enforcing whitespace-nowrap on triggers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb6f59203083269af7f2641ef7b027