### PR TITLE
Allow views to skip org filtering when current_org is unset

### DIFF
--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,23 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision if down_revision else None}
+Create Date: ${create_date}
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "${up_revision}"
+down_revision = ${repr(down_revision) if down_revision else None}
+branch_labels = ${repr(branch_labels) if branch_labels else None}
+depends_on = ${repr(depends_on) if depends_on else None}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations/versions/20251106_01_s3_api_views_org_audit.py
+++ b/backend/migrations/versions/20251106_01_s3_api_views_org_audit.py
@@ -75,11 +75,13 @@ def _create_views() -> None:
         LEFT JOIN licencas l ON l.empresa_id = e.id AND l.org_id = e.org_id
         LEFT JOIN taxas t ON t.empresa_id = e.id AND t.org_id = e.org_id
         LEFT JOIN processos p ON p.empresa_id = e.id AND p.org_id = e.org_id
-        WHERE e.org_id = current_setting('app.current_org')::uuid
+        WHERE current_setting('app.current_org', true) IS NULL
+          OR e.org_id = current_setting('app.current_org')::uuid
         GROUP BY e.id, e.org_id, e.empresa, e.cnpj, e.municipio, e.porte, e.categoria,
                  e.status_empresas, e.situacao, e.debito, e.certificado, e.updated_at;
         """
     )
+    op.execute("ALTER VIEW v_empresas OWNER TO CURRENT_USER;")
 
     op.execute(
         """
@@ -97,9 +99,11 @@ def _create_views() -> None:
             CASE WHEN l.validade IS NULL THEN NULL ELSE (l.validade - CURRENT_DATE) END AS dias_para_vencer
         FROM licencas l
         JOIN empresas e ON e.id = l.empresa_id AND e.org_id = l.org_id
-        WHERE e.org_id = current_setting('app.current_org')::uuid;
+        WHERE current_setting('app.current_org', true) IS NULL
+          OR e.org_id = current_setting('app.current_org')::uuid;
         """
     )
+    op.execute("ALTER VIEW v_licencas_status OWNER TO CURRENT_USER;")
 
     op.execute(
         """
@@ -117,9 +121,11 @@ def _create_views() -> None:
             (LOWER(COALESCE(t.status, '')) LIKE 'pago%') AS esta_pago
         FROM taxas t
         JOIN empresas e ON e.id = t.empresa_id AND e.org_id = t.org_id
-        WHERE e.org_id = current_setting('app.current_org')::uuid;
+        WHERE current_setting('app.current_org', true) IS NULL
+          OR e.org_id = current_setting('app.current_org')::uuid;
         """
     )
+    op.execute("ALTER VIEW v_taxas_status OWNER TO CURRENT_USER;")
 
     op.execute(
         """
@@ -151,9 +157,11 @@ def _create_views() -> None:
             END AS status_cor
         FROM processos p
         JOIN empresas e ON e.id = p.empresa_id AND e.org_id = p.org_id
-        WHERE e.org_id = current_setting('app.current_org')::uuid;
+        WHERE current_setting('app.current_org', true) IS NULL
+          OR e.org_id = current_setting('app.current_org')::uuid;
         """
     )
+    op.execute("ALTER VIEW v_processos_resumo OWNER TO CURRENT_USER;")
 
     op.execute(
         """
@@ -170,7 +178,10 @@ def _create_views() -> None:
                 (l.validade - CURRENT_DATE) AS dias_restantes
             FROM licencas l
             JOIN empresas e ON e.id = l.empresa_id AND e.org_id = l.org_id
-            WHERE e.org_id = current_setting('app.current_org')::uuid
+            WHERE (
+                current_setting('app.current_org', true) IS NULL
+                OR e.org_id = current_setting('app.current_org')::uuid
+            )
               AND l.validade IS NOT NULL
               AND l.validade <= CURRENT_DATE + INTERVAL '30 days'
             UNION ALL
@@ -185,7 +196,10 @@ def _create_views() -> None:
                 CASE WHEN t.vencimento_tpi IS NULL THEN NULL ELSE (t.vencimento_tpi - CURRENT_DATE) END AS dias_restantes
             FROM taxas t
             JOIN empresas e ON e.id = t.empresa_id AND e.org_id = t.org_id
-            WHERE e.org_id = current_setting('app.current_org')::uuid
+            WHERE (
+                current_setting('app.current_org', true) IS NULL
+                OR e.org_id = current_setting('app.current_org')::uuid
+            )
               AND LOWER(COALESCE(t.status, '')) NOT LIKE 'pago%'
             UNION ALL
             SELECT
@@ -199,7 +213,10 @@ def _create_views() -> None:
                 CASE WHEN p.prazo IS NULL THEN NULL ELSE (p.prazo - CURRENT_DATE) END AS dias_restantes
             FROM processos p
             JOIN empresas e ON e.id = p.empresa_id AND e.org_id = p.org_id
-            WHERE e.org_id = current_setting('app.current_org')::uuid
+            WHERE (
+                current_setting('app.current_org', true) IS NULL
+                OR e.org_id = current_setting('app.current_org')::uuid
+            )
               AND p.prazo IS NOT NULL
               AND p.prazo <= CURRENT_DATE + INTERVAL '30 days'
         )
@@ -216,54 +233,56 @@ def _create_views() -> None:
         FROM base;
         """
     )
+    op.execute("ALTER VIEW v_alertas_vencendo_30d OWNER TO CURRENT_USER;")
 
     op.execute(
         """
         CREATE OR REPLACE VIEW v_grupos_kpis AS
-        SELECT
-            e.org_id,
-            'empresas'::text AS grupo,
-            'total_empresas'::text AS chave,
-            COUNT(*)::bigint AS valor
-        FROM empresas e
-        WHERE e.org_id = current_setting('app.current_org')::uuid
-        GROUP BY e.org_id
-        UNION ALL
-        SELECT
-            e.org_id,
-            'empresas'::text AS grupo,
-            'sem_certificado'::text AS chave,
-            COUNT(*) FILTER (
-                WHERE COALESCE(e.certificado, '') NOT ILIKE 'sim%'
-            )::bigint AS valor
-        FROM empresas e
-        WHERE e.org_id = current_setting('app.current_org')::uuid
-        GROUP BY e.org_id
-        UNION ALL
-        SELECT
-            l.org_id,
-            'licencas'::text AS grupo,
-            'licencas_vencidas'::text AS chave,
-            COUNT(*)::bigint AS valor
-        FROM licencas l
-        WHERE l.org_id = current_setting('app.current_org')::uuid
-          AND l.validade IS NOT NULL
-          AND l.validade < CURRENT_DATE
-        GROUP BY l.org_id
-        UNION ALL
-        SELECT
-            t.org_id,
-            'taxas'::text AS grupo,
-            'tpi_pendente'::text AS chave,
-            COUNT(*) FILTER (
-                WHERE (LOWER(COALESCE(t.status, '')) NOT LIKE 'pago%')
-                  AND (UPPER(t.tipo) LIKE 'TPI%')
-            )::bigint AS valor
-        FROM taxas t
-        WHERE t.org_id = current_setting('app.current_org')::uuid
-        GROUP BY t.org_id;
+        WITH emp AS (
+            SELECT
+                e.org_id,
+                COUNT(*)::bigint AS total_empresas,
+                COUNT(*) FILTER (
+                    WHERE COALESCE(e.certificado, '') NOT ILIKE 'sim%'
+                )::bigint AS sem_certificado
+            FROM empresas e
+            GROUP BY e.org_id
+        ),
+        lic_venc AS (
+            SELECT
+                l.org_id,
+                COUNT(*) FILTER (
+                    WHERE l.validade IS NOT NULL AND l.validade < CURRENT_DATE
+                )::bigint AS licencas_vencidas
+            FROM licencas l
+            GROUP BY l.org_id
+        ),
+        tpi_pend AS (
+            SELECT
+                t.org_id,
+                COUNT(*) FILTER (
+                    WHERE (LOWER(COALESCE(t.status, '')) NOT LIKE 'pago%')
+                      AND (UPPER(t.tipo) LIKE 'TPI%')
+                )::bigint AS tpi_pendente
+            FROM taxas t
+            GROUP BY t.org_id
+        ),
+        unioned AS (
+            SELECT emp.org_id, 'empresas'::text AS grupo, 'total_empresas'::text AS chave, emp.total_empresas::bigint AS valor FROM emp
+            UNION ALL
+            SELECT emp.org_id, 'empresas'::text AS grupo, 'sem_certificado'::text AS chave, emp.sem_certificado::bigint AS valor FROM emp
+            UNION ALL
+            SELECT l.org_id, 'licencas'::text AS grupo, 'licencas_vencidas'::text AS chave, COALESCE(l.licencas_vencidas, 0)::bigint AS valor FROM lic_venc l
+            UNION ALL
+            SELECT t.org_id, 'taxas'::text AS grupo, 'tpi_pendente'::text AS chave, COALESCE(t.tpi_pendente, 0)::bigint AS valor FROM tpi_pend t
+        )
+        SELECT *
+        FROM unioned
+        WHERE current_setting('app.current_org', true) IS NULL
+           OR org_id = current_setting('app.current_org')::uuid;
         """
     )
+    op.execute("ALTER VIEW v_grupos_kpis OWNER TO CURRENT_USER;")
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary
- relax each tenant filter to allow all rows when `app.current_org` is not configured
- wrap the alert subqueries so additional predicates still apply after the relaxed filter

## Testing
- not run (SQL text updates only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d04b6babc8326aca84a7eb25cdaf5)