### PR TITLE
Handle placeholder processos rows and add unique index

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,76 @@ Sistema interno para gestão de empresas, licenças, taxas, processos administra
 
 ---
 
+## S2 – ETL idempotente (Excel → Postgres)
+
+> **Objetivo:** importar planilhas Excel/CSV para o banco mantendo idempotência e auditabilidade.
+
+### Arquitetura
+
+1. **Extract** (`backend/etl/extract_xlsm.py`)
+   - Lê `.xlsm`/`.xlsx` com `openpyxl` (aceita `.csv` para amostras).
+   - Respeita `sheet_names` e `table_names` definidos no `config.yaml`.
+   - Retém o número da linha original para rastreabilidade.
+2. **Transform** (`backend/etl/transform_normalize.py`)
+   - Concilia cabeçalhos via `column_aliases` e aplica normalizadores (CNPJ, datas, enums).
+   - Gera payload canônico por entidade e valida domínios contra `config.yaml`.
+3. **Load** (`backend/etl/load_upsert.py`)
+   - Persiste nas tabelas de staging (`stg_*`) com `run_id`, `row_hash` e payload em JSON.
+   - Resolve `empresa_id` pelo CNPJ e executa UPSERT idempotente nas tabelas finais.
+   - Calcula diffs campo a campo para decidir entre `insert`, `update` ou `skip`.
+
+### Dependências
+
+Instale as dependências do backend (inclui Typer para a CLI):
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+### Migrations
+
+Aplicar o schema base (S1) + staging tables (S2):
+
+```bash
+alembic -c backend/alembic.ini upgrade head
+```
+
+### Execução do ETL
+
+```bash
+# Dry-run (sem commitar alterações)
+python -m etl import --source "caminho/planilha.xlsm" --dry-run
+
+# Aplicar alterações
+python -m etl import --source "caminho/planilha.xlsm" --apply
+```
+
+A CLI lê `DATABASE_URL` e `CONFIG_PATH` do ambiente. A saída é JSONL com `run_id`, `sheet`, `row_number`, `table`, `action` e `changed_fields`.
+
+### Logs e idempotência
+
+- As tabelas de staging armazenam `payload` e `row_hash` de cada execução.
+- Execuções repetidas com os mesmos dados retornam `skip` (sem alterações nas tabelas finais).
+- Alterações parciais produzem `update` com a lista de campos modificados.
+
+### Testes
+
+Execute a suíte focada no ETL:
+
+```bash
+pytest tests/test_etl_basic.py
+```
+
+Os cenários cobrem duplicidade, enums inválidos, datas inválidas e atualizações parciais.
+
+### Troubleshooting
+
+- **Enums inválidos**: ajuste o texto da planilha para coincidir com os valores do `config.yaml`.
+- **Datas**: suportados `dd/mm/aaaa`, `dd-mm-aaaa`, `aaaa-mm-dd` e serial numérico do Excel.
+- **CNPJ**: sempre tratado apenas com dígitos; entradas vazias são ignoradas.
+
+---
+
 ## Backend FastAPI
 
 ### Responsabilidades principais

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package root for eControle."""

--- a/backend/etl/__init__.py
+++ b/backend/etl/__init__.py
@@ -1,0 +1,6 @@
+"""ETL package for the eControle S2 pipeline."""
+from __future__ import annotations
+
+from . import cli  # noqa: F401  (re-export CLI entry-point)
+
+__all__ = ["cli"]

--- a/backend/etl/cli.py
+++ b/backend/etl/cli.py
@@ -1,0 +1,65 @@
+"""Command line interface for the ETL pipeline."""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+
+import sqlalchemy as sa
+import typer
+
+from .contracts import load_contract
+from .extract_xlsm import load as load_source
+from .load_upsert import run as run_loader
+from .transform_normalize import transform
+
+app = typer.Typer(add_completion=False, help="Comandos do ETL idempotente do eControle.")
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context) -> None:
+    """Exibe ajuda quando nenhum subcomando é informado."""
+
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit()
+
+
+@app.command("import")
+def import_command(
+    source: Path = typer.Argument(..., exists=True, readable=True, help="Arquivo XLSM/XLSX/CSV"),
+    dry_run: bool = typer.Option(True, help="Executa sem commitar alterações"),
+    file_source: str | None = typer.Option(None, help="Rótulo amigável para o arquivo"),
+) -> None:
+    run_id = str(uuid.uuid4())
+    file_label = file_source or source.name
+
+    contract = load_contract()
+    raw_data = load_source(source, contract)
+    normalized = transform(raw_data, contract)
+
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL não definido no ambiente")
+
+    engine = sa.create_engine(database_url, future=True)
+    results = run_loader(
+        engine,
+        normalized,
+        run_id=run_id,
+        file_source=file_label,
+        dry_run=dry_run,
+    )
+
+    typer.echo(
+        json.dumps(
+            {"run_id": run_id, "dry_run": dry_run, "file_source": file_label, "results": results},
+            ensure_ascii=False,
+            default=str,
+        )
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/backend/etl/contracts.py
+++ b/backend/etl/contracts.py
@@ -1,0 +1,79 @@
+"""Contracts derived from ``config.yaml`` for the ETL."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, List, Mapping, MutableMapping
+
+import yaml
+from pydantic import BaseModel, Field, PrivateAttr, field_validator
+
+from .normalizers import strip_accents
+
+
+class ConfigContract(BaseModel):
+    sheet_names: Dict[str, str]
+    table_names: Dict[str, Dict[str, str]] = Field(default_factory=dict)
+    enums: Dict[str, List[str]]
+    column_aliases: Dict[str, Dict[str, List[str]]]
+
+    _alias_cache: MutableMapping[str, Dict[str, str]] = PrivateAttr(default_factory=dict)
+
+    @field_validator("sheet_names", mode="before")
+    @classmethod
+    def _ensure_sheet_names(cls, value: Mapping[str, str]) -> Mapping[str, str]:
+        if not value:
+            raise ValueError("sheet_names must not be empty")
+        return value
+
+    def alias_map(self, section: str) -> Dict[str, str]:
+        if section not in self.column_aliases:
+            raise KeyError(f"Section '{section}' not present in column_aliases")
+        if section not in self._alias_cache:
+            alias_section: Dict[str, str] = {}
+            for canonical, aliases in self.column_aliases[section].items():
+                all_aliases = [canonical, *aliases]
+                for alias in all_aliases:
+                    if alias is None:
+                        continue
+                    key = self._normalize_alias(alias)
+                    alias_section[key] = canonical
+            self._alias_cache[section] = alias_section
+        return self._alias_cache[section]
+
+    @staticmethod
+    def _normalize_alias(alias: str) -> str:
+        normalized = strip_accents(str(alias)).casefold()
+        return normalized.replace(" ", "").replace("_", "")
+
+    def match_alias(self, section: str, header: str | None) -> str | None:
+        if header is None:
+            return None
+        key = self._normalize_alias(header)
+        return self.alias_map(section).get(key)
+
+    def require_enum(self, enum_key: str) -> List[str]:
+        values = self.enums.get(enum_key)
+        if not values:
+            raise KeyError(f"Enum '{enum_key}' not found in config.yaml")
+        return values
+
+
+def load_contract(path: str | Path | None = None) -> ConfigContract:
+    config_path = Path(path) if path else _default_config_path()
+    if not config_path.exists():
+        raise FileNotFoundError(f"config.yaml não encontrado em {config_path}")
+    with config_path.open("r", encoding="utf-8") as handler:
+        data = yaml.safe_load(handler) or {}
+    return ConfigContract(**data)
+
+
+def _default_config_path() -> Path:
+    base_dir = Path(__file__).resolve().parents[1]
+    env_path = os.getenv("CONFIG_PATH")
+    if env_path:
+        path = Path(env_path)
+        if not path.is_absolute():
+            path = (base_dir / env_path).resolve()
+        return path
+    return (base_dir / "config.yaml").resolve()

--- a/backend/etl/extract_xlsm.py
+++ b/backend/etl/extract_xlsm.py
@@ -1,0 +1,96 @@
+"""Data extraction helpers for Excel/CSV sources."""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+from openpyxl import load_workbook
+
+from .contracts import ConfigContract
+from .normalizers import normalize_text
+
+ROW_NUMBER_KEY = "__row_number__"
+
+
+def load(source: str | Path, contract: ConfigContract) -> Dict[str, Any]:
+    path = Path(source)
+    suffix = path.suffix.lower()
+    if suffix in {".xlsx", ".xlsm", ".xls"}:
+        return _load_excel(path, contract)
+    if suffix == ".csv":
+        return {"empresas": _load_csv(path)}
+    raise ValueError(f"Formato não suportado: {suffix}")
+
+
+def _load_csv(path: Path) -> List[Dict[str, Any]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handler:
+        reader = csv.DictReader(handler)
+        rows: List[Dict[str, Any]] = []
+        for index, row in enumerate(reader, start=2):
+            row_data = {key: value for key, value in row.items()}
+            row_data[ROW_NUMBER_KEY] = index
+            rows.append(row_data)
+    return rows
+
+
+def _load_excel(path: Path, contract: ConfigContract) -> Dict[str, Any]:
+    workbook = load_workbook(path, read_only=True, data_only=True)
+    data: Dict[str, Any] = {}
+    for logical_sheet, sheet_name in contract.sheet_names.items():
+        if sheet_name not in workbook.sheetnames:
+            continue
+        worksheet = workbook[sheet_name]
+        if logical_sheet in {"processos", "uteis", "certificados", "certificados_agendamentos"}:
+            tables_map = contract.table_names.get(logical_sheet, {})
+            data[logical_sheet] = _load_tables(worksheet, tables_map)
+        else:
+            data[logical_sheet] = _load_worksheet(worksheet)
+    return data
+
+
+def _load_tables(worksheet, tables_map: Dict[str, str]) -> Dict[str, List[Dict[str, Any]]]:
+    tables: Dict[str, List[Dict[str, Any]]] = {}
+    for logical_table, table_name in tables_map.items():
+        if table_name not in worksheet.tables:
+            continue
+        table = worksheet.tables[table_name]
+        cells = worksheet[table.ref]
+        rows = _rows_from_cells(cells)
+        tables[logical_table] = rows
+    return tables
+
+
+def _load_worksheet(worksheet) -> List[Dict[str, Any]]:
+    cells = worksheet.iter_rows()
+    return _rows_from_cells(cells)
+
+
+def _rows_from_cells(cells: Iterable[Iterable[Any]]) -> List[Dict[str, Any]]:
+    iterator = iter(cells)
+    try:
+        header_row = next(iterator)
+    except StopIteration:
+        return []
+    headers = [normalize_text(cell.value) or "" for cell in header_row]
+    rows: List[Dict[str, Any]] = []
+    for row in iterator:
+        values = [cell.value for cell in row]
+        if _is_empty_row(values):
+            continue
+        record: Dict[str, Any] = {}
+        for header, cell in zip(headers, row):
+            record[header] = cell.value
+        first_cell = row[0]
+        record[ROW_NUMBER_KEY] = getattr(first_cell, "row", len(rows) + 2)
+        rows.append(record)
+    return rows
+
+
+def _is_empty_row(values: Iterable[Any]) -> bool:
+    for value in values:
+        if value not in (None, ""):
+            if isinstance(value, str) and not value.strip():
+                continue
+            return False
+    return True

--- a/backend/etl/load_upsert.py
+++ b/backend/etl/load_upsert.py
@@ -1,0 +1,303 @@
+"""Load step: writes staging rows and performs idempotent upserts."""
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from typing import Any, Dict, List, Optional, Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.engine import Connection, Engine
+
+from .normalizers import make_row_hash, only_digits
+from .transform_normalize import NormalizedRow
+
+FINAL_TABLES = {"empresas", "licencas", "taxas", "processos"}
+
+
+def run(
+    engine: Engine,
+    normalized: Dict[str, List[NormalizedRow]],
+    run_id: str,
+    file_source: str,
+    dry_run: bool = True,
+) -> List[Dict[str, Any]]:
+    with _transaction(engine, dry_run) as connection:
+        metadata = sa.MetaData()
+        metadata.reflect(connection, only={
+            "empresas",
+            "licencas",
+            "taxas",
+            "processos",
+            "stg_empresas",
+            "stg_licencas",
+            "stg_taxas",
+            "stg_processos",
+            "stg_certificados",
+            "stg_certificados_agendamentos",
+        })
+        empresas_table = metadata.tables["empresas"]
+        staging_tables = {
+            name: metadata.tables[name]
+            for name in (
+                "stg_empresas",
+                "stg_licencas",
+                "stg_taxas",
+                "stg_processos",
+                "stg_certificados",
+                "stg_certificados_agendamentos",
+            )
+        }
+        results: List[Dict[str, Any]] = []
+        empresa_cache: Dict[str, int] = {}
+
+        ordered_tables = ["empresas", "licencas", "taxas", "processos", "certificados", "certificados_agendamentos"]
+        for table in ordered_tables:
+            rows = normalized.get(table, [])
+            for item in rows:
+                staging_table = staging_tables[f"stg_{table}"]
+                payload = dict(item.payload)
+                payload_json = json.dumps(payload, sort_keys=True, default=str)
+                row_hash = make_row_hash(item.table, item.row_number, payload_json)
+                _insert_staging(
+                    connection,
+                    staging_table,
+                    run_id,
+                    file_source,
+                    item.row_number,
+                    row_hash,
+                    payload,
+                )
+                if table not in FINAL_TABLES:
+                    results.append(
+                        {
+                            "run_id": run_id,
+                            "sheet": item.sheet,
+                            "row_number": item.row_number,
+                            "table": table,
+                            "action": "insert",
+                            "changed_fields": [],
+                        }
+                    )
+                    continue
+                action, changed = _upsert_final(
+                    connection,
+                    table,
+                    payload,
+                    empresa_cache,
+                    empresas_table,
+                    metadata.tables[table],
+                )
+                results.append(
+                    {
+                        "run_id": run_id,
+                        "sheet": item.sheet,
+                        "row_number": item.row_number,
+                        "table": table,
+                        "action": action,
+                        "changed_fields": changed,
+                    }
+                )
+        return results
+
+
+@contextmanager
+def _transaction(engine: Engine, dry_run: bool):
+    connection = engine.connect()
+    trans = connection.begin()
+    try:
+        yield connection
+        if dry_run:
+            trans.rollback()
+        else:
+            trans.commit()
+    finally:
+        connection.close()
+
+
+def _insert_staging(
+    connection: Connection,
+    table: sa.Table,
+    run_id: str,
+    file_source: str,
+    row_number: int,
+    row_hash: str,
+    payload: Dict[str, Any],
+) -> None:
+    value = (
+        payload
+        if connection.dialect.name == "postgresql"
+        else json.dumps(payload, ensure_ascii=False, default=str)
+    )
+    stmt = table.insert().values(
+        run_id=run_id,
+        file_source=file_source,
+        row_number=row_number,
+        row_hash=row_hash,
+        payload=value,
+    )
+    connection.execute(stmt)
+
+
+def _upsert_final(
+    connection: Connection,
+    table_name: str,
+    payload: Dict[str, Any],
+    empresa_cache: Dict[str, int],
+    empresas_table: sa.Table,
+    table: sa.Table,
+) -> tuple[str, List[str]]:
+    final_payload = dict(payload)
+    if table_name != "empresas":
+        empresa_id = _resolve_empresa_id(connection, empresas_table, empresa_cache, final_payload.get("empresa_cnpj"))
+        if not empresa_id:
+            raise ValueError(f"Empresa não encontrada para CNPJ {final_payload.get('empresa_cnpj')}")
+        final_payload["empresa_id"] = empresa_id
+        final_payload.pop("empresa_cnpj", None)
+    else:
+        empresa_id = None
+
+    select_stmt, natural_key_cols = _build_natural_key(table_name, table, final_payload, empresa_id)
+    existing = connection.execute(select_stmt).mappings().first()
+
+    if existing is None:
+        _execute_insert(connection, table, final_payload, natural_key_cols)
+        return "insert", []
+
+    changed_fields = _diff(existing, final_payload, natural_key_cols)
+    if not changed_fields:
+        return "skip", []
+
+    _execute_update(connection, table, final_payload, natural_key_cols, existing)
+    return "update", changed_fields
+
+
+def _resolve_empresa_id(
+    connection: Connection,
+    empresas_table: sa.Table,
+    cache: Dict[str, int],
+    cnpj: Optional[str],
+) -> Optional[int]:
+    normalized = only_digits(cnpj)
+    if not normalized:
+        return None
+    if normalized in cache:
+        return cache[normalized]
+    result = connection.execute(
+        sa.select(empresas_table.c.id).where(empresas_table.c.cnpj == normalized)
+    ).scalar()
+    if result is None:
+        raise ValueError(f"Empresa com CNPJ {normalized} não encontrada")
+    cache[normalized] = result
+    return result
+
+
+def _build_natural_key(
+    table_name: str,
+    table: sa.Table,
+    payload: Dict[str, Any],
+    empresa_id: Optional[int],
+) -> tuple[sa.Select, Sequence[str]]:
+    if table_name == "empresas":
+        cols = (table.c.cnpj,)
+        where_clause = table.c.cnpj == payload["cnpj"]
+        return sa.select(table).where(where_clause), ("cnpj",)
+    if table_name == "taxas":
+        if "data_referencia" in table.c and payload.get("data_referencia"):
+            where_clause = sa.and_(
+                table.c.empresa_id == payload["empresa_id"],
+                table.c.tipo == payload["tipo"],
+                table.c.data_referencia == payload["data_referencia"],
+            )
+            return sa.select(table).where(where_clause), (
+                "empresa_id",
+                "tipo",
+                "data_referencia",
+            )
+        where_clause = sa.and_(
+            table.c.empresa_id == payload["empresa_id"],
+            table.c.tipo == payload["tipo"],
+        )
+        return sa.select(table).where(where_clause), ("empresa_id", "tipo")
+    if table_name == "licencas":
+        where_clause = sa.and_(
+            table.c.empresa_id == payload["empresa_id"],
+            table.c.tipo == payload["tipo"],
+        )
+        return sa.select(table).where(where_clause), ("empresa_id", "tipo")
+    if table_name == "processos":
+        protocolo = payload.get("protocolo")
+        if protocolo:
+            where_clause = sa.and_(
+                table.c.protocolo == protocolo,
+                table.c.tipo == payload["tipo"],
+            )
+            return sa.select(table).where(where_clause), ("protocolo", "tipo")
+        data_solicitacao = payload.get("data_solicitacao")
+        if data_solicitacao is not None:
+            where_clause = sa.and_(
+                table.c.empresa_id == payload["empresa_id"],
+                table.c.tipo == payload["tipo"],
+                table.c.data_solicitacao == data_solicitacao,
+            )
+            return sa.select(table).where(where_clause), (
+                "empresa_id",
+                "tipo",
+                "data_solicitacao",
+            )
+        where_clause = sa.and_(
+            table.c.empresa_id == payload["empresa_id"],
+            table.c.tipo == payload["tipo"],
+            table.c.protocolo.is_(None),
+            table.c.data_solicitacao.is_(None),
+        )
+        return sa.select(table).where(where_clause), ("empresa_id", "tipo")
+    raise ValueError(f"Tabela não suportada: {table_name}")
+
+
+def _execute_insert(
+    connection: Connection,
+    table: sa.Table,
+    payload: Dict[str, Any],
+    natural_key_cols: Sequence[str],
+) -> None:
+    if connection.dialect.name == "postgresql":
+        stmt = postgresql.insert(table).values(**payload)
+        update_columns = {col: getattr(stmt.excluded, col) for col in payload.keys() if col not in natural_key_cols}
+        if update_columns:
+            where_clause = sa.or_(
+                table.c[col].is_distinct_from(getattr(stmt.excluded, col)) for col in update_columns
+            )
+        else:
+            where_clause = None
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[table.c[col] for col in natural_key_cols],
+            set_=update_columns,
+            where=where_clause,
+        )
+        connection.execute(stmt)
+    else:
+        connection.execute(table.insert().values(**payload))
+
+
+def _execute_update(
+    connection: Connection,
+    table: sa.Table,
+    payload: Dict[str, Any],
+    natural_key_cols: Sequence[str],
+    existing: sa.RowMapping,
+) -> None:
+    where_clause = sa.and_(
+        *[table.c[col] == existing[col] for col in natural_key_cols]
+    )
+    connection.execute(table.update().where(where_clause).values(**payload))
+
+
+def _diff(existing: sa.RowMapping, payload: Dict[str, Any], natural_key_cols: Sequence[str]) -> List[str]:
+    changed: List[str] = []
+    for key, value in payload.items():
+        if key in natural_key_cols:
+            continue
+        if existing.get(key) != value:
+            changed.append(key)
+    return changed

--- a/backend/etl/load_upsert.py
+++ b/backend/etl/load_upsert.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 import json
 from contextlib import contextmanager
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.sql.elements import ClauseElement
 
 from .normalizers import make_row_hash, only_digits
 from .transform_normalize import NormalizedRow
@@ -157,11 +158,19 @@ def _upsert_final(
     else:
         empresa_id = None
 
-    select_stmt, natural_key_cols = _build_natural_key(table_name, table, final_payload, empresa_id)
+    select_stmt, natural_key_cols, conflict_where = _build_natural_key(
+        table_name, table, final_payload, empresa_id
+    )
     existing = connection.execute(select_stmt).mappings().first()
 
     if existing is None:
-        _execute_insert(connection, table, final_payload, natural_key_cols)
+        _execute_insert(
+            connection,
+            table,
+            final_payload,
+            natural_key_cols,
+            conflict_where,
+        )
         return "insert", []
 
     changed_fields = _diff(existing, final_payload, natural_key_cols)
@@ -197,11 +206,11 @@ def _build_natural_key(
     table: sa.Table,
     payload: Dict[str, Any],
     empresa_id: Optional[int],
-) -> tuple[sa.Select, Sequence[str]]:
+) -> Tuple[sa.Select, Sequence[str], ClauseElement | None]:
     if table_name == "empresas":
         cols = (table.c.cnpj,)
         where_clause = table.c.cnpj == payload["cnpj"]
-        return sa.select(table).where(where_clause), ("cnpj",)
+        return sa.select(table).where(where_clause), ("cnpj",), None
     if table_name == "taxas":
         if "data_referencia" in table.c and payload.get("data_referencia"):
             where_clause = sa.and_(
@@ -213,18 +222,18 @@ def _build_natural_key(
                 "empresa_id",
                 "tipo",
                 "data_referencia",
-            )
+            ), None
         where_clause = sa.and_(
             table.c.empresa_id == payload["empresa_id"],
             table.c.tipo == payload["tipo"],
         )
-        return sa.select(table).where(where_clause), ("empresa_id", "tipo")
+        return sa.select(table).where(where_clause), ("empresa_id", "tipo"), None
     if table_name == "licencas":
         where_clause = sa.and_(
             table.c.empresa_id == payload["empresa_id"],
             table.c.tipo == payload["tipo"],
         )
-        return sa.select(table).where(where_clause), ("empresa_id", "tipo")
+        return sa.select(table).where(where_clause), ("empresa_id", "tipo"), None
     if table_name == "processos":
         protocolo = payload.get("protocolo")
         if protocolo:
@@ -232,7 +241,7 @@ def _build_natural_key(
                 table.c.protocolo == protocolo,
                 table.c.tipo == payload["tipo"],
             )
-            return sa.select(table).where(where_clause), ("protocolo", "tipo")
+            return sa.select(table).where(where_clause), ("protocolo", "tipo"), None
         data_solicitacao = payload.get("data_solicitacao")
         if data_solicitacao is not None:
             where_clause = sa.and_(
@@ -244,14 +253,18 @@ def _build_natural_key(
                 "empresa_id",
                 "tipo",
                 "data_solicitacao",
-            )
+            ), table.c.protocolo.is_(None)
         where_clause = sa.and_(
             table.c.empresa_id == payload["empresa_id"],
             table.c.tipo == payload["tipo"],
             table.c.protocolo.is_(None),
             table.c.data_solicitacao.is_(None),
         )
-        return sa.select(table).where(where_clause), ("empresa_id", "tipo")
+        return (
+            sa.select(table).where(where_clause),
+            ("empresa_id", "tipo"),
+            sa.and_(table.c.protocolo.is_(None), table.c.data_solicitacao.is_(None)),
+        )
     raise ValueError(f"Tabela não suportada: {table_name}")
 
 
@@ -260,6 +273,7 @@ def _execute_insert(
     table: sa.Table,
     payload: Dict[str, Any],
     natural_key_cols: Sequence[str],
+    conflict_where: ClauseElement | None,
 ) -> None:
     if connection.dialect.name == "postgresql":
         stmt = postgresql.insert(table).values(**payload)
@@ -273,6 +287,7 @@ def _execute_insert(
         stmt = stmt.on_conflict_do_update(
             index_elements=[table.c[col] for col in natural_key_cols],
             set_=update_columns,
+            index_where=conflict_where,
             where=where_clause,
         )
         connection.execute(stmt)

--- a/backend/etl/normalizers.py
+++ b/backend/etl/normalizers.py
@@ -1,0 +1,74 @@
+"""Utility functions used across ETL steps."""
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+import unicodedata
+from datetime import date, datetime, timedelta
+from typing import Any
+
+EXCEL_EPOCH = date(1899, 12, 30)
+_DIGITS_RE = re.compile(r"\D+")
+
+
+def only_digits(value: Any | None) -> str | None:
+    """Return only the numeric characters of *value* or ``None`` if empty."""
+    if value is None:
+        return None
+    if isinstance(value, int):
+        digits = f"{value:d}"
+    elif isinstance(value, float):
+        if math.isnan(value):
+            return None
+        digits = f"{int(value):d}"
+    else:
+        digits = _DIGITS_RE.sub("", str(value))
+    return digits or None
+
+
+def strip_accents(value: str) -> str:
+    """Normalize a string removing accents for matching purposes."""
+    normalized = unicodedata.normalize("NFKD", value)
+    return "".join(ch for ch in normalized if not unicodedata.combining(ch))
+
+
+def normalize_text(value: Any | None) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def parse_date_br(value: Any | None) -> date | None:
+    """Parse dates in dd/mm/yyyy, yyyy-mm-dd or Excel serial formats."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, int):
+        return EXCEL_EPOCH + timedelta(days=value)
+    if isinstance(value, float):
+        if math.isnan(value):
+            return None
+        return EXCEL_EPOCH + timedelta(days=int(value))
+    text = str(value).strip()
+    if not text:
+        return None
+    for fmt in ("%d/%m/%Y", "%d-%m-%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"Data inválida: {value}")
+
+
+def make_row_hash(table: str, row_number: int, payload_json: str) -> str:
+    """Create a deterministic SHA-256 hash for staging rows."""
+
+    digest = hashlib.sha256()
+    digest.update(f"{table}::{row_number}||".encode("utf-8"))
+    digest.update(payload_json.encode("utf-8"))
+    return digest.hexdigest()

--- a/backend/etl/transform_normalize.py
+++ b/backend/etl/transform_normalize.py
@@ -1,0 +1,397 @@
+"""Transformation layer turning raw rows into canonical payloads."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, Iterable, List, Optional
+
+from .contracts import ConfigContract
+from .normalizers import normalize_text, only_digits, parse_date_br, strip_accents
+from .extract_xlsm import ROW_NUMBER_KEY
+
+
+@dataclass(slots=True)
+class NormalizedRow:
+    table: str
+    sheet: str
+    row_number: int
+    payload: Dict[str, Any]
+
+
+PROCESS_TYPE_LABEL = {
+    "diversos": "DIVERSOS",
+    "funcionamento": "FUNCIONAMENTO",
+    "bombeiros": "BOMBEIROS",
+    "uso_solo": "USO_DO_SOLO",
+    "sanitario": "SANITARIO",
+    "ambiental": "AMBIENTAL",
+}
+
+LICENSE_COLUMNS = {
+    "SANITARIA_STATUS": "SANITARIA",
+    "FUNCIONAMENTO_STATUS": "FUNCIONAMENTO",
+    "AMBIENTAL_STATUS": "AMBIENTAL",
+    "USO_SOLO_STATUS": "USO_DO_SOLO",
+    "CERCON_STATUS": "CERCON",
+}
+
+TAX_COLUMNS = {
+    "TPI": "TPI",
+    "FUNCIONAMENTO": "FUNCIONAMENTO",
+    "PUBLICIDADE": "PUBLICIDADE",
+    "SANITARIA": "SANITARIA",
+    "LOCALIZACAO_INSTALACAO": "LOCALIZACAO_INSTALACAO",
+    "AREA_PUBLICA": "AREA_PUBLICA",
+}
+
+
+class TransformError(ValueError):
+    pass
+
+
+def transform(raw_data: Dict[str, Any], contract: ConfigContract) -> Dict[str, List[NormalizedRow]]:
+    batches: Dict[str, List[NormalizedRow]] = {
+        "empresas": [],
+        "licencas": [],
+        "taxas": [],
+        "processos": [],
+        "certificados": [],
+        "certificados_agendamentos": [],
+    }
+
+    empresas_rows = raw_data.get("empresas", [])
+    batches["empresas"].extend(_transform_empresas(empresas_rows, contract))
+
+    licenca_rows = raw_data.get("licencas", [])
+    batches["licencas"].extend(_transform_licencas(licenca_rows, contract))
+
+    taxa_rows = raw_data.get("taxas", [])
+    batches["taxas"].extend(_transform_taxas(taxa_rows, contract))
+
+    processos_section = raw_data.get("processos", {})
+    batches["processos"].extend(_transform_processos(processos_section, contract))
+
+    certificados_rows = raw_data.get("certificados", {})
+    batches["certificados"].extend(
+        _transform_generic_tables(
+            certificados_rows, contract, "certificados", expected_keys=["certificados"]
+        )
+    )
+    agendamento_rows = raw_data.get("certificados_agendamentos", {})
+    batches["certificados_agendamentos"].extend(
+        _transform_generic_tables(
+            agendamento_rows,
+            contract,
+            "certificados_agendamentos",
+            expected_keys=["agendamentos"],
+        )
+    )
+
+    return batches
+
+
+def apply(raw_data: Dict[str, Any], contract: ConfigContract) -> Dict[str, List[NormalizedRow]]:
+    """Compatibility wrapper exposing :func:`transform` as ``apply``."""
+
+    return transform(raw_data, contract)
+
+
+def _transform_empresas(rows: Iterable[Dict[str, Any]], contract: ConfigContract) -> List[NormalizedRow]:
+    alias_map = contract.alias_map("empresas")
+    normalized_rows: List[NormalizedRow] = []
+    sheet_name = contract.sheet_names.get("empresas", "EMPRESAS")
+    for index, row in enumerate(rows, start=1):
+        mapped = _remap_row(row, alias_map)
+        cnpj = only_digits(mapped.get("CNPJ"))
+        if not cnpj:
+            continue
+        empresa = normalize_text(mapped.get("EMPRESA"))
+        municipio = normalize_text(mapped.get("MUNICIPIO"))
+        if not empresa or not municipio:
+            raise TransformError("Empresa ou município ausente para CNPJ %s" % cnpj)
+        payload: Dict[str, Any] = {
+            "empresa": empresa,
+            "cnpj": cnpj,
+            "municipio": municipio,
+            "porte": normalize_text(mapped.get("PORTE")),
+            "categoria": normalize_text(mapped.get("CATEGORIA")),
+            "ie": normalize_text(mapped.get("IE")),
+            "im": normalize_text(mapped.get("IM")),
+            "situacao": normalize_text(mapped.get("SITUACAO")),
+            "debito": normalize_text(mapped.get("DEBITO_PREFEITURA")),
+            "certificado": normalize_text(mapped.get("CERTIFICADO_DIGITAL")),
+            "obs": normalize_text(mapped.get("OBS")),
+            "proprietario": normalize_text(mapped.get("PROPRIETARIO_PRINCIPAL")),
+            "cpf": only_digits(mapped.get("CPF")),
+            "telefone": normalize_text(mapped.get("TELEFONE")),
+            "email": normalize_text(mapped.get("E_MAIL")),
+            "responsavel": normalize_text(mapped.get("RESPONSAVEL_FISCAL")),
+        }
+        row_number = _row_number(row, index)
+        normalized_rows.append(
+            NormalizedRow(
+                table="empresas",
+                sheet=sheet_name,
+                row_number=row_number,
+                payload=payload,
+            )
+        )
+    return normalized_rows
+
+
+def _transform_licencas(rows: Iterable[Dict[str, Any]], contract: ConfigContract) -> List[NormalizedRow]:
+    alias_map = contract.alias_map("licencas")
+    normalized: List[NormalizedRow] = []
+    sheet_name = contract.sheet_names.get("licencas", "LICENÇAS")
+    for index, row in enumerate(rows, start=1):
+        mapped = _remap_row(row, alias_map)
+        cnpj = only_digits(mapped.get("CNPJ"))
+        if not cnpj:
+            continue
+        row_number = _row_number(row, index)
+        for source_col, tipo in LICENSE_COLUMNS.items():
+            status = normalize_text(mapped.get(source_col))
+            if not status:
+                continue
+            payload = {
+                "empresa_cnpj": cnpj,
+                "tipo": tipo,
+                "status": status,
+                "obs": normalize_text(mapped.get("OBS")),
+            }
+            normalized.append(
+                NormalizedRow(
+                    table="licencas",
+                    sheet=sheet_name,
+                    row_number=row_number,
+                    payload=payload,
+                )
+            )
+    return normalized
+
+
+def _transform_taxas(rows: Iterable[Dict[str, Any]], contract: ConfigContract) -> List[NormalizedRow]:
+    alias_map = contract.alias_map("taxas")
+    normalized: List[NormalizedRow] = []
+    sheet_name = contract.sheet_names.get("taxas", "TAXAS")
+    for index, row in enumerate(rows, start=1):
+        mapped = _remap_row(row, alias_map)
+        cnpj = only_digits(mapped.get("CNPJ"))
+        if not cnpj:
+            continue
+        row_number = _row_number(row, index)
+        for source_col, tipo in TAX_COLUMNS.items():
+            status = normalize_text(mapped.get(source_col))
+            if not status:
+                continue
+            payload = {
+                "empresa_cnpj": cnpj,
+                "tipo": tipo,
+                "status": status,
+                "obs": normalize_text(mapped.get("STATUS_TAXAS")) or normalize_text(mapped.get("OBS")),
+            }
+            normalized.append(
+                NormalizedRow(
+                    table="taxas",
+                    sheet=sheet_name,
+                    row_number=row_number,
+                    payload=payload,
+                )
+            )
+    return normalized
+
+
+def _transform_processos(section: Dict[str, Iterable[Dict[str, Any]]], contract: ConfigContract) -> List[NormalizedRow]:
+    normalized: List[NormalizedRow] = []
+    sheet_name = contract.sheet_names.get("processos", "PROCESSOS")
+    for logical_table, rows in section.items():
+        tipo = PROCESS_TYPE_LABEL.get(logical_table)
+        if not tipo:
+            continue
+        alias_section = f"processos_{logical_table}"
+        alias_map = contract.alias_map(alias_section)
+        enum_situacao = contract.require_enum("situacao_processos")
+        enum_operacao = contract.require_enum("operacoes_diversos")
+        enum_orgao = contract.require_enum("orgaos_diversos")
+        enum_alvara = contract.require_enum("alvaras_funcionamento")
+        enum_servico = contract.require_enum("servicos_sanitarios")
+        enum_notificacao = contract.require_enum("notificacoes_sanitarias")
+        for index, row in enumerate(rows, start=1):
+            mapped = _remap_row(row, alias_map)
+            cnpj = only_digits(mapped.get("CNPJ"))
+            if not cnpj:
+                continue
+            situacao_raw = (
+                mapped.get("SITUACAO")
+                or mapped.get("STATUS_PADRAO")
+                or "PENDENTE"
+            )
+            situacao = _normalize_enum(
+                situacao_raw,
+                enum_situacao,
+                "situacao",
+                tipo,
+                required=True,
+            )
+            data_solicitacao = _safe_parse_date(
+                mapped.get("DATA_SOLICITACAO"), "data_solicitacao", tipo
+            )
+            if data_solicitacao is None:
+                raise TransformError(
+                    f"Data de solicitação obrigatória em processos {tipo}"
+                )
+            protocolo = normalize_text(mapped.get("PROTOCOLO"))
+            status_padrao = normalize_text(mapped.get("STATUS_PADRAO"))
+            payload: Dict[str, Any] = {
+                "empresa_cnpj": cnpj,
+                "tipo": tipo,
+                "protocolo": protocolo,
+                "data_solicitacao": data_solicitacao,
+                "situacao": situacao,
+                "status_padrao": status_padrao,
+                "obs": normalize_text(mapped.get("OBS")),
+            }
+            if logical_table == "diversos":
+                payload["operacao"] = _normalize_enum(
+                    mapped.get("OPERACAO"),
+                    enum_operacao,
+                    "operacao",
+                    tipo,
+                    required=False,
+                )
+                payload["orgao"] = _normalize_enum(
+                    mapped.get("ORGAO"),
+                    enum_orgao,
+                    "orgao",
+                    tipo,
+                    required=False,
+                )
+            if logical_table == "funcionamento":
+                payload["alvara"] = _normalize_enum(
+                    mapped.get("ALVARA"),
+                    enum_alvara,
+                    "alvara",
+                    tipo,
+                    required=False,
+                )
+                payload["municipio"] = normalize_text(mapped.get("MUNICIPIO"))
+            if logical_table == "bombeiros":
+                payload["tpi"] = normalize_text(mapped.get("TPI"))
+            if logical_table == "uso_solo":
+                payload["inscricao_imobiliaria"] = normalize_text(mapped.get("INSCRICAO_IMOBILIARIA"))
+            if logical_table == "sanitario":
+                payload["servico"] = _normalize_enum(
+                    mapped.get("SERVICO"),
+                    enum_servico,
+                    "servico",
+                    tipo,
+                    required=False,
+                )
+                payload["taxa"] = normalize_text(mapped.get("TAXA"))
+                payload["notificacao"] = _normalize_enum(
+                    mapped.get("NOTIFICACAO"),
+                    enum_notificacao,
+                    "notificacao",
+                    tipo,
+                    required=False,
+                )
+                payload["data_val"] = _safe_parse_date(
+                    mapped.get("DATA_VAL"), "data_val", tipo
+                )
+            row_number = _row_number(row, index)
+            normalized.append(
+                NormalizedRow(
+                    table="processos",
+                    sheet=sheet_name,
+                    row_number=row_number,
+                    payload=payload,
+                )
+            )
+    return normalized
+
+
+def _transform_generic_tables(
+    tables: Dict[str, Iterable[Dict[str, Any]]],
+    contract: ConfigContract,
+    section: str,
+    expected_keys: List[str],
+) -> List[NormalizedRow]:
+    normalized: List[NormalizedRow] = []
+    for key in expected_keys:
+        rows = tables.get(key) or []
+        alias_section = f"{section}_{key}"
+        if alias_section not in contract.column_aliases:
+            continue
+        alias_map = contract.alias_map(alias_section)
+        sheet_name = contract.sheet_names.get(section, section.upper())
+        for index, row in enumerate(rows, start=1):
+            mapped = _remap_row(row, alias_map)
+            row_number = _row_number(row, index)
+            normalized.append(
+                NormalizedRow(
+                    table=section,
+                    sheet=sheet_name,
+                    row_number=row_number,
+                    payload=mapped,
+                )
+            )
+    return normalized
+
+
+def _normalize_enum(
+    value: Any | None,
+    allowed: Iterable[str],
+    field: str,
+    tipo: str,
+    *,
+    required: bool = True,
+) -> Optional[str]:
+    if value in (None, ""):
+        if required:
+            raise TransformError(f"Valor obrigatório para {field} em {tipo}")
+        return None
+    target = normalize_text(value)
+    if not target:
+        if required:
+            raise TransformError(f"Valor obrigatório para {field} em {tipo}")
+        return None
+    target_key = strip_accents(target).casefold()
+    for option in allowed:
+        option_key = strip_accents(option).casefold()
+        if option_key == target_key:
+            return option
+    raise TransformError(f"Valor inválido '{value}' para {field} em {tipo}")
+
+
+def _safe_parse_date(value: Any | None, field: str, tipo: str) -> date | None:
+    if value in (None, ""):
+        return None
+    try:
+        return parse_date_br(value)
+    except ValueError as exc:
+        raise TransformError(f"Data inválida em {field} ({tipo}): {value}") from exc
+
+
+def _remap_row(row: Dict[str, Any], alias_map: Dict[str, str]) -> Dict[str, Any]:
+    mapped: Dict[str, Any] = {}
+    for key, value in row.items():
+        if key == ROW_NUMBER_KEY:
+            continue
+        canonical = alias_map.get(_normalize_key(key))
+        if canonical:
+            mapped[canonical] = value
+    return mapped
+
+
+def _normalize_key(key: str) -> str:
+    return strip_accents(str(key)).casefold().replace(" ", "").replace("_", "")
+
+
+def _row_number(row: Dict[str, Any], default_index: int) -> int:
+    value = row.get(ROW_NUMBER_KEY)
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default_index + 1

--- a/backend/migrations/versions/20251024_01_create_staging.py
+++ b/backend/migrations/versions/20251024_01_create_staging.py
@@ -1,0 +1,53 @@
+"""Create staging tables for ETL v2."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20251024_01_create_staging"
+down_revision = "20250101_01"
+branch_labels = None
+depends_on = None
+
+
+STAGING_TABLES = (
+    "empresas",
+    "licencas",
+    "taxas",
+    "processos",
+    "certificados",
+    "certificados_agendamentos",
+)
+
+
+def _create_staging_table(name: str) -> None:
+    table_name = f"stg_{name}"
+    op.create_table(
+        table_name,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("run_id", sa.String(length=36), nullable=False),
+        sa.Column("file_source", sa.String(length=255), nullable=False),
+        sa.Column("row_number", sa.Integer, nullable=False),
+        sa.Column("row_hash", sa.String(length=64), nullable=False),
+        sa.Column("payload", postgresql.JSONB, nullable=False),
+        sa.Column(
+            "ingested_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(f"idx_{table_name}_run_id", table_name, ["run_id"])
+
+
+def upgrade() -> None:
+    for table in STAGING_TABLES:
+        _create_staging_table(table)
+
+
+def downgrade() -> None:
+    for table in reversed(STAGING_TABLES):
+        table_name = f"stg_{table}"
+        op.drop_index(f"idx_{table_name}_run_id", table_name=table_name)
+        op.drop_table(table_name)

--- a/backend/migrations/versions/20251024_02_add_uniques_for_upsert.py
+++ b/backend/migrations/versions/20251024_02_add_uniques_for_upsert.py
@@ -1,0 +1,27 @@
+"""Add unique constraints for UPSERTs."""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20251024_02_add_uniques_for_upsert"
+down_revision = "20251024_01_create_staging"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "uq_licencas_empresa_tipo",
+        "licencas",
+        ["empresa_id", "tipo"],
+    )
+    op.create_unique_constraint(
+        "uq_taxas_empresa_tipo",
+        "taxas",
+        ["empresa_id", "tipo"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_taxas_empresa_tipo", "taxas", type_="unique")
+    op.drop_constraint("uq_licencas_empresa_tipo", "licencas", type_="unique")

--- a/backend/migrations/versions/20251024_03_uq_processos_null_protocolo.py
+++ b/backend/migrations/versions/20251024_03_uq_processos_null_protocolo.py
@@ -1,0 +1,25 @@
+"""Unique index for processos with NULL protocolo."""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20251024_03_uq_processos_null_protocolo"
+down_revision = "20251024_02_add_uniques_for_upsert"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_proc_empresa_tipo_data_solicitacao_null_protocolo
+        ON processos (empresa_id, tipo, data_solicitacao)
+        WHERE protocolo IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS uq_proc_empresa_tipo_data_solicitacao_null_protocolo"
+    )

--- a/backend/migrations/versions/20251024_04_uq_proc_sem_proto_sem_data.py
+++ b/backend/migrations/versions/20251024_04_uq_proc_sem_proto_sem_data.py
@@ -1,0 +1,25 @@
+"""Unique index for processos without protocolo and data."""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20251024_04_uq_proc_sem_proto_sem_data"
+down_revision = "20251024_03_uq_processos_null_protocolo"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_proc_empresa_tipo_sem_protocolo_sem_data
+        ON processos (empresa_id, tipo)
+        WHERE protocolo IS NULL AND data_solicitacao IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS uq_proc_empresa_tipo_sem_protocolo_sem_data"
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,6 +18,7 @@ python-dotenv==1.0.0
 python-multipart==0.0.6
 aiofiles==23.2.1
 requests==2.31.0
+typer==0.9.0
 
 # Automação (CND/CAE)
 playwright==1.40.0

--- a/etl/__init__.py
+++ b/etl/__init__.py
@@ -1,0 +1,7 @@
+"""Compatibility shim exposing the backend ETL CLI as a top-level package."""
+from __future__ import annotations
+
+from backend.etl.cli import app as app
+from backend.etl.cli import import_command as import_command
+
+__all__ = ["app", "import_command"]

--- a/etl/__main__.py
+++ b/etl/__main__.py
@@ -1,0 +1,7 @@
+"""Module entry-point for ``python -m etl`` convenience wrapper."""
+from __future__ import annotations
+
+from backend.etl.cli import app
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_etl_basic.py
+++ b/tests/test_etl_basic.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.etl.contracts import load_contract
+from backend.etl.extract_xlsm import ROW_NUMBER_KEY
+from backend.etl.load_upsert import run as run_loader
+from backend.etl.transform_normalize import TransformError, transform
+
+
+@pytest.fixture()
+def contract():
+    config_path = Path(__file__).resolve().parents[1] / "backend" / "config.yaml"
+    return load_contract(config_path)
+
+
+@pytest.fixture()
+def engine(contract) -> Engine:
+    engine = sa.create_engine("sqlite+pysqlite:///:memory:", future=True)
+    metadata = sa.MetaData()
+
+    sa.Table(
+        "empresas",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("empresa", sa.String(255), nullable=False),
+        sa.Column("cnpj", sa.String(14), nullable=False, unique=True),
+        sa.Column("municipio", sa.String(120), nullable=False),
+        sa.Column("porte", sa.String(50)),
+        sa.Column("categoria", sa.String(120)),
+        sa.Column("ie", sa.String(50)),
+        sa.Column("im", sa.String(50)),
+        sa.Column("situacao", sa.String(120)),
+        sa.Column("debito", sa.String(120)),
+        sa.Column("certificado", sa.String(120)),
+        sa.Column("obs", sa.Text),
+        sa.Column("proprietario", sa.String(255)),
+        sa.Column("cpf", sa.String(14)),
+        sa.Column("telefone", sa.String(60)),
+        sa.Column("email", sa.String(255)),
+        sa.Column("responsavel", sa.String(255)),
+    )
+
+    sa.Table(
+        "licencas",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("empresa_id", sa.Integer, nullable=False),
+        sa.Column("tipo", sa.String(50), nullable=False),
+        sa.Column("status", sa.String(120), nullable=False),
+        sa.Column("obs", sa.Text),
+    )
+
+    sa.Table(
+        "taxas",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("empresa_id", sa.Integer, nullable=False),
+        sa.Column("tipo", sa.String(50), nullable=False),
+        sa.Column("status", sa.String(120), nullable=False),
+        sa.Column("obs", sa.Text),
+    )
+
+    sa.Table(
+        "processos",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("empresa_id", sa.Integer, nullable=False),
+        sa.Column("tipo", sa.String(50), nullable=False),
+        sa.Column("protocolo", sa.String(120)),
+        sa.Column("data_solicitacao", sa.Date, nullable=False),
+        sa.Column("situacao", sa.String(120), nullable=False),
+        sa.Column("status_padrao", sa.String(120)),
+        sa.Column("obs", sa.Text),
+        sa.Column("operacao", sa.String(120)),
+        sa.Column("orgao", sa.String(120)),
+        sa.Column("alvara", sa.String(120)),
+        sa.Column("municipio", sa.String(120)),
+        sa.Column("tpi", sa.String(120)),
+        sa.Column("inscricao_imobiliaria", sa.String(120)),
+        sa.Column("servico", sa.String(120)),
+        sa.Column("taxa", sa.String(120)),
+        sa.Column("notificacao", sa.String(120)),
+        sa.Column("data_val", sa.Date),
+    )
+
+    for name in (
+        "stg_empresas",
+        "stg_licencas",
+        "stg_taxas",
+        "stg_processos",
+        "stg_certificados",
+        "stg_certificados_agendamentos",
+    ):
+        sa.Table(
+            name,
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("run_id", sa.String(36), nullable=False),
+            sa.Column("file_source", sa.String(255), nullable=False),
+            sa.Column("row_number", sa.Integer, nullable=False),
+            sa.Column("row_hash", sa.String(64), nullable=False),
+            sa.Column("payload", sa.JSON, nullable=False),
+            sa.Column("ingested_at", sa.String(25)),
+        )
+
+    metadata.create_all(engine)
+    return engine
+
+
+def sample_raw_data():
+    empresas = [
+        {
+            "EMPRESA": "ACME LTDA",
+            "CNPJ": "12.345.678/0001-90",
+            "MUNICÍPIO": "Anápolis",
+            "PORTE": "ME",
+            "CATEGORIA": "Serviços",
+            "SITUAÇÃO": "Ativa",
+            ROW_NUMBER_KEY: 2,
+        }
+    ]
+
+    licencas = [
+        {
+            "EMPRESA": "ACME LTDA",
+            "CNPJ": "12.345.678/0001-90",
+            "ALVARÁ FUNCIONAMENTO": "Regular",
+            "ALVARÁ VIG SANITÁRIA": "Em dia",
+            ROW_NUMBER_KEY: 2,
+        }
+    ]
+
+    taxas = [
+        {
+            "EMPRESA": "ACME LTDA",
+            "CNPJ": "12.345.678/0001-90",
+            "TAXA FUNCIONAMENTO": "Aberto",
+            ROW_NUMBER_KEY: 2,
+        }
+    ]
+
+    processos = {
+        "diversos": [
+            {
+                "EMPRESA": "ACME LTDA",
+                "CNPJ": "12.345.678/0001-90",
+                "PROTOCOLO": "PROC-123",
+                "DATA SOLICITAÇÃO": "01/02/2024",
+                "SITUAÇÃO": "EM ANÁLISE",
+                "OPERAÇÃO": "INSCRIÇÃO",
+                "ÓRGÃO": "PREFEITURA",
+                ROW_NUMBER_KEY: 2,
+            },
+            {
+                "EMPRESA": "ACME LTDA",
+                "CNPJ": "12.345.678/0001-90",
+                "DATA SOLICITAÇÃO": "10/02/2024",
+                ROW_NUMBER_KEY: 5,
+            }
+        ],
+        "sanitario": [
+            {
+                "EMPRESA": "ACME LTDA",
+                "CNPJ": "12.345.678/0001-90",
+                "PROTOCOLO": "SAN-55",
+                "DATA SOLICITAÇÃO": "05/02/2024",
+                "SITUAÇÃO": "AGUARD DOCTO",
+                "SERVIÇO": "RENOVAÇÃO",
+                "TAXA": "Pago",
+                "NOTIFICAÇÃO": "SEM PENDÊNCIAS",
+                "DATA VAL": "05/08/2024",
+                ROW_NUMBER_KEY: 3,
+            }
+        ],
+    }
+
+    return {
+        "empresas": empresas,
+        "licencas": licencas,
+        "taxas": taxas,
+        "processos": processos,
+    }
+
+
+def test_upsert_idempotent(engine, contract):
+    raw = sample_raw_data()
+    normalized = transform(raw, contract)
+
+    first = run_loader(
+        engine,
+        normalized,
+        run_id="run-1",
+        file_source="teste.xlsx",
+        dry_run=False,
+    )
+    assert any(item["action"] == "insert" and item["table"] == "empresas" for item in first)
+
+    second = run_loader(
+        engine,
+        normalized,
+        run_id="run-2",
+        file_source="teste.xlsx",
+        dry_run=False,
+    )
+    assert any(item["action"] == "skip" and item["table"] == "empresas" for item in second)
+
+    # Update taxa status to trigger update
+    raw["taxas"][0]["TAXA FUNCIONAMENTO"] = "Pago"
+    normalized_update = transform(raw, contract)
+    third = run_loader(
+        engine,
+        normalized_update,
+        run_id="run-3",
+        file_source="teste.xlsx",
+        dry_run=False,
+    )
+    assert any(item["action"] == "update" and item["table"] == "taxas" for item in third)
+
+
+def test_invalid_enum(contract):
+    raw = sample_raw_data()
+    raw["processos"]["diversos"][0]["SITUAÇÃO"] = "INVALIDO"
+    with pytest.raises(TransformError):
+        transform(raw, contract)
+
+
+def test_invalid_date(contract):
+    raw = sample_raw_data()
+    raw["processos"]["diversos"][0]["DATA SOLICITAÇÃO"] = "32/13/2024"
+    with pytest.raises(TransformError):
+        transform(raw, contract)
+
+
+def test_placeholder_process_defaults(contract):
+    raw = sample_raw_data()
+    normalized = transform(raw, contract)
+    placeholder_row = next(
+        row
+        for row in normalized["processos"]
+        if row.row_number == 5
+    )
+    assert placeholder_row.payload["situacao"] == "PENDENTE"


### PR DESCRIPTION
## Summary
- default processo rows with missing status to the "PENDENTE" enum and relax enum helpers so optional fields can be absent without raising
- adjust natural-key handling for processos upserts and add a partial unique index to guard rows lacking protocolo and data
- extend ETL tests with a placeholder scenario and introduce the optional unique index migration for processos without protocolo/data

## Testing
- pytest tests/test_etl_basic.py

------
https://chatgpt.com/codex/tasks/task_e_68fbcef3b2c883268ecd405432caee5e