### PR TITLE
Add scrolling constraints to select dropdown

### DIFF
--- a/frontend/src/components/ui/select.jsx
+++ b/frontend/src/components/ui/select.jsx
@@ -21,7 +21,7 @@ SelectTrigger.displayName = "SelectTrigger";
 
 export const SelectContent = React.forwardRef(({ className, children, position = "popper", ...props }, ref) => (
   <RadixSelect.Content ref={ref} position={position} className={cn("z-50 rounded-xl border bg-popover p-1 shadow-md", className)} {...props}>
-    <RadixSelect.Viewport className="p-1">
+    <RadixSelect.Viewport className="max-h-72 overflow-y-auto overscroll-contain p-1">
       {children}
     </RadixSelect.Viewport>
   </RadixSelect.Content>


### PR DESCRIPTION
## Summary
- limit the select dropdown viewport height and enable internal scrolling to prevent body scrolling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb7e0bf3508326b1c4744ae1d9bd0c