### PR TITLE
Adjust JWT decoding and add org context debug route

### DIFF
--- a/backend/app/deps/auth.py
+++ b/backend/app/deps/auth.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from enum import Enum
-from typing import Callable
+from typing import Callable, Generator
 from uuid import UUID
 
 from fastapi import Depends, HTTPException, Security
@@ -41,7 +41,12 @@ def get_current_user(creds: HTTPAuthorizationCredentials = Security(bearer)) -> 
 
     token = creds.credentials
     try:
-        payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_alg])
+        payload = jwt.decode(
+            token,
+            settings.jwt_secret.encode("utf-8"),
+            algorithms=[settings.jwt_alg],
+            options={"verify_sub": False},  # Ignora a validação de tipo do 'sub'
+        )
     except JWTError as exc:
         logger.warning(
             "Falha ao decodificar JWT: %s | alg=%s secret_fp=%s",
@@ -91,10 +96,23 @@ def require_role(min_role: Role) -> Callable[[User], User]:
 def db_with_org(
     db: Session = Depends(get_db),
     user: User = Depends(require_role(Role.VIEWER)),
-) -> Session:
+) -> Generator[Session, None, None]:
     try:
-        db.execute(text("SET LOCAL app.current_org = :org_id"), {"org_id": str(user.org_id)})
+        # Evita depender de transação aberta: use SET (não LOCAL)
+        db.execute(text("SET app.current_org = :org_id"), {"org_id": str(user.org_id)})
     except Exception as exc:  # noqa: BLE001
-        logger.error("Falha ao definir app.current_org: org_id=%s", user.org_id)
+        logger.warning(
+            "Falha ao definir app.current_org: org_id=%s err=%s",
+            user.org_id,
+            exc,
+        )
         raise HTTPException(status_code=500, detail="Contexto de organização indisponível") from exc
-    return db
+
+    try:
+        yield db
+    finally:
+        try:
+            db.execute(text("RESET app.current_org"))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("RESET app.current_org falhou (safe to ignore): %s", exc)
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import text
 
 from app.api.v1.api import api_router
 from app.core.config import settings
+from app.deps.auth import db_with_org, get_current_user
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +33,12 @@ app.add_middleware(
 @app.get("/healthz")
 def healthz() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.get("/__debug/guc")
+def guc_debug(_: dict = Depends(get_current_user), db = Depends(db_with_org)):
+    val = db.execute(text("SELECT current_setting('app.current_org', true)")).scalar()
+    return {"app.current_org": val}
 
 
 app.include_router(api_router, prefix="/api/v1")


### PR DESCRIPTION
## Summary
- encode the JWT secret before decoding and disable sub verification in the auth dependency
- ensure the organization-scoped session closes after resetting the GUC
- add a debug endpoint that reports the current `app.current_org` setting via `db_with_org`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912497010b0832691e948a29e161276)