### PR TITLE
Add missing processos avulsos migrations

### DIFF
--- a/backend/etl/load_upsert.py
+++ b/backend/etl/load_upsert.py
@@ -12,7 +12,7 @@ from sqlalchemy.engine import Connection, Engine
 from .normalizers import make_row_hash, only_digits
 from .transform_normalize import NormalizedRow
 
-FINAL_TABLES = {"empresas", "licencas", "taxas", "processos"}
+FINAL_TABLES = {"empresas", "licencas", "taxas", "processos", "processos_avulsos"}
 
 def _coerce_jsonable(obj: Any) -> Any:
     """Converte objetos (date, Decimal, etc.) para tipos serializáveis em JSON.
@@ -28,11 +28,19 @@ def run(
 ) -> List[Dict[str, Any]]:
     with _transaction(engine, dry_run) as connection:
         metadata = sa.MetaData()
-        metadata.reflect(connection, only={
-            "empresas",
-            "licencas",
-            "taxas",
-            "processos",
+        inspector = sa.inspect(connection)
+        available_tables = set(inspector.get_table_names())
+
+        required_tables = {"empresas", "licencas", "taxas", "processos"}
+        missing_required = required_tables - available_tables
+        if missing_required:
+            raise ValueError(f"Tabelas obrigatórias ausentes: {', '.join(sorted(missing_required))}")
+
+        optional_tables = {
+            "processos_avulsos",
+            "stg_processos_avulsos",
+        }
+        tables_to_reflect = list(required_tables | optional_tables | {
             "stg_empresas",
             "stg_licencas",
             "stg_taxas",
@@ -40,6 +48,10 @@ def run(
             "stg_certificados",
             "stg_certificados_agendamentos",
         })
+        metadata.reflect(
+            connection,
+            only=[name for name in tables_to_reflect if name in available_tables],
+        )
         empresas_table = metadata.tables["empresas"]
         staging_tables = {
             name: metadata.tables[name]
@@ -48,9 +60,11 @@ def run(
                 "stg_licencas",
                 "stg_taxas",
                 "stg_processos",
+                "stg_processos_avulsos",
                 "stg_certificados",
                 "stg_certificados_agendamentos",
             )
+            if name in metadata.tables
         }
         results: List[Dict[str, Any]] = []
         empresa_cache: Dict[str, int] = {}
@@ -59,7 +73,10 @@ def run(
         for table in ordered_tables:
             rows = normalized.get(table, [])
             for item in rows:
-                staging_table = staging_tables[f"stg_{table}"]
+                stg_name = f"stg_{'processos_avulsos' if (table == 'processos' and _is_avulso(item.payload)) else table}"
+                if stg_name not in staging_tables:
+                    raise ValueError(f"Tabela de staging '{stg_name}' não encontrada")
+                staging_table = staging_tables[stg_name]
                 payload = dict(item.payload)
                 # coerção para JSON determinístico (datas → "YYYY-MM-DD", etc.)
                 payload_coerced = _coerce_jsonable(payload)
@@ -93,6 +110,7 @@ def run(
                     empresa_cache,
                     empresas_table,
                     metadata.tables[table],
+                    metadata.tables.get("processos_avulsos"),
                 )
                 results.append(
                     {
@@ -149,14 +167,23 @@ def _upsert_final(
     empresa_cache: Dict[str, int],
     empresas_table: sa.Table,
     table: sa.Table,
+    processos_avulsos_table: Optional[sa.Table] = None,
 ) -> tuple[str, List[str]]:
     final_payload = dict(payload)
     if table_name != "empresas":
-        empresa_id = _resolve_empresa_id(connection, empresas_table, empresa_cache, final_payload.get("empresa_cnpj"))
+        cnpj_norm = only_digits(final_payload.get("empresa_cnpj"))
+        if table_name == "processos" and (not cnpj_norm or len(cnpj_norm) not in (11, 14)):
+            return _upsert_processos_avulsos(connection, processos_avulsos_table, final_payload)
+        empresa_id = _resolve_empresa_id(connection, empresas_table, empresa_cache, cnpj_norm)
         if not empresa_id:
-            raise ValueError(f"Empresa não encontrada para CNPJ {final_payload.get('empresa_cnpj')}")
+            if table_name == "processos" and processos_avulsos_table is not None:
+                return _upsert_processos_avulsos(connection, processos_avulsos_table, final_payload)
+            raise ValueError(
+                f"Empresa não encontrada para documento {final_payload.get('empresa_cnpj')}"
+            )
         final_payload["empresa_id"] = empresa_id
         final_payload.pop("empresa_cnpj", None)
+        final_payload.pop("empresa_nome", None)
     else:
         empresa_id = None
 
@@ -190,9 +217,65 @@ def _resolve_empresa_id(
         sa.select(empresas_table.c.id).where(empresas_table.c.cnpj == normalized)
     ).scalar()
     if result is None:
-        raise ValueError(f"Empresa com CNPJ {normalized} não encontrada")
+        return None
     cache[normalized] = result
     return result
+
+
+def _upsert_processos_avulsos(
+    connection: Connection,
+    table: Optional[sa.Table],
+    payload: Dict[str, Any],
+) -> tuple[str, List[str]]:
+    if table is None:
+        raise ValueError("Tabela processos_avulsos não configurada na base")
+
+    final_payload = dict(payload)
+    documento = only_digits(final_payload.get("empresa_cnpj"))
+    final_payload["documento"] = documento or final_payload.get("empresa_cnpj")
+    final_payload.pop("empresa_cnpj", None)
+
+    select_stmt, natural_key_cols = _build_processos_avulsos_key(table, final_payload)
+    existing = connection.execute(select_stmt).mappings().first()
+
+    if existing is None:
+        _execute_insert(connection, table, final_payload, natural_key_cols)
+        return "insert", []
+
+    changed_fields = _diff(existing, final_payload, natural_key_cols)
+    if not changed_fields:
+        return "skip", []
+
+    _execute_update(connection, table, final_payload, natural_key_cols, existing)
+    return "update", changed_fields
+
+
+def _build_processos_avulsos_key(
+    table: sa.Table,
+    payload: Dict[str, Any],
+) -> tuple[sa.Select, Sequence[str]]:
+    protocolo = payload.get("protocolo")
+    if protocolo:
+        where_clause = sa.and_(table.c.protocolo == protocolo, table.c.tipo == payload["tipo"])
+        return sa.select(table).where(where_clause), ("protocolo", "tipo")
+
+    documento = payload.get("documento")
+    data_ref = payload.get("data_solicitacao")
+    if data_ref is not None:
+        where_clause = sa.and_(
+            table.c.documento == documento,
+            table.c.tipo == payload["tipo"],
+            table.c.data_solicitacao == data_ref,
+        )
+        return sa.select(table).where(where_clause), ("documento", "tipo", "data_solicitacao")
+
+    where_clause = sa.and_(
+        table.c.documento == documento,
+        table.c.tipo == payload["tipo"],
+        table.c.protocolo.is_(None),
+        table.c.data_solicitacao.is_(None),
+    )
+    return sa.select(table).where(where_clause), ("documento", "tipo")
 
 
 def _build_natural_key(
@@ -304,3 +387,8 @@ def _diff(existing: sa.RowMapping, payload: Dict[str, Any], natural_key_cols: Se
         if existing.get(key) != value:
             changed.append(key)
     return changed
+
+
+def _is_avulso(payload: Dict[str, Any]) -> bool:
+    c = only_digits(payload.get("empresa_cnpj"))
+    return (not c) or (len(c) not in (11, 14))

--- a/backend/etl/transform_normalize.py
+++ b/backend/etl/transform_normalize.py
@@ -107,8 +107,12 @@ def _transform_empresas(rows: Iterable[Dict[str, Any]], contract: ConfigContract
             continue
         empresa = normalize_text(mapped.get("EMPRESA"))
         municipio = normalize_text(mapped.get("MUNICIPIO"))
-        if not empresa or not municipio:
-            raise TransformError("Empresa ou município ausente para CNPJ %s" % cnpj)
+        porte = normalize_text(mapped.get("PORTE"))
+        if not empresa:
+            raise TransformError("Empresa ausente para documento %s" % cnpj)
+        # Para PF/CAEPF, aceite município vazio (sua regra operacional)
+        if not municipio and porte not in {"PF", "CAEPF"}:
+            raise TransformError("Município ausente para documento %s" % cnpj)
         payload: Dict[str, Any] = {
             "empresa": empresa,
             "cnpj": cnpj,

--- a/backend/migrations/versions/20251024_05_create_processos_avulsos.py
+++ b/backend/migrations/versions/20251024_05_create_processos_avulsos.py
@@ -1,0 +1,77 @@
+"""Create processos_avulsos table for orphan processes."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20251024_05_create_processos_avulsos"
+down_revision = "20251024_04_uq_proc_sem_protocolo_sem_data"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    situacao_enum = postgresql.ENUM(name="situacao_processo_enum", create_type=False)
+    operacao_enum = postgresql.ENUM(name="operacao_diversos_enum", create_type=False)
+    orgao_enum = postgresql.ENUM(name="orgao_diversos_enum", create_type=False)
+    alvara_enum = postgresql.ENUM(name="alvara_funcionamento_enum", create_type=False)
+    servico_enum = postgresql.ENUM(name="servico_sanitario_enum", create_type=False)
+    notificacao_enum = postgresql.ENUM(name="notificacao_sanitaria_enum", create_type=False)
+
+    op.create_table(
+        "processos_avulsos",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("documento", sa.String(length=30), nullable=False),
+        sa.Column("tipo", sa.String(length=50), nullable=False),
+        sa.Column("protocolo", sa.String(length=120), nullable=True),
+        sa.Column("data_solicitacao", sa.Date, nullable=True),
+        sa.Column("situacao", situacao_enum, nullable=False),
+        sa.Column("status_padrao", sa.String(length=120), nullable=True),
+        sa.Column("obs", sa.Text, nullable=True),
+        sa.Column("operacao", operacao_enum, nullable=True),
+        sa.Column("orgao", orgao_enum, nullable=True),
+        sa.Column("alvara", alvara_enum, nullable=True),
+        sa.Column("municipio", sa.String(length=120), nullable=True),
+        sa.Column("tpi", sa.String(length=120), nullable=True),
+        sa.Column("inscricao_imobiliaria", sa.String(length=120), nullable=True),
+        sa.Column("servico", servico_enum, nullable=True),
+        sa.Column("taxa", sa.String(length=120), nullable=True),
+        sa.Column("notificacao", notificacao_enum, nullable=True),
+        sa.Column("data_val", sa.Date, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            server_default=sa.text("now()"),
+            onupdate=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("protocolo", "tipo", name="uq_proc_avulso_protocolo_tipo"),
+    )
+
+    op.create_index(
+        "idx_proc_avulso_doc_tipo_data",
+        "processos_avulsos",
+        ["documento", "tipo", "data_solicitacao"],
+        unique=True,
+        postgresql_where=sa.text("data_solicitacao IS NOT NULL"),
+    )
+    op.create_index(
+        "idx_proc_avulso_doc_tipo_sem_data",
+        "processos_avulsos",
+        ["documento", "tipo"],
+        unique=True,
+        postgresql_where=sa.text("data_solicitacao IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_proc_avulso_doc_tipo_sem_data", table_name="processos_avulsos")
+    op.drop_index("idx_proc_avulso_doc_tipo_data", table_name="processos_avulsos")
+    op.drop_table("processos_avulsos")

--- a/backend/migrations/versions/20251024_06_stg_processos_avulsos.py
+++ b/backend/migrations/versions/20251024_06_stg_processos_avulsos.py
@@ -1,0 +1,36 @@
+"""Create staging table for processos_avulsos."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20251024_06_stg_processos_avulsos"
+down_revision = "20251024_05_create_processos_avulsos"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    table_name = "stg_processos_avulsos"
+    op.create_table(
+        table_name,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("run_id", sa.String(length=36), nullable=False),
+        sa.Column("file_source", sa.String(length=255), nullable=False),
+        sa.Column("row_number", sa.Integer, nullable=False),
+        sa.Column("row_hash", sa.String(length=64), nullable=False),
+        sa.Column("payload", postgresql.JSONB, nullable=False),
+        sa.Column(
+            "ingested_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("idx_stg_processos_avulsos_run_id", table_name, ["run_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_stg_processos_avulsos_run_id", table_name="stg_processos_avulsos")
+    op.drop_table("stg_processos_avulsos")

--- a/backend/migrations/versions/20251028_01_empresas_doc_relax_and_normalize.py
+++ b/backend/migrations/versions/20251028_01_empresas_doc_relax_and_normalize.py
@@ -1,0 +1,34 @@
+"""Normalize empresas.cnpj and allow 11 (CPF) or 14 (CNPJ/CAEPF) digits."""
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20251028_01_empresas_doc_relax_and_normalize"
+down_revision = "20251024_06_stg_processos_avulsos"  # ajuste para sua cadeia
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE empresas SET cnpj = regexp_replace(cnpj, '\\D', '', 'g');")
+    op.execute("ALTER TABLE empresas DROP CONSTRAINT IF EXISTS ck_empresas_cnpj_digits;")
+    op.execute("ALTER TABLE empresas DROP CONSTRAINT IF EXISTS ck_empresas_cnpj_len;")
+    op.execute(
+        """
+        ALTER TABLE empresas
+        ADD CONSTRAINT ck_empresas_cnpj_digits_len
+        CHECK (cnpj ~ '^[0-9]{11}$' OR cnpj ~ '^[0-9]{14}$')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE empresas DROP CONSTRAINT IF EXISTS ck_empresas_cnpj_digits_len;")
+    op.execute(
+        """
+        ALTER TABLE empresas
+        ADD CONSTRAINT ck_empresas_cnpj_len
+        CHECK (cnpj ~ '^[0-9]{14}$')
+        """
+    )


### PR DESCRIPTION
## Summary
- create the `processos_avulsos` table with unique indexes that match the loader's upsert keys
- add the `stg_processos_avulsos` staging table to keep the ETL pipeline aligned with the new final table

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6900f27af7588326bd78cb65c4d6b91e