### PR TITLE
Add auth org migrations and update ETL org handling

### DIFF
--- a/backend/etl/load_upsert.py
+++ b/backend/etl/load_upsert.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -11,6 +12,8 @@ from sqlalchemy.engine import Connection, Engine
 
 from .normalizers import make_row_hash, only_digits
 from .transform_normalize import NormalizedRow
+
+ORG_ID = os.getenv("ORG_ID", "00000000-0000-0000-0000-000000000001")
 
 FINAL_TABLES = {"empresas", "licencas", "taxas", "processos", "processos_avulsos"}
 
@@ -86,6 +89,7 @@ def run(
                     raise ValueError(f"Tabela de staging '{stg_name}' não encontrada")
                 staging_table = staging_tables[stg_name]
                 payload = dict(item.payload)
+                payload.setdefault("org_id", ORG_ID)
                 # coerção para JSON determinístico (datas → "YYYY-MM-DD", etc.)
                 payload_coerced = _coerce_jsonable(payload)
                 payload_json = json.dumps(payload_coerced, sort_keys=True, ensure_ascii=False)
@@ -178,11 +182,18 @@ def _upsert_final(
     processos_avulsos_table: Optional[sa.Table] = None,
 ) -> tuple[str, List[str]]:
     final_payload = dict(payload)
+    final_payload.setdefault("org_id", ORG_ID)
     if table_name != "empresas":
         cnpj_norm = only_digits(final_payload.get("empresa_cnpj"))
         if table_name == "processos" and (not cnpj_norm or len(cnpj_norm) not in (11, 14)):
             return _upsert_processos_avulsos(connection, processos_avulsos_table, final_payload)
-        empresa_id = _resolve_empresa_id(connection, empresas_table, empresa_cache, cnpj_norm)
+        empresa_id = _resolve_empresa_id(
+            connection,
+            empresas_table,
+            empresa_cache,
+            final_payload.get("org_id"),
+            cnpj_norm,
+        )
         if not empresa_id:
             if table_name == "processos" and processos_avulsos_table is not None:
                 return _upsert_processos_avulsos(connection, processos_avulsos_table, final_payload)
@@ -216,19 +227,27 @@ def _resolve_empresa_id(
     connection: Connection,
     empresas_table: sa.Table,
     cache: Dict[str, int],
+    org_id: Optional[str],
     cnpj: Optional[str],
 ) -> Optional[int]:
+    org = org_id or ORG_ID
     normalized = only_digits(cnpj)
     if not normalized:
         return None
-    if normalized in cache:
-        return cache[normalized]
+    cache_key = f"{org}:{normalized}"
+    if cache_key in cache:
+        return cache[cache_key]
     result = connection.execute(
-        sa.select(empresas_table.c.id).where(empresas_table.c.cnpj == normalized)
+        sa.select(empresas_table.c.id).where(
+            sa.and_(
+                empresas_table.c.cnpj == normalized,
+                empresas_table.c.org_id == org,
+            )
+        )
     ).scalar()
     if result is None:
         return None
-    cache[normalized] = result
+    cache[cache_key] = result
     return result
 
 
@@ -241,6 +260,7 @@ def _upsert_processos_avulsos(
         raise ValueError("Tabela processos_avulsos não configurada na base")
 
     final_payload = dict(payload)
+    final_payload.setdefault("org_id", ORG_ID)
     documento = only_digits(final_payload.get("empresa_cnpj"))
     final_payload["documento"] = documento or final_payload.get("empresa_cnpj")
     final_payload.pop("empresa_cnpj", None)
@@ -271,46 +291,56 @@ def _build_natural_key(
     payload: Dict[str, Any],
     empresa_id: Optional[int],
 ) -> tuple[sa.Select, Sequence[str], Optional[sa.sql.ClauseElement]]:
+    org_id = payload.get("org_id", ORG_ID)
+    payload.setdefault("org_id", org_id)
     if table_name == "empresas":
-        cols = (table.c.cnpj,)
-        where_clause = table.c.cnpj == payload["cnpj"]
-        return sa.select(table).where(where_clause), ("cnpj",), None
+        cols = (table.c.org_id, table.c.cnpj)
+        where_clause = sa.and_(
+            table.c.org_id == org_id,
+            table.c.cnpj == payload["cnpj"],
+        )
+        return sa.select(table).where(where_clause), ("org_id", "cnpj"), None
     if table_name == "taxas":
         if "data_referencia" in table.c and payload.get("data_referencia"):
             where_clause = sa.and_(
+                table.c.org_id == org_id,
                 table.c.empresa_id == payload["empresa_id"],
                 table.c.tipo == payload["tipo"],
                 table.c.data_referencia == payload["data_referencia"],
             )
             return (
                 sa.select(table).where(where_clause),
-                ("empresa_id", "tipo", "data_referencia"),
+                ("org_id", "empresa_id", "tipo", "data_referencia"),
                 None,
             )
         where_clause = sa.and_(
+            table.c.org_id == org_id,
             table.c.empresa_id == payload["empresa_id"],
             table.c.tipo == payload["tipo"],
         )
-        return sa.select(table).where(where_clause), ("empresa_id", "tipo"), None
+        return sa.select(table).where(where_clause), ("org_id", "empresa_id", "tipo"), None
     if table_name == "licencas":
         where_clause = sa.and_(
+            table.c.org_id == org_id,
             table.c.empresa_id == payload["empresa_id"],
             table.c.tipo == payload["tipo"],
         )
-        return sa.select(table).where(where_clause), ("empresa_id", "tipo"), None
+        return sa.select(table).where(where_clause), ("org_id", "empresa_id", "tipo"), None
     if table_name == "processos":
         protocolo = payload.get("protocolo")
         if protocolo:  # usa índice parcial: protocolo IS NOT NULL
             where_clause = sa.and_(
+                table.c.org_id == org_id,
                 table.c.protocolo == protocolo,
                 table.c.tipo == payload["tipo"],
             )
             index_where = table.c.protocolo.isnot(None)
-            return sa.select(table).where(where_clause), ("protocolo", "tipo"), index_where
+            return sa.select(table).where(where_clause), ("org_id", "protocolo", "tipo"), index_where
 
         # sem protocolo: duas chaves naturais
         if payload.get("data_solicitacao"):
             where_clause = sa.and_(
+                table.c.org_id == org_id,
                 table.c.empresa_id == payload["empresa_id"],
                 table.c.tipo == payload["tipo"],
                 table.c.data_solicitacao == payload["data_solicitacao"],
@@ -321,12 +351,13 @@ def _build_natural_key(
             )
             return (
                 sa.select(table).where(where_clause),
-                ("empresa_id", "tipo", "data_solicitacao"),
+                ("org_id", "empresa_id", "tipo", "data_solicitacao"),
                 index_where,
             )
 
         # sem protocolo e sem data
         where_clause = sa.and_(
+            table.c.org_id == org_id,
             table.c.empresa_id == payload["empresa_id"],
             table.c.tipo == payload["tipo"],
         )
@@ -334,19 +365,21 @@ def _build_natural_key(
             table.c.protocolo.is_(None),
             table.c.data_solicitacao.is_(None),
         )
-        return sa.select(table).where(where_clause), ("empresa_id", "tipo"), index_where
+        return sa.select(table).where(where_clause), ("org_id", "empresa_id", "tipo"), index_where
     if table_name == "processos_avulsos":
         protocolo = payload.get("protocolo")
         if protocolo:
             where_clause = sa.and_(
+                table.c.org_id == org_id,
                 table.c.protocolo == protocolo,
                 table.c.tipo == payload["tipo"],
             )
-            return sa.select(table).where(where_clause), ("protocolo", "tipo"), None
+            return sa.select(table).where(where_clause), ("org_id", "protocolo", "tipo"), None
 
         data_ref = payload.get("data_solicitacao")
         if data_ref is not None:
             where_clause = sa.and_(
+                table.c.org_id == org_id,
                 table.c.documento == payload["documento"],
                 table.c.tipo == payload["tipo"],
                 table.c.data_solicitacao == data_ref,
@@ -354,11 +387,12 @@ def _build_natural_key(
             )
             return (
                 sa.select(table).where(where_clause),
-                ("documento", "tipo", "data_solicitacao"),
+                ("org_id", "documento", "tipo", "data_solicitacao"),
                 table.c.protocolo.is_(None),
             )
 
         where_clause = sa.and_(
+            table.c.org_id == org_id,
             table.c.documento == payload["documento"],
             table.c.tipo == payload["tipo"],
             table.c.data_solicitacao.is_(None),
@@ -366,7 +400,7 @@ def _build_natural_key(
         )
         return (
             sa.select(table).where(where_clause),
-            ("documento", "tipo"),
+            ("org_id", "documento", "tipo"),
             sa.and_(table.c.protocolo.is_(None), table.c.data_solicitacao.is_(None)),
         )
     raise ValueError(f"Tabela não suportada: {table_name}")

--- a/backend/migrations/versions/20251103_00_auth_core.py
+++ b/backend/migrations/versions/20251103_00_auth_core.py
@@ -1,0 +1,76 @@
+"""Auth core: orgs + users, seed default org and master user.
+
+Revision ID: 20251103_00_auth_core
+Revises: 20251030_02_processos_protocolo_nullable
+Create Date: 2025-11-03 09:40:00-03
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+import os
+
+# revision identifiers
+revision = "20251103_00_auth_core"
+down_revision = "20251030_02_processos_protocolo_nullable"
+branch_labels = None
+depends_on = None
+
+DEFAULT_ORG_ID = os.getenv("ORG_ID", "00000000-0000-0000-0000-000000000001")
+DEFAULT_ORG_NAME = os.getenv("ORG_NAME", "Neto Contabilidade")
+MASTER_EMAIL = os.getenv("MASTER_USER_EMAIL", "cadastro@netocontabilidade.com.br")
+MASTER_NAME = os.getenv("MASTER_USER_NAME", "Maria Clara")
+
+
+def upgrade():
+    # orgs
+    op.create_table(
+        "orgs",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()")),
+    )
+    op.create_index("uq_orgs_name", "orgs", ["name"], unique=True)
+
+    # users
+    role_enum = postgresql.ENUM("OWNER", "ADMIN", "STAFF", "VIEWER", name="user_role_enum", create_type=True)
+    role_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer, primary_key=True, nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=False), sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("email", sa.String(length=320), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("role", role_enum, nullable=False, server_default="OWNER"),
+        sa.Column("is_active", sa.Boolean, nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()")),
+    )
+    op.create_index("uq_users_org_email", "users", ["org_id", "email"], unique=True)
+
+    # seeds idempotentes
+    op.execute(f"""
+    INSERT INTO orgs (id, name)
+    VALUES ('{DEFAULT_ORG_ID}'::uuid, '{DEFAULT_ORG_NAME}')
+    ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+    """)
+
+    op.execute(f"""
+    INSERT INTO users (org_id, email, name, role, is_active)
+    VALUES ('{DEFAULT_ORG_ID}'::uuid, '{MASTER_EMAIL}', '{MASTER_NAME}', 'OWNER', TRUE)
+    ON CONFLICT (org_id, email) DO UPDATE
+      SET name = EXCLUDED.name, role = EXCLUDED.role, is_active = EXCLUDED.is_active;
+    """)
+
+
+def downgrade():
+    op.drop_index("uq_users_org_email", table_name="users")
+    op.drop_table("users")
+    op.drop_index("uq_orgs_name", table_name="orgs")
+    op.drop_table("orgs")
+    try:
+        role_enum = postgresql.ENUM("OWNER", "ADMIN", "STAFF", "VIEWER", name="user_role_enum")
+        role_enum.drop(op.get_bind(), checkfirst=True)
+    except Exception:
+        pass

--- a/backend/migrations/versions/20251103_01_add_org_id_and_uniques.py
+++ b/backend/migrations/versions/20251103_01_add_org_id_and_uniques.py
@@ -1,0 +1,187 @@
+"""Add org_id to core tables and (re)create uniques per organization.
+
+Revision ID: 20251103_01_add_org_id_and_uniques
+Revises: 20251103_00_auth_core
+Create Date: 2025-11-03 09:45:00-03
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+import os
+
+revision = "20251103_01_add_org_id_and_uniques"
+down_revision = "20251103_00_auth_core"
+branch_labels = None
+depends_on = None
+
+DEFAULT_ORG_ID = os.getenv("ORG_ID", "00000000-0000-0000-0000-000000000001")
+
+TABLES_FINAL = [
+    "empresas",
+    "licencas",
+    "taxas",
+    "processos",
+    "processos_avulsos",
+]
+TABLES_STG = [
+    "stg_empresas",
+    "stg_licencas",
+    "stg_taxas",
+    "stg_processos",
+]
+
+
+def _add_org_id(table):
+    op.add_column(table, sa.Column("org_id", postgresql.UUID(as_uuid=False), nullable=True))
+    op.create_foreign_key(
+        f"fk_{table}_org", table, "orgs", ["org_id"], ["id"], ondelete="CASCADE"
+    )
+    op.execute(f"UPDATE {table} SET org_id = '{DEFAULT_ORG_ID}'::uuid WHERE org_id IS NULL;")
+    op.alter_column(table, "org_id", nullable=False)
+
+
+def upgrade():
+    # 1) adicionar org_id (finais e staging)
+    for t in TABLES_FINAL:
+        _add_org_id(t)
+    for t in TABLES_STG:
+        op.add_column(t, sa.Column("org_id", postgresql.UUID(as_uuid=False), nullable=True))
+        op.execute(f"UPDATE {t} SET org_id = '{DEFAULT_ORG_ID}'::uuid WHERE org_id IS NULL;")
+        op.alter_column(t, "org_id", nullable=False)
+
+    # 2) soltar unicidades antigas (se existirem)
+    safe_drops = [
+        # EMPRESAS
+        ("empresas", "uq_empresas_cnpj"),
+        ("empresas", "uq_empresas_org_cnpj"),
+        # LICENCAS
+        ("licencas", "uq_licencas_empresa_tipo"),
+        ("licencas", "uq_licencas_org_empresa_tipo"),
+        # TAXAS
+        ("taxas", "uq_taxas_empresa_tipo"),
+        ("taxas", "uq_taxas_org_empresa_tipo"),
+        # PROCESSOS (variantes)
+        ("processos", "uq_processos_protocolo_tipo"),
+        ("processos", "uq_proc_protocolo_tipo"),
+        ("processos", "uq_proc_empresa_tipo_com_data"),
+        ("processos", "uq_proc_empresa_tipo_sem_data"),
+        ("processos", "uq_proc_empresa_tipo_sem_protocolo_sem_data"),
+        # AVULSOS
+        ("processos_avulsos", "uq_proc_avulso_protocolo_tipo"),
+        ("processos_avulsos", "uq_proc_avulso_doc_tipo_data"),
+        ("processos_avulsos", "idx_proc_avulso_doc_tipo_sem_data"),
+        ("processos_avulsos", "idx_proc_avulso_doc_tipo_data"),
+        ("processos_avulsos", "uq_proc_avulsos_doc_tipo_data"),
+    ]
+    for table, idx in safe_drops:
+        try:
+            op.execute(f'DROP INDEX IF EXISTS {idx};')
+        except Exception:
+            pass
+        try:
+            op.execute(f'ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {idx};')
+        except Exception:
+            pass
+
+    # 3) recriar unicidades por organização
+
+    # EMPRESAS: CNPJ/CPF/CAEPF normalizado já está no pipeline
+    op.create_index(
+        "uq_empresas_org_cnpj", "empresas",
+        ["org_id", "cnpj"], unique=True
+    )
+
+    # LICENCAS: uma por org + empresa + tipo
+    op.create_index(
+        "uq_licencas_org_empresa_tipo", "licencas",
+        ["org_id", "empresa_id", "tipo"], unique=True
+    )
+
+    # TAXAS: uma por org + empresa + tipo
+    op.create_index(
+        "uq_taxas_org_empresa_tipo", "taxas",
+        ["org_id", "empresa_id", "tipo"], unique=True
+    )
+
+    # PROCESSOS:
+    # 3.1 protocolo presente => único por org + (protocolo, tipo)
+    op.create_index(
+        "uq_proc_org_protocolo_tipo",
+        "processos",
+        ["org_id", "protocolo", "tipo"],
+        unique=True,
+        postgresql_where=sa.text("protocolo IS NOT NULL"),
+    )
+    # 3.2 sem protocolo e COM data => único por org + (empresa_id, tipo, data)
+    op.create_index(
+        "uq_proc_org_empresa_tipo_data",
+        "processos",
+        ["org_id", "empresa_id", "tipo", "data_solicitacao"],
+        unique=True,
+        postgresql_where=sa.text("protocolo IS NULL AND data_solicitacao IS NOT NULL"),
+    )
+    # 3.3 sem protocolo e SEM data => único por org + (empresa_id, tipo)
+    op.create_index(
+        "uq_proc_org_empresa_tipo_sem_data",
+        "processos",
+        ["org_id", "empresa_id", "tipo"],
+        unique=True,
+        postgresql_where=sa.text("protocolo IS NULL AND data_solicitacao IS NULL"),
+    )
+
+    # PROCESSOS AVULSOS (sem empresa_id):
+    # 3.4 protocolo presente => único por org + (protocolo, tipo)
+    op.create_index(
+        "uq_proc_avulso_org_protocolo_tipo",
+        "processos_avulsos",
+        ["org_id", "protocolo", "tipo"],
+        unique=True,
+        postgresql_where=sa.text("protocolo IS NOT NULL"),
+    )
+    # 3.5 sem protocolo e COM data => único por org + (documento, tipo, data)
+    op.create_index(
+        "uq_proc_avulso_org_doc_tipo_data",
+        "processos_avulsos",
+        ["org_id", "documento", "tipo", "data_solicitacao"],
+        unique=True,
+        postgresql_where=sa.text("protocolo IS NULL AND data_solicitacao IS NOT NULL"),
+    )
+    # 3.6 sem protocolo e SEM data => único por org + (documento, tipo)
+    op.create_index(
+        "uq_proc_avulso_org_doc_tipo_sem_data",
+        "processos_avulsos",
+        ["org_id", "documento", "tipo"],
+        unique=True,
+        postgresql_where=sa.text("protocolo IS NULL AND data_solicitacao IS NULL"),
+    )
+
+
+def downgrade():
+    # drop novos índices
+    for idx in [
+        "uq_empresas_org_cnpj",
+        "uq_licencas_org_empresa_tipo",
+        "uq_taxas_org_empresa_tipo",
+        "uq_proc_org_protocolo_tipo",
+        "uq_proc_org_empresa_tipo_data",
+        "uq_proc_org_empresa_tipo_sem_data",
+        "uq_proc_avulso_org_protocolo_tipo",
+        "uq_proc_avulso_org_doc_tipo_data",
+        "uq_proc_avulso_org_doc_tipo_sem_data",
+    ]:
+        op.execute(f"DROP INDEX IF EXISTS {idx};")
+
+    # remover FKs e colunas org_id
+    for t in TABLES_STG:
+        try:
+            op.drop_constraint(f"fk_{t}_org", t, type_="foreignkey")
+        except Exception:
+            pass
+        op.drop_column(t, "org_id")
+
+    for t in TABLES_FINAL:
+        try:
+            op.drop_constraint(f"fk_{t}_org", t, type_="foreignkey")
+        except Exception:
+            pass
+        op.drop_column(t, "org_id")


### PR DESCRIPTION
## Summary
- add core auth migration defining orgs/users with default seeds
- introduce org_id columns and per-org unique indexes across core and staging tables
- update the ETL load step to inject org_id and use per-org natural keys for upserts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690914881fe483269337068d63714abc