### PR TITLE
Add Alembic migration script template

### DIFF
--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,23 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision if down_revision else None}
+Create Date: ${create_date}
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "${up_revision}"
+down_revision = ${repr(down_revision) if down_revision else None}
+branch_labels = ${repr(branch_labels) if branch_labels else None}
+depends_on = ${repr(depends_on) if depends_on else None}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}


### PR DESCRIPTION
## Summary
- add the standard Alembic migration script template at backend/migrations/script.py.mako

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_690d04b6babc8326aca84a7eb25cdaf5