### PR TITLE
Flatten ListObject output for single-table sheets

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -11,6 +11,9 @@ sheet_names:
 # Nomes das Tabelas (ListObjects) dentro da aba PROCESSOS
 # — estas strings devem bater exatamente com os nomes dos ListObjects no Excel
 table_names:
+  empresas:
+    principal: "Principal"
+
   processos:
     diversos: "Diversos"
     funcionamento: "Funcionamento"

--- a/backend/etl/extract_xlsm.py
+++ b/backend/etl/extract_xlsm.py
@@ -47,11 +47,16 @@ def _load_excel(path: Path, contract: ConfigContract) -> Dict[str, Any]:
             # sem aba correspondente — pula silenciosamente (mantém compat)
             continue
         worksheet = workbook[chosen_sheet]
-        if logical_sheet in {"processos", "uteis", "certificados", "certificados_agendamentos"}:
-            tables_map = contract.table_names.get(logical_sheet, {})
-            data[logical_sheet] = _load_tables(worksheet, tables_map)
-        else:
-            data[logical_sheet] = _load_worksheet(worksheet)
+        tables_map = contract.table_names.get(logical_sheet, {})
+        if tables_map:
+            table_data = _load_tables(worksheet, tables_map)
+            if table_data:
+                if logical_sheet in contract.column_aliases:
+                    data[logical_sheet] = _flatten_table_rows(table_data)
+                else:
+                    data[logical_sheet] = table_data
+                continue
+        data[logical_sheet] = _load_worksheet(worksheet)
     return data
 
 
@@ -72,6 +77,13 @@ def _load_tables(worksheet, tables_map: Dict[str, str]) -> Dict[str, List[Dict[s
         rows = _rows_from_cells(cells)
         tables[logical_table] = rows
     return tables
+
+
+def _flatten_table_rows(tables: Dict[str, List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    flattened: List[Dict[str, Any]] = []
+    for rows in tables.values():
+        flattened.extend(rows)
+    return flattened
 
 
 def _load_worksheet(worksheet) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- ensure Excel extraction flattens ListObject data into plain row lists whenever the sheet exposes direct column aliases
- keep multi-table sheets returning table-keyed dictionaries so downstream consumers remain unchanged

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69038fcaa40883269dc97eb0c278498c