### PR TITLE
feat: add certificados and agendamentos support

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from app.api.v1.endpoints import (
+    agendamentos,
     alertas,
+    certificados,
     empresas,
     grupos,
     licencas,
@@ -14,9 +16,11 @@ from app.api.v1.endpoints import (
 
 api_router = APIRouter()
 api_router.include_router(empresas.router)
+api_router.include_router(certificados.router)
 api_router.include_router(licencas.router)
 api_router.include_router(taxas.router)
 api_router.include_router(processos.router)
 api_router.include_router(alertas.router)
 api_router.include_router(grupos.router)
+api_router.include_router(agendamentos.router)
 api_router.include_router(uteis.router)

--- a/backend/app/api/v1/endpoints/agendamentos.py
+++ b/backend/app/api/v1/endpoints/agendamentos.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.v1.endpoints.utils import (
+    build_where_clause,
+    ensure_positive_pagination,
+    paginate_query,
+    resolve_sort,
+)
+from app.deps.auth import Role, User, db_with_org, require_role
+from app.schemas.agendamentos import AgendamentoListResponse
+
+router = APIRouter(prefix="/agendamentos", tags=["Agendamentos"])
+
+ALLOWED_SORTS: Dict[str, str] = {
+    "inicio": "inicio",
+    "titulo": "titulo",
+    "tipo": "tipo",
+    "situacao": "situacao",
+}
+
+
+@router.get("", response_model=AgendamentoListResponse)
+def listar_agendamentos(
+    empresa_id: int | None = Query(None, description="Filtrar por empresa"),
+    tipo: str | None = Query(None),
+    situacao: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    sort: str | None = Query(None, description="Campo de ordenação"),
+    db: Session = Depends(db_with_org),
+    _: User = Depends(require_role(Role.VIEWER)),
+) -> AgendamentoListResponse:
+    page, size = ensure_positive_pagination(page, size)
+
+    params: Dict[str, object] = {}
+    filters: list[str] = [
+        "(current_setting('app.current_org', true) IS NULL OR a.org_id = current_setting('app.current_org')::uuid)"
+    ]
+
+    if empresa_id is not None:
+        params["empresa_id"] = empresa_id
+        filters.append("a.empresa_id = :empresa_id")
+    if tipo:
+        params["tipo"] = tipo
+        filters.append("a.tipo = :tipo")
+    if situacao:
+        params["situacao"] = situacao
+        filters.append("a.situacao = :situacao")
+
+    where_clause = build_where_clause(filters)
+    base_query = f"SELECT a.* FROM agendamentos a{where_clause}"
+
+    sort_column, direction = resolve_sort(sort, ALLOWED_SORTS, "inicio")
+    if sort is None:
+        direction = "DESC"
+
+    data = paginate_query(db, base_query, params, sort_column, direction, page, size)
+    return AgendamentoListResponse(**data)

--- a/backend/app/api/v1/endpoints/certificados.py
+++ b/backend/app/api/v1/endpoints/certificados.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.v1.endpoints.utils import (
+    build_where_clause,
+    ensure_positive_pagination,
+    paginate_query,
+    resolve_sort,
+)
+from app.deps.auth import Role, User, db_with_org, require_role
+from app.schemas.certificados import CertificadoListResponse
+
+router = APIRouter(prefix="/certificados", tags=["Certificados"])
+
+ALLOWED_SORTS: Dict[str, str] = {
+    "empresa": "empresa",
+    "cnpj": "cnpj",
+    "valido_de": "valido_de",
+    "valido_ate": "valido_ate",
+    "dias_restantes": "dias_restantes",
+}
+
+
+@router.get("", response_model=CertificadoListResponse)
+def listar_certificados(
+    q: str | None = Query(None, description="Busca por empresa ou CNPJ"),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    sort: str | None = Query(None, description="Campo de ordenação"),
+    db: Session = Depends(db_with_org),
+    _: User = Depends(require_role(Role.VIEWER)),
+) -> CertificadoListResponse:
+    page, size = ensure_positive_pagination(page, size)
+
+    params: Dict[str, object] = {}
+    filters: list[str] = []
+
+    if q:
+        params["q"] = f"%{q}%"
+        filters.append("(empresa ILIKE :q OR cnpj ILIKE :q)")
+
+    where_clause = build_where_clause(filters)
+    base_query = f"SELECT * FROM v_certificados_status{where_clause}"
+
+    sort_column, direction = resolve_sort(sort, ALLOWED_SORTS, "valido_ate")
+    data = paginate_query(db, base_query, params, sort_column, direction, page, size)
+    return CertificadoListResponse(**data)

--- a/backend/app/deps/auth.py
+++ b/backend/app/deps/auth.py
@@ -105,12 +105,18 @@ def db_with_org(
             {"org_id": str(user.org_id)},
         )
     except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "Falha ao definir app.current_org: org_id=%s err=%s",
-            user.org_id,
-            exc,
-        )
-        raise HTTPException(status_code=500, detail="Contexto de organização indisponível") from exc
+        try:
+            db.execute(
+                text("SET LOCAL app.current_org = :org_id"),
+                {"org_id": str(user.org_id)},
+            )
+        except Exception as fallback_exc:  # noqa: BLE001
+            logger.warning(
+                "Falha ao definir app.current_org: org_id=%s err=%s",
+                user.org_id,
+                fallback_exc,
+            )
+            raise HTTPException(status_code=500, detail="Contexto de organização indisponível") from exc
 
     try:
         yield db

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .base import Base
+from .certificados import Certificado
+from .agendamentos import Agendamento
+
+__all__ = ["Base", "Certificado", "Agendamento"]

--- a/backend/app/models/agendamentos.py
+++ b/backend/app/models/agendamentos.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+
+from .base import Base
+
+
+class Agendamento(Base):
+    __tablename__ = "agendamentos"
+
+    id = Column(BigInteger, primary_key=True)
+    org_id = Column(UUID(as_uuid=False), nullable=False, index=True)
+    empresa_id = Column(Integer, ForeignKey("empresas.id"), nullable=True, index=True)
+    titulo = Column(String(255), nullable=False)
+    descricao = Column(Text, nullable=True)
+    inicio = Column(DateTime(timezone=True), nullable=False, index=True)
+    fim = Column(DateTime(timezone=True), nullable=True)
+    tipo = Column(String(50), nullable=True)
+    situacao = Column(String(50), nullable=True)

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from db.models_sql import Base  # re-export for app models
+
+__all__ = ["Base"]

--- a/backend/app/models/certificados.py
+++ b/backend/app/models/certificados.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from sqlalchemy import BigInteger, Column, Date, DateTime, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class Certificado(Base):
+    __tablename__ = "certificados"
+
+    id = Column(BigInteger, primary_key=True)
+    org_id = Column(UUID(as_uuid=False), nullable=False, index=True)
+    empresa_id = Column(Integer, ForeignKey("empresas.id"), nullable=True, index=True)
+    arquivo = Column(String(512), nullable=True)
+    caminho = Column(String(1024), nullable=True)
+    serial = Column(String(128), nullable=True)
+    sha1 = Column(String(128), nullable=True)
+    subject = Column(String(1024), nullable=True)
+    issuer = Column(String(1024), nullable=True)
+    valido_de = Column(Date, nullable=True)
+    valido_ate = Column(Date, nullable=True)
+    senha = Column(String(255), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=True)
+    updated_at = Column(DateTime(timezone=True), nullable=True)
+
+    empresa = relationship("Empresa", lazy="joined", viewonly=True)

--- a/backend/app/schemas/agendamentos.py
+++ b/backend/app/schemas/agendamentos.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.common import PaginatedResponse
+
+
+class AgendamentoItem(BaseModel):
+    id: int
+    org_id: UUID
+    empresa_id: Optional[int] = None
+    titulo: str
+    descricao: Optional[str] = None
+    inicio: datetime
+    fim: Optional[datetime] = None
+    tipo: Optional[str] = None
+    situacao: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgendamentoListResponse(PaginatedResponse[AgendamentoItem]):
+    pass

--- a/backend/app/schemas/certificados.py
+++ b/backend/app/schemas/certificados.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.common import PaginatedResponse
+
+
+class CertificadoView(BaseModel):
+    cert_id: int
+    empresa_id: Optional[int] = None
+    org_id: UUID
+    empresa: Optional[str] = None
+    cnpj: Optional[str] = None
+    valido_de: Optional[date] = None
+    valido_ate: Optional[date] = None
+    dias_restantes: Optional[int] = None
+    situacao: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CertificadoListResponse(PaginatedResponse[CertificadoView]):
+    pass

--- a/backend/migrations/versions/20251112_01_certificados_agendamentos.py
+++ b/backend/migrations/versions/20251112_01_certificados_agendamentos.py
@@ -1,0 +1,100 @@
+"""S3.1: certificados + agendamentos + view de status
+
+Revision ID: 20251112_01_certificados_agend
+Revises: be2b8ef49772
+Create Date: 2025-11-12 10:40:00
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "20251112_01_certificados_agend"
+down_revision = "be2b8ef49772"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "certificados",
+        sa.Column("id", sa.BigInteger, primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("empresa_id", sa.Integer, sa.ForeignKey("empresas.id"), nullable=True),
+        sa.Column("arquivo", sa.String(length=512), nullable=True),
+        sa.Column("caminho", sa.String(length=1024), nullable=True),
+        sa.Column("serial", sa.String(length=128), nullable=True),
+        sa.Column("sha1", sa.String(length=128), nullable=True),
+        sa.Column("subject", sa.String(length=1024), nullable=True),
+        sa.Column("issuer", sa.String(length=1024), nullable=True),
+        sa.Column("valido_de", sa.Date, nullable=True),
+        sa.Column("valido_ate", sa.Date, nullable=True),
+        sa.Column("senha", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.UniqueConstraint("org_id", "serial", name="uq_certificados_org_serial"),
+    )
+    op.create_index("ix_certificados_org_id", "certificados", ["org_id"])
+    op.create_index("ix_certificados_empresa_id", "certificados", ["empresa_id"])
+    op.create_index("ix_certificados_valido_ate", "certificados", ["valido_ate"])
+
+    op.create_table(
+        "agendamentos",
+        sa.Column("id", sa.BigInteger, primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("empresa_id", sa.Integer, sa.ForeignKey("empresas.id"), nullable=True),
+        sa.Column("titulo", sa.String(length=255), nullable=False),
+        sa.Column("descricao", sa.Text, nullable=True),
+        sa.Column("inicio", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("fim", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("tipo", sa.String(length=50), nullable=True),
+        sa.Column("situacao", sa.String(length=50), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+    )
+    op.create_index("ix_agendamentos_org_id", "agendamentos", ["org_id"])
+    op.create_index("ix_agendamentos_empresa_id", "agendamentos", ["empresa_id"])
+    op.create_index("ix_agendamentos_inicio", "agendamentos", ["inicio"])
+
+    op.execute(
+        sa.text(
+            """
+        CREATE OR REPLACE VIEW v_certificados_status AS
+        SELECT
+            c.id                 AS cert_id,
+            e.id                 AS empresa_id,
+            e.org_id             AS org_id,
+            e.empresa            AS empresa,
+            e.cnpj               AS cnpj,
+            c.valido_de,
+            c.valido_ate,
+            GREATEST(0, (c.valido_ate::date - current_date))::int AS dias_restantes,
+            CASE
+                WHEN c.valido_ate IS NULL THEN 'INDEFINIDO'
+                WHEN c.valido_ate < current_date THEN 'VENCIDO'
+                WHEN c.valido_ate <= current_date + INTERVAL '7 day' THEN 'VENCE EM 7 DIAS'
+                WHEN c.valido_ate <= current_date + INTERVAL '30 day' THEN 'VENCE EM 30 DIAS'
+                ELSE 'VÁLIDO'
+            END AS situacao
+        FROM certificados c
+        LEFT JOIN empresas e
+          ON e.id = c.empresa_id AND e.org_id = c.org_id
+        WHERE current_setting('app.current_org', true) IS NULL
+           OR e.org_id = current_setting('app.current_org')::uuid;
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP VIEW IF EXISTS v_certificados_status"))
+    op.drop_index("ix_agendamentos_inicio", table_name="agendamentos")
+    op.drop_index("ix_agendamentos_empresa_id", table_name="agendamentos")
+    op.drop_index("ix_agendamentos_org_id", table_name="agendamentos")
+    op.drop_table("agendamentos")
+    op.drop_index("ix_certificados_valido_ate", table_name="certificados")
+    op.drop_index("ix_certificados_empresa_id", table_name="certificados")
+    op.drop_index("ix_certificados_org_id", table_name="certificados")
+    op.drop_table("certificados")


### PR DESCRIPTION
## Summary
- add Alembic migration for certificados/agendamentos tables and certificates status view
- implement SQLAlchemy models, Pydantic schemas, and FastAPI endpoints for certificados and agendamentos
- extend router wiring and harden org scoping dependency for non-Postgres sessions

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69148fb6705c8326af266c8697623be8)