### PR TITLE
Drop and recreate tenant views before rebuilding

### DIFF
--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,23 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision if down_revision else None}
+Create Date: ${create_date}
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "${up_revision}"
+down_revision = ${repr(down_revision) if down_revision else None}
+branch_labels = ${repr(branch_labels) if branch_labels else None}
+depends_on = ${repr(depends_on) if depends_on else None}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations/versions/20251106_01_s3_api_views_org_audit.py
+++ b/backend/migrations/versions/20251106_01_s3_api_views_org_audit.py
@@ -50,19 +50,31 @@ def _ensure_audit_columns(table: str) -> None:
 
 
 def _create_views() -> None:
+    # Sempre dropar antes, para evitar restrições de REPLACE sobre colunas
+    op.execute("DROP VIEW IF EXISTS v_grupos_kpis CASCADE;")
+    op.execute("DROP VIEW IF EXISTS v_alertas_vencendo_30d CASCADE;")
+    op.execute("DROP VIEW IF EXISTS v_processos_resumo CASCADE;")
+    op.execute("DROP VIEW IF EXISTS v_taxas_status CASCADE;")
+    op.execute("DROP VIEW IF EXISTS v_licencas_status CASCADE;")
+    op.execute("DROP VIEW IF EXISTS v_empresas CASCADE;")
+
+    # v_empresas – mantenha a ordem que você já usa em produção:
+    # empresa_id, org_id, empresa, cnpj, municipio, porte, categoria,
+    # situacao, status_empresas, debito, certificado, total_licencas,
+    # total_taxas, processos_ativos, updated_at
     op.execute(
         """
-        CREATE OR REPLACE VIEW v_empresas AS
+        CREATE VIEW v_empresas AS
         SELECT
-            e.id AS empresa_id,
+            e.id          AS empresa_id,
             e.org_id,
             e.empresa,
             e.cnpj,
             e.municipio,
             e.porte,
             e.categoria,
-            e.status_empresas,
             e.situacao,
+            e.status_empresas,
             e.debito,
             e.certificado,
             COALESCE(COUNT(DISTINCT l.id) FILTER (WHERE l.id IS NOT NULL), 0) AS total_licencas,
@@ -72,18 +84,22 @@ def _create_views() -> None:
             ), 0) AS processos_ativos,
             e.updated_at
         FROM empresas e
-        LEFT JOIN licencas l ON l.empresa_id = e.id AND l.org_id = e.org_id
-        LEFT JOIN taxas t ON t.empresa_id = e.id AND t.org_id = e.org_id
-        LEFT JOIN processos p ON p.empresa_id = e.id AND p.org_id = e.org_id
-        WHERE e.org_id = current_setting('app.current_org')::uuid
-        GROUP BY e.id, e.org_id, e.empresa, e.cnpj, e.municipio, e.porte, e.categoria,
-                 e.status_empresas, e.situacao, e.debito, e.certificado, e.updated_at;
+        LEFT JOIN licencas  l ON l.empresa_id = e.id AND l.org_id = e.org_id
+        LEFT JOIN taxas     t ON t.empresa_id   = e.id AND t.org_id = e.org_id
+        LEFT JOIN processos p ON p.empresa_id   = e.id AND p.org_id = e.org_id
+        WHERE current_setting('app.current_org', true) IS NULL
+           OR e.org_id = current_setting('app.current_org')::uuid
+        GROUP BY
+            e.id, e.org_id, e.empresa, e.cnpj, e.municipio, e.porte, e.categoria,
+            e.situacao, e.status_empresas, e.debito, e.certificado, e.updated_at;
         """
     )
+    op.execute("ALTER VIEW v_empresas OWNER TO CURRENT_USER;")
 
+    # v_licencas_status – já inclui municipio
     op.execute(
         """
-        CREATE OR REPLACE VIEW v_licencas_status AS
+        CREATE VIEW v_licencas_status AS
         SELECT
             l.id AS licenca_id,
             e.id AS empresa_id,
@@ -97,19 +113,25 @@ def _create_views() -> None:
             CASE WHEN l.validade IS NULL THEN NULL ELSE (l.validade - CURRENT_DATE) END AS dias_para_vencer
         FROM licencas l
         JOIN empresas e ON e.id = l.empresa_id AND e.org_id = l.org_id
-        WHERE e.org_id = current_setting('app.current_org')::uuid;
+        WHERE current_setting('app.current_org', true) IS NULL
+          OR e.org_id = current_setting('app.current_org')::uuid;
         """
     )
+    op.execute("ALTER VIEW v_licencas_status OWNER TO CURRENT_USER;")
 
+    # v_taxas_status – **inclui municipio** para não “sumir” coluna
+    # Ordem sugerida (igual à sua definição anterior):
+    # taxa_id, empresa_id, org_id, empresa, cnpj, municipio, tipo, status, data_envio, vencimento_tpi, esta_pago
     op.execute(
         """
-        CREATE OR REPLACE VIEW v_taxas_status AS
+        CREATE VIEW v_taxas_status AS
         SELECT
             t.id AS taxa_id,
             e.id AS empresa_id,
             e.org_id,
             e.empresa,
             e.cnpj,
+            e.municipio,
             t.tipo,
             t.status,
             t.data_envio,
@@ -117,13 +139,16 @@ def _create_views() -> None:
             (LOWER(COALESCE(t.status, '')) LIKE 'pago%') AS esta_pago
         FROM taxas t
         JOIN empresas e ON e.id = t.empresa_id AND e.org_id = t.org_id
-        WHERE e.org_id = current_setting('app.current_org')::uuid;
+        WHERE current_setting('app.current_org', true) IS NULL
+          OR e.org_id = current_setting('app.current_org')::uuid;
         """
     )
+    op.execute("ALTER VIEW v_taxas_status OWNER TO CURRENT_USER;")
 
+    # v_processos_resumo – mantenha colunas existentes primeiro; 'status_cor' pode ficar no fim
     op.execute(
         """
-        CREATE OR REPLACE VIEW v_processos_resumo AS
+        CREATE VIEW v_processos_resumo AS
         SELECT
             p.id AS processo_id,
             e.id AS empresa_id,
@@ -151,13 +176,17 @@ def _create_views() -> None:
             END AS status_cor
         FROM processos p
         JOIN empresas e ON e.id = p.empresa_id AND e.org_id = p.org_id
-        WHERE e.org_id = current_setting('app.current_org')::uuid;
+        WHERE current_setting('app.current_org', true) IS NULL
+          OR e.org_id = current_setting('app.current_org')::uuid;
         """
     )
+    op.execute("ALTER VIEW v_processos_resumo OWNER TO CURRENT_USER;")
 
+    # v_alertas_vencendo_30d – mantenha as colunas originais **no começo** e, se quiser, adicione novas **no fim**
+    # Colunas originais: org_id, empresa_id, empresa, cnpj, tipo_alerta, descricao, validade, dias_restantes
     op.execute(
         """
-        CREATE OR REPLACE VIEW v_alertas_vencendo_30d AS
+        CREATE VIEW v_alertas_vencendo_30d AS
         WITH base AS (
             SELECT
                 e.org_id,
@@ -165,14 +194,15 @@ def _create_views() -> None:
                 e.empresa,
                 e.cnpj,
                 'LICENCA'::text AS tipo_alerta,
-                l.tipo || ' - ' || l.status AS descricao,
+                l.tipo || ' - ' || COALESCE(l.status,'?') AS descricao,
                 l.validade,
                 (l.validade - CURRENT_DATE) AS dias_restantes
             FROM licencas l
             JOIN empresas e ON e.id = l.empresa_id AND e.org_id = l.org_id
-            WHERE e.org_id = current_setting('app.current_org')::uuid
+            WHERE (current_setting('app.current_org', true) IS NULL
+                   OR e.org_id = current_setting('app.current_org')::uuid)
               AND l.validade IS NOT NULL
-              AND l.validade <= CURRENT_DATE + INTERVAL '30 days'
+              AND l.validade <= CURRENT_DATE + INTERVAL '30 day'
             UNION ALL
             SELECT
                 e.org_id,
@@ -180,13 +210,15 @@ def _create_views() -> None:
                 e.empresa,
                 e.cnpj,
                 'TAXA'::text AS tipo_alerta,
-                t.tipo || ' - ' || t.status AS descricao,
+                'TPI - ' || COALESCE(t.status,'?') AS descricao,
                 t.vencimento_tpi AS validade,
                 CASE WHEN t.vencimento_tpi IS NULL THEN NULL ELSE (t.vencimento_tpi - CURRENT_DATE) END AS dias_restantes
             FROM taxas t
             JOIN empresas e ON e.id = t.empresa_id AND e.org_id = t.org_id
-            WHERE e.org_id = current_setting('app.current_org')::uuid
-              AND LOWER(COALESCE(t.status, '')) NOT LIKE 'pago%'
+            WHERE (current_setting('app.current_org', true) IS NULL
+                   OR e.org_id = current_setting('app.current_org')::uuid)
+              AND t.vencimento_tpi IS NOT NULL
+              AND LOWER(COALESCE(t.status,'')) NOT LIKE 'pago%'
             UNION ALL
             SELECT
                 e.org_id,
@@ -199,71 +231,68 @@ def _create_views() -> None:
                 CASE WHEN p.prazo IS NULL THEN NULL ELSE (p.prazo - CURRENT_DATE) END AS dias_restantes
             FROM processos p
             JOIN empresas e ON e.id = p.empresa_id AND e.org_id = p.org_id
-            WHERE e.org_id = current_setting('app.current_org')::uuid
+            WHERE (current_setting('app.current_org', true) IS NULL
+                   OR e.org_id = current_setting('app.current_org')::uuid)
               AND p.prazo IS NOT NULL
-              AND p.prazo <= CURRENT_DATE + INTERVAL '30 days'
+              AND p.prazo <= CURRENT_DATE + INTERVAL '30 day'
         )
         SELECT
-            ROW_NUMBER() OVER (ORDER BY empresa, tipo_alerta, COALESCE(validade, CURRENT_DATE)) AS alerta_id,
-            org_id,
-            empresa_id,
-            empresa,
-            cnpj,
-            tipo_alerta,
-            descricao,
-            validade,
-            dias_restantes
+            org_id, empresa_id, empresa, cnpj, tipo_alerta, descricao, validade, dias_restantes
+            -- Se quiser acrescentar depois: , ROW_NUMBER() OVER (...) AS alerta_id
         FROM base;
         """
     )
+    op.execute("ALTER VIEW v_alertas_vencendo_30d OWNER TO CURRENT_USER;")
 
+    # v_grupos_kpis – como você já recriou manualmente, mantive o modelo com grupos ‘empresas’, ‘licencas’, ‘taxas’
     op.execute(
         """
-        CREATE OR REPLACE VIEW v_grupos_kpis AS
-        SELECT
-            e.org_id,
-            'empresas'::text AS grupo,
-            'total_empresas'::text AS chave,
-            COUNT(*)::bigint AS valor
-        FROM empresas e
-        WHERE e.org_id = current_setting('app.current_org')::uuid
-        GROUP BY e.org_id
-        UNION ALL
-        SELECT
-            e.org_id,
-            'empresas'::text AS grupo,
-            'sem_certificado'::text AS chave,
-            COUNT(*) FILTER (
-                WHERE COALESCE(e.certificado, '') NOT ILIKE 'sim%'
-            )::bigint AS valor
-        FROM empresas e
-        WHERE e.org_id = current_setting('app.current_org')::uuid
-        GROUP BY e.org_id
-        UNION ALL
-        SELECT
-            l.org_id,
-            'licencas'::text AS grupo,
-            'licencas_vencidas'::text AS chave,
-            COUNT(*)::bigint AS valor
-        FROM licencas l
-        WHERE l.org_id = current_setting('app.current_org')::uuid
-          AND l.validade IS NOT NULL
-          AND l.validade < CURRENT_DATE
-        GROUP BY l.org_id
-        UNION ALL
-        SELECT
-            t.org_id,
-            'taxas'::text AS grupo,
-            'tpi_pendente'::text AS chave,
-            COUNT(*) FILTER (
-                WHERE (LOWER(COALESCE(t.status, '')) NOT LIKE 'pago%')
-                  AND (UPPER(t.tipo) LIKE 'TPI%')
-            )::bigint AS valor
-        FROM taxas t
-        WHERE t.org_id = current_setting('app.current_org')::uuid
-        GROUP BY t.org_id;
+        CREATE VIEW v_grupos_kpis AS
+        WITH emp AS (
+            SELECT
+                e.org_id,
+                COUNT(*)::bigint AS total_empresas,
+                COUNT(*) FILTER (
+                    WHERE COALESCE(UPPER(TRIM(e.certificado)),'NÃO') IN ('NÃO','NAO','N/A','N')
+                )::bigint AS sem_certificado
+            FROM empresas e
+            GROUP BY e.org_id
+        ),
+        lic_venc AS (
+            SELECT
+                l.org_id,
+                COUNT(*) FILTER (
+                    WHERE l.validade IS NOT NULL AND l.validade < CURRENT_DATE
+                )::bigint AS licencas_vencidas
+            FROM licencas l
+            GROUP BY l.org_id
+        ),
+        tpi_pend AS (
+            SELECT
+                t.org_id,
+                COUNT(*) FILTER (
+                    WHERE (LOWER(COALESCE(t.status, '')) NOT LIKE 'pago%')
+                      AND (UPPER(TRIM(t.tipo)) = 'TPI')
+                )::bigint AS tpi_pendente
+            FROM taxas t
+            GROUP BY t.org_id
+        ),
+        unioned AS (
+            SELECT emp.org_id, 'empresas'::text AS grupo, 'total_empresas'::text AS chave, emp.total_empresas::bigint AS valor FROM emp
+            UNION ALL
+            SELECT emp.org_id, 'empresas'::text AS grupo, 'sem_certificado'::text AS chave, emp.sem_certificado::bigint AS valor FROM emp
+            UNION ALL
+            SELECT l.org_id, 'licencas'::text AS grupo, 'licencas_vencidas'::text AS chave, COALESCE(l.licencas_vencidas, 0)::bigint AS valor FROM lic_venc l
+            UNION ALL
+            SELECT t.org_id, 'taxas'::text AS grupo, 'tpi_pendente'::text AS chave, COALESCE(t.tpi_pendente, 0)::bigint AS valor FROM tpi_pend t
+        )
+        SELECT *
+        FROM unioned
+        WHERE current_setting('app.current_org', true) IS NULL
+           OR org_id = current_setting('app.current_org')::uuid;
         """
     )
+    op.execute("ALTER VIEW v_grupos_kpis OWNER TO CURRENT_USER;")
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary
- drop each reporting view before recreating it to keep column definitions consistent
- rebuild v_empresas, v_licencas_status, v_taxas_status, v_processos_resumo, and v_alertas_vencendo_30d with the prescribed column order and filters
- ensure v_taxas_status exposes municipio and keep the existing grouping logic for v_grupos_kpis

## Testing
- not run (SQL text updates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d04b6babc8326aca84a7eb25cdaf5)