### PR TITLE
Add úteis requerimento utilities endpoints

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,3 +37,8 @@ MASTER_USER_NAME=Maria Clara
 JWT_SECRET=secret_key_aqui
 JWT_ALG=HS256
 CORS_ORIGINS=http://localhost:5173,http://localhost:3000,http://localhost:8000
+
+# Configurações dos requerimentos úteis
+UTEIS_REQ_ROOT="G:\\PMA\\Requerimentos Word\\Modelos"
+UTEIS_ALLOWED_EXTS=.pdf,.doc,.docx,.xls,.xlsx,.png,.jpg,.jpeg
+UTEIS_REQ_MAX_DEPTH=4

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import alertas, empresas, grupos, licencas, processos, taxas
+from app.api.v1.endpoints import (
+    alertas,
+    empresas,
+    grupos,
+    licencas,
+    processos,
+    taxas,
+    uteis,
+)
 
 api_router = APIRouter()
 api_router.include_router(empresas.router)
@@ -11,3 +19,4 @@ api_router.include_router(taxas.router)
 api_router.include_router(processos.router)
 api_router.include_router(alertas.router)
 api_router.include_router(grupos.router)
+api_router.include_router(uteis.router)

--- a/backend/app/api/v1/endpoints/uteis.py
+++ b/backend/app/api/v1/endpoints/uteis.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.api.v1.endpoints.utils import ensure_positive_pagination
+from app.core.config import settings
+from app.deps.auth import Role, User, db_with_org, require_role
+from app.schemas.uteis import (
+    Contato,
+    ContatoListResponse,
+    Modelo,
+    ModeloListResponse,
+    RequerimentoFile,
+    RequerimentoListResponse,
+)
+from app.services.file_browse import decode_id_to_path, file_info, iter_files
+
+router = APIRouter(prefix="/uteis", tags=["Úteis"])
+
+
+def _paginate_items(items: list[dict[str, object]], page: int, size: int) -> tuple[list[dict[str, object]], int]:
+    start = (page - 1) * size
+    end = start + size
+    return items[start:end], len(items)
+
+
+@router.get("/requerimentos", response_model=RequerimentoListResponse)
+def listar_requerimentos(
+    q: Optional[str] = Query(None, description="Busca por nome ou caminho"),
+    tipo: Optional[str] = Query(None),
+    municipio: Optional[str] = Query(None),
+    sort: Optional[str] = Query("-mtime", description="nome ou -mtime"),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=200),
+    _: User = Depends(require_role(Role.VIEWER)),
+) -> RequerimentoListResponse:
+    page, size = ensure_positive_pagination(page, size, max_size=200)
+
+    root = Path(settings.uteis_req_root)
+    if not root.exists() or not root.is_dir():
+        return RequerimentoListResponse(items=[], total=0, page=page, size=size)
+
+    allowed_exts = settings.uteis_allowed_exts
+    max_depth = settings.uteis_req_max_depth
+    resolved_root = root.resolve()
+
+    rows = [
+        file_info(resolved_root, path)
+        for path in iter_files(resolved_root, allowed_exts=allowed_exts, max_depth=max_depth)
+    ]
+
+    if tipo:
+        rows = [row for row in rows if (row.get("tipo") or "").lower() == tipo.lower()]
+    if municipio:
+        rows = [row for row in rows if (row.get("municipio") or "").lower() == municipio.lower()]
+    if q:
+        query_lower = q.lower()
+        rows = [
+            row
+            for row in rows
+            if query_lower in row["nome"].lower() or query_lower in row["relpath"].lower()
+        ]
+
+    if sort == "nome":
+        rows.sort(key=lambda row: (row["nome"].lower(), row["relpath"].lower()))
+    elif sort == "-nome":
+        rows.sort(key=lambda row: (row["nome"].lower(), row["relpath"].lower()), reverse=True)
+    else:
+        rows.sort(key=lambda row: row["mtime"], reverse=sort != "mtime")
+
+    page_items, total = _paginate_items(rows, page, size)
+    return RequerimentoListResponse(
+        items=[RequerimentoFile(**item) for item in page_items],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+@router.get("/requerimentos/download/{file_id}")
+def download_requerimento(
+    file_id: str,
+    inline: bool = Query(False, description="Definir Content-Disposition como inline"),
+    _: User = Depends(require_role(Role.VIEWER)),
+):
+    root = Path(settings.uteis_req_root)
+    try:
+        path = decode_id_to_path(root, file_id)
+    except PermissionError as exc:  # noqa: BLE001
+        raise HTTPException(status_code=404, detail="Arquivo não encontrado") from exc
+
+    if not path.exists() or not path.is_file():
+        raise HTTPException(status_code=404, detail="Arquivo não encontrado")
+
+    headers = {}
+    if inline:
+        headers["Content-Disposition"] = f'inline; filename="{path.name}"'
+    return FileResponse(path, filename=path.name, headers=headers)
+
+
+@router.get("/contatos", response_model=ContatoListResponse)
+def listar_contatos(
+    municipio: Optional[str] = Query(None),
+    categoria: Optional[str] = Query(None),
+    q: Optional[str] = Query(None, description="Busca por contato ou e-mail"),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=200),
+    db: Session = Depends(db_with_org),
+    _: User = Depends(require_role(Role.VIEWER)),
+) -> ContatoListResponse:
+    page, size = ensure_positive_pagination(page, size, max_size=200)
+
+    filters = ["1=1"]
+    params: dict[str, object] = {}
+    if municipio:
+        filters.append("LOWER(municipio) = LOWER(:municipio)")
+        params["municipio"] = municipio
+    if categoria:
+        filters.append("categoria = :categoria")
+        params["categoria"] = categoria
+    if q:
+        filters.append("(contato ILIKE :q OR COALESCE(email, '') ILIKE :q)")
+        params["q"] = f"%{q}%"
+
+    where_clause = " AND ".join(filters)
+    total = db.execute(text(f"SELECT COUNT(*) FROM contatos WHERE {where_clause}"), params).scalar_one()
+
+    query = text(
+        f"""
+        SELECT id, contato, municipio, telefone, whatsapp, email, categoria
+        FROM contatos
+        WHERE {where_clause}
+        ORDER BY contato ASC
+        LIMIT :limit OFFSET :offset
+        """
+    )
+    rows = db.execute(query, {**params, "limit": size, "offset": (page - 1) * size}).mappings().all()
+
+    items = [
+        Contato(
+            id=row["id"],
+            contato=row["contato"],
+            municipio=row["municipio"],
+            telefone=row["telefone"],
+            whatsapp=row["whatsapp"],
+            e_mail=row["email"],
+            categoria=row["categoria"],
+        )
+        for row in rows
+    ]
+    return ContatoListResponse(items=items, total=total, page=page, size=size)
+
+
+@router.get("/modelos", response_model=ModeloListResponse)
+def listar_modelos(
+    q: Optional[str] = Query(None, description="Busca por modelo ou descrição"),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=200),
+    db: Session = Depends(db_with_org),
+    _: User = Depends(require_role(Role.VIEWER)),
+) -> ModeloListResponse:
+    page, size = ensure_positive_pagination(page, size, max_size=200)
+
+    filters = ["1=1"]
+    params: dict[str, object] = {}
+    if q:
+        filters.append("(modelo ILIKE :q OR COALESCE(descricao, '') ILIKE :q)")
+        params["q"] = f"%{q}%"
+
+    where_clause = " AND ".join(filters)
+    try:
+        total_stmt = text(f"SELECT COUNT(*) FROM modelos WHERE {where_clause}")
+        total = db.execute(total_stmt, params).scalar_one()
+
+        query = text(
+            f"""
+            SELECT id, modelo, descricao, utilizacao
+            FROM modelos
+            WHERE {where_clause}
+            ORDER BY modelo ASC
+            LIMIT :limit OFFSET :offset
+            """
+        )
+        rows = db.execute(query, {**params, "limit": size, "offset": (page - 1) * size}).mappings().all()
+    except Exception:  # noqa: BLE001
+        return ModeloListResponse(items=[], total=0, page=page, size=size)
+
+    items = [
+        Modelo(
+            id=row["id"],
+            modelo=row["modelo"],
+            descricao=row["descricao"],
+            utilizacao=row["utilizacao"],
+        )
+        for row in rows
+    ]
+    return ModeloListResponse(items=items, total=total, page=page, size=size)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -18,12 +18,38 @@ class Settings(BaseModel):
     jwt_secret: str = Field(alias="JWT_SECRET")
     jwt_alg: str = Field(default="HS256", alias="JWT_ALG")
     cors_origins: List[str] = Field(default_factory=list, alias="CORS_ORIGINS")
+    uteis_req_root: Path = Field(
+        default=Path(r"G:\PMA\Requerimentos Word\Modelos"), alias="UTEIS_REQ_ROOT"
+    )
+    uteis_allowed_exts: List[str] = Field(
+        default_factory=lambda: [
+            ".pdf",
+            ".doc",
+            ".docx",
+            ".xls",
+            ".xlsx",
+            ".png",
+            ".jpg",
+            ".jpeg",
+        ],
+        alias="UTEIS_ALLOWED_EXTS",
+    )
+    uteis_req_max_depth: int = Field(default=4, alias="UTEIS_REQ_MAX_DEPTH")
     config_path: Path = Field(default_factory=lambda: Path(__file__).resolve().parents[2] / "config.yaml", alias="CONFIG_PATH")
 
     model_config = {
         "populate_by_name": True,
         "arbitrary_types_allowed": True,
     }
+
+    @staticmethod
+    def _normalize_ext(value: str) -> str:
+        ext = value.strip().lower()
+        if not ext:
+            return ""
+        if not ext.startswith("."):
+            ext = f".{ext}"
+        return ext
 
     @field_validator("jwt_secret", mode="before")
     @classmethod
@@ -74,6 +100,32 @@ class Settings(BaseModel):
             path = (Path(__file__).resolve().parents[2] / value).resolve()
         return path
 
+    @field_validator("uteis_allowed_exts", mode="before")
+    @classmethod
+    def _parse_allowed_exts(cls, value: Any) -> List[str]:
+        if value is None:
+            return value
+        if isinstance(value, str):
+            items = [cls._normalize_ext(part) for part in value.split(",")]
+            return [item for item in items if item]
+        if isinstance(value, (list, tuple, set)):
+            items = [cls._normalize_ext(str(part)) for part in value]
+            return [item for item in items if item]
+        raise TypeError("UTEIS_ALLOWED_EXTS deve ser string ou coleção de strings")
+
+    @field_validator("uteis_req_max_depth", mode="before")
+    @classmethod
+    def _parse_max_depth(cls, value: Any) -> int:
+        if value in (None, ""):
+            return value
+        try:
+            depth = int(value)
+        except (TypeError, ValueError) as exc:  # noqa: BLE001
+            raise TypeError("UTEIS_REQ_MAX_DEPTH deve ser um número inteiro") from exc
+        if depth < 0:
+            raise ValueError("UTEIS_REQ_MAX_DEPTH deve ser não negativo")
+        return depth
+
     @classmethod
     def from_env(cls) -> "Settings":
         data: Dict[str, Any] = {}
@@ -92,6 +144,10 @@ class Settings(BaseModel):
             "CORS_ORIGINS": os.getenv("CORS_ORIGINS", ""),
             "CONFIG_PATH": os.getenv("CONFIG_PATH"),
         }
+        for key in ("UTEIS_REQ_ROOT", "UTEIS_ALLOWED_EXTS", "UTEIS_REQ_MAX_DEPTH"):
+            env_value = os.getenv(key)
+            if env_value not in (None, ""):
+                optional_fields[key] = env_value
         data.update(optional_fields)
         return cls(**data)
 

--- a/backend/app/schemas/uteis.py
+++ b/backend/app/schemas/uteis.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PageMeta(BaseModel):
+    total: int
+    page: int
+    size: int
+
+
+class RequerimentoFile(BaseModel):
+    id: str
+    nome: str
+    tipo: Optional[str] = None
+    municipio: Optional[str] = None
+    relpath: str
+    ext: str
+    mtime: float
+
+
+class RequerimentoListResponse(BaseModel):
+    items: List[RequerimentoFile]
+    total: int
+    page: int
+    size: int
+
+
+class Contato(BaseModel):
+    id: int
+    contato: str
+    municipio: Optional[str] = None
+    telefone: Optional[str] = None
+    whatsapp: Optional[str] = None
+    email: Optional[str] = Field(None, alias="e_mail")
+    categoria: str
+
+
+class ContatoListResponse(BaseModel):
+    items: List[Contato]
+    total: int
+    page: int
+    size: int
+
+
+class Modelo(BaseModel):
+    id: int
+    modelo: str
+    descricao: Optional[str] = None
+    utilizacao: Optional[str] = None
+
+
+class ModeloListResponse(BaseModel):
+    items: List[Modelo]
+    total: int
+    page: int
+    size: int

--- a/backend/app/services/file_browse.py
+++ b/backend/app/services/file_browse.py
@@ -1,0 +1,124 @@
+"""Ferramentas utilitárias para navegação segura em diretórios de requerimentos."""
+
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+from typing import Iterable, Iterator, Tuple
+
+DEFAULT_ALLOWED_EXTS = {
+    ".pdf",
+    ".doc",
+    ".docx",
+    ".xls",
+    ".xlsx",
+    ".png",
+    ".jpg",
+    ".jpeg",
+}
+
+
+def _normalize_ext(ext: str) -> str:
+    value = ext.strip().lower()
+    if not value:
+        return ""
+    if not value.startswith("."):
+        value = f".{value}"
+    return value
+
+
+def _prepare_allowed_exts(allowed_exts: Iterable[str] | None) -> set[str]:
+    if allowed_exts is None:
+        return set(DEFAULT_ALLOWED_EXTS)
+    normalized = {_normalize_ext(ext) for ext in allowed_exts}
+    filtered = {ext for ext in normalized if ext}
+    return filtered or set(DEFAULT_ALLOWED_EXTS)
+
+
+def _is_allowed(path: Path, root: Path, allowed_exts: set[str]) -> bool:
+    try:
+        resolved = path.resolve(strict=False)
+    except FileNotFoundError:
+        return False
+    if not resolved.is_file():
+        return False
+    if resolved.suffix.lower() not in allowed_exts:
+        return False
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _b64u(value: str) -> str:
+    encoded = base64.urlsafe_b64encode(value.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def _b64u_dec(value: str) -> str:
+    padding = "=" * (-len(value) % 4)
+    decoded = base64.urlsafe_b64decode((value + padding).encode("ascii"))
+    return decoded.decode("utf-8")
+
+
+def iter_files(
+    root: Path,
+    allowed_exts: Iterable[str] | None = None,
+    max_depth: int | None = None,
+) -> Iterator[Path]:
+    """Percorre arquivos permitidos a partir de uma raiz, respeitando profundidade."""
+
+    resolved_root = root.resolve()
+    allowed = _prepare_allowed_exts(allowed_exts)
+    base_parts = len(resolved_root.parts)
+
+    for dirpath, dirnames, filenames in os.walk(resolved_root):
+        current_dir = Path(dirpath)
+        depth = len(current_dir.parts) - base_parts
+        if max_depth is not None and depth >= max_depth:
+            dirnames[:] = []
+        for filename in filenames:
+            candidate = current_dir / filename
+            if _is_allowed(candidate, resolved_root, allowed):
+                yield candidate
+
+
+def relid_for(root: Path, file_path: Path) -> Tuple[str, str]:
+    relative = file_path.resolve().relative_to(root.resolve()).as_posix()
+    file_id = _b64u(relative)
+    return file_id, relative
+
+
+def decode_id_to_path(root: Path, file_id: str) -> Path:
+    relative = _b64u_dec(file_id)
+    candidate = (root / Path(relative)).resolve()
+    resolved_root = root.resolve()
+    try:
+        candidate.relative_to(resolved_root)
+    except ValueError as exc:  # noqa: BLE001
+        raise PermissionError("Invalid path traversal") from exc
+    return candidate
+
+
+def infer_tipo_municipio(relpath: str) -> Tuple[str | None, str | None]:
+    parts = relpath.split("/")
+    tipo = parts[0] if len(parts) >= 2 else ""
+    municipio = parts[1] if len(parts) >= 3 else ""
+    return (tipo or None, municipio or None)
+
+
+def file_info(root: Path, path: Path) -> dict[str, object]:
+    file_id, rel = relid_for(root, path)
+    tipo, municipio = infer_tipo_municipio(rel)
+    stat = path.stat()
+    return {
+        "id": file_id,
+        "nome": path.stem,
+        "tipo": tipo,
+        "municipio": municipio,
+        "relpath": rel,
+        "ext": path.suffix.lower().lstrip("."),
+        "mtime": stat.st_mtime,
+    }


### PR DESCRIPTION
## Summary
- document úteis requerimentos environment variables in the sample configuration
- expose úteis settings and safe file browsing helpers for requerimentos assets
- add schemas and API routes for listar/download requerimentos as well as contatos e modelos

## Testing
- pytest *(fails: missing dependency `email_validator`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691374ec0da88326ad51faa5de1ddace)