### PR TITLE
Handle úteis view permission fallback

### DIFF
--- a/backend/app/api/v1/endpoints/uteis.py
+++ b/backend/app/api/v1/endpoints/uteis.py
@@ -1,60 +1,244 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
+from psycopg.errors import InsufficientPrivilege
 from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db
+from app.deps.auth import Role, User, db_with_org, require_role
 
 router = APIRouter(prefix="/uteis", tags=["Uteis"])
 
 
-def _table_exists(db: Session, name: str) -> bool:
+def _relation_exists(db: Session, name: str) -> bool:
+    """Return True when the given table or view exists in the public schema."""
+
     return bool(
         db.execute(
-            text(
-                """
-                SELECT 1
-                FROM information_schema.tables
-                WHERE table_schema = 'public' AND table_name = :t
-                LIMIT 1
-                """
-            ),
-            {"t": name},
+            text("SELECT to_regclass(:relname)"),
+            {"relname": f"public.{name}"},
         ).scalar()
     )
 
 
-@router.get("")
-def listar_uteis(db: Session = Depends(get_db)):
-    contatos = []
-    if _table_exists(db, "contatos"):
-        contatos = [
-            dict(row)
-            for row in db.execute(
-                text(
-                    """
-                    SELECT id, contato, municipio, telefone, whatsapp, email, categoria
-                    FROM contatos
-                    ORDER BY categoria, contato
-                    """
-                )
-            ).mappings().all()
-        ]
+def _is_permission_error(exc: ProgrammingError) -> bool:
+    """Detecta se a exceção foi causada por falta de permissão em uma view."""
 
-    modelos = []
-    if _table_exists(db, "modelos"):
-        modelos = [
-            dict(row)
-            for row in db.execute(
-                text(
-                    """
-                    SELECT id, titulo, categoria, caminho
-                    FROM modelos
-                    ORDER BY categoria, titulo
-                    """
-                )
-            ).mappings().all()
-        ]
+    return isinstance(exc.orig, InsufficientPrivilege) if exc.orig else False
+
+
+def _listar_contatos_base(
+    db: Session,
+    search: str | None,
+    categoria: str | None,
+    org_id: str,
+) -> list[dict[str, object]]:
+    filtros: list[str] = ["org_id = :org_id::uuid"]
+    params: dict[str, object] = {"org_id": org_id}
+
+    if search:
+        params["search"] = f"%{search}%"
+        filtros.append(
+            "(" "contato ILIKE :search OR "
+            "coalesce(email,'') ILIKE :search OR "
+            "coalesce(telefone,'') ILIKE :search OR "
+            "coalesce(municipio,'') ILIKE :search OR "
+            "coalesce(whatsapp,'') ILIKE :search)"
+        )
+
+    if categoria:
+        params["categoria"] = categoria
+        filtros.append("categoria = :categoria::categoria_contato_enum")
+
+    where_clause = " WHERE " + " AND ".join(filtros) if filtros else ""
+
+    query = text(
+        """
+        SELECT
+            id,
+            contato AS nome,
+            municipio,
+            telefone,
+            whatsapp,
+            email,
+            categoria::text AS categoria,
+            created_at,
+            updated_at
+        FROM contatos
+        {where}
+        ORDER BY categoria, contato
+        """.format(where=where_clause)
+    )
+
+    registros: list[dict[str, object]] = []
+    for row in db.execute(query, params).mappings().all():
+        registro = dict(row)
+        registro["contato"] = registro.pop("nome")
+        registros.append(registro)
+
+    return registros
+
+
+def _listar_modelos_base(
+    db: Session,
+    search: str | None,
+    utilizacao: str | None,
+    org_id: str,
+) -> list[dict[str, object]]:
+    filtros: list[str] = ["org_id = :org_id::uuid"]
+    params: dict[str, object] = {"org_id": org_id}
+
+    if search:
+        params["search"] = f"%{search}%"
+        filtros.append(
+            "(" "modelo ILIKE :search OR "
+            "coalesce(descricao,'') ILIKE :search)"
+        )
+
+    if utilizacao:
+        params["utilizacao"] = utilizacao
+        filtros.append("utilizacao = :utilizacao")
+
+    where_clause = " WHERE " + " AND ".join(filtros) if filtros else ""
+
+    query = text(
+        """
+        SELECT
+            id,
+            modelo AS titulo,
+            descricao AS conteudo,
+            utilizacao AS categoria,
+            created_at,
+            updated_at
+        FROM modelos
+        {where}
+        ORDER BY categoria, modelo
+        """.format(where=where_clause)
+    )
+
+    registros: list[dict[str, object]] = []
+    for row in db.execute(query, params).mappings().all():
+        registro = dict(row)
+        registro["modelo"] = registro.pop("titulo")
+        registro["descricao"] = registro.pop("conteudo")
+        registro["utilizacao"] = registro.pop("categoria")
+        registros.append(registro)
+
+    return registros
+
+
+@router.get("")
+def listar_uteis(
+    search: str | None = Query(None, description="Texto para filtrar contatos e modelos."),
+    categoria: str | None = Query(None, description="Filtrar contatos por categoria."),
+    utilizacao: str | None = Query(None, description="Filtrar modelos pela utilização."),
+    db: Session = Depends(db_with_org),
+    user: User = Depends(require_role(Role.VIEWER)),
+):
+    contatos: list[dict[str, object]] = []
+    if _relation_exists(db, "v_contatos_uteis"):
+        filtros_contatos: list[str] = []
+        params_contatos: dict[str, object] = {}
+
+        if search:
+            params_contatos["search"] = f"%{search}%"
+            filtros_contatos.append(
+                "(nome ILIKE :search OR "
+                "coalesce(email,'') ILIKE :search OR "
+                "coalesce(telefone,'') ILIKE :search OR "
+                "coalesce(municipio,'') ILIKE :search OR "
+                "coalesce(whatsapp,'') ILIKE :search)"
+            )
+
+        if categoria:
+            params_contatos["categoria"] = categoria
+            filtros_contatos.append("categoria = :categoria::categoria_contato_enum")
+
+        where_clause_contatos = ""
+        if filtros_contatos:
+            where_clause_contatos = " WHERE " + " AND ".join(filtros_contatos)
+
+        query_contatos = text(
+            """
+            SELECT
+                id,
+                nome,
+                municipio,
+                telefone,
+                whatsapp,
+                email,
+                categoria::text AS categoria,
+                created_at,
+                updated_at
+            FROM v_contatos_uteis
+            {where}
+            ORDER BY categoria, nome
+            """.format(where=where_clause_contatos)
+        )
+
+        try:
+            contatos = []
+            for row in db.execute(query_contatos, params_contatos).mappings().all():
+                registro = dict(row)
+                registro["contato"] = registro.pop("nome")
+                contatos.append(registro)
+        except ProgrammingError as exc:
+            if _is_permission_error(exc):
+                contatos = _listar_contatos_base(db, search, categoria, str(user.org_id))
+            else:  # pragma: no cover - propagates unexpected SQL errors
+                raise
+    elif _relation_exists(db, "contatos"):
+        contatos = _listar_contatos_base(db, search, categoria, str(user.org_id))
+
+    modelos: list[dict[str, object]] = []
+    if _relation_exists(db, "v_modelos_uteis"):
+        filtros_modelos: list[str] = []
+        params_modelos: dict[str, object] = {}
+
+        if search:
+            params_modelos["search"] = f"%{search}%"
+            filtros_modelos.append(
+                "(titulo ILIKE :search OR coalesce(conteudo,'') ILIKE :search)"
+            )
+
+        if utilizacao:
+            params_modelos["utilizacao"] = utilizacao
+            filtros_modelos.append("categoria = :utilizacao")
+
+        where_clause_modelos = ""
+        if filtros_modelos:
+            where_clause_modelos = " WHERE " + " AND ".join(filtros_modelos)
+
+        query_modelos = text(
+            """
+            SELECT
+                id,
+                titulo,
+                conteudo,
+                categoria,
+                created_at,
+                updated_at
+            FROM v_modelos_uteis
+            {where}
+            ORDER BY categoria, titulo
+            """.format(where=where_clause_modelos)
+        )
+
+        try:
+            modelos = []
+            for row in db.execute(query_modelos, params_modelos).mappings().all():
+                registro = dict(row)
+                registro["modelo"] = registro.pop("titulo")
+                registro["descricao"] = registro.pop("conteudo")
+                registro["utilizacao"] = registro.pop("categoria")
+                modelos.append(registro)
+        except ProgrammingError as exc:
+            if _is_permission_error(exc):
+                modelos = _listar_modelos_base(db, search, utilizacao, str(user.org_id))
+            else:  # pragma: no cover - unexpected SQL errors
+                raise
+    elif _relation_exists(db, "modelos"):
+        modelos = _listar_modelos_base(db, search, utilizacao, str(user.org_id))
 
     return {"contatos": contatos, "modelos": modelos}

--- a/backend/app/api/v1/endpoints/uteis.py
+++ b/backend/app/api/v1/endpoints/uteis.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query
 from psycopg.errors import InsufficientPrivilege
-from sqlalchemy import text
+from sqlalchemy import cast, or_, select, text
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
+from sqlalchemy.types import String
 
 from app.deps.auth import Role, User, db_with_org, require_role
+from db.models_sql import Contato, Modelo
 
 router = APIRouter(prefix="/uteis", tags=["Uteis"])
 
@@ -34,50 +36,40 @@ def _listar_contatos_base(
     categoria: str | None,
     org_id: str,
 ) -> list[dict[str, object]]:
-    filtros: list[str] = ["org_id = :org_id::uuid"]
-    params: dict[str, object] = {"org_id": org_id}
+    categoria_text = cast(Contato.categoria, String)
+    stmt = (
+        select(
+            Contato.id,
+            Contato.contato.label("contato"),
+            Contato.municipio,
+            Contato.telefone,
+            Contato.whatsapp,
+            Contato.email,
+            categoria_text.label("categoria"),
+            Contato.created_at,
+            Contato.updated_at,
+        )
+        .where(Contato.org_id == org_id)
+    )
 
     if search:
-        params["search"] = f"%{search}%"
-        filtros.append(
-            "(" "contato ILIKE :search OR "
-            "coalesce(email,'') ILIKE :search OR "
-            "coalesce(telefone,'') ILIKE :search OR "
-            "coalesce(municipio,'') ILIKE :search OR "
-            "coalesce(whatsapp,'') ILIKE :search)"
+        pattern = f"%{search}%"
+        stmt = stmt.where(
+            or_(
+                Contato.contato.ilike(pattern),
+                Contato.email.ilike(pattern),
+                Contato.telefone.ilike(pattern),
+                Contato.municipio.ilike(pattern),
+                Contato.whatsapp.ilike(pattern),
+            )
         )
 
     if categoria:
-        params["categoria"] = categoria
-        filtros.append("categoria = :categoria::categoria_contato_enum")
+        stmt = stmt.where(Contato.categoria == categoria)
 
-    where_clause = " WHERE " + " AND ".join(filtros) if filtros else ""
+    stmt = stmt.order_by(categoria_text, Contato.contato)
 
-    query = text(
-        """
-        SELECT
-            id,
-            contato AS nome,
-            municipio,
-            telefone,
-            whatsapp,
-            email,
-            categoria::text AS categoria,
-            created_at,
-            updated_at
-        FROM contatos
-        {where}
-        ORDER BY categoria, contato
-        """.format(where=where_clause)
-    )
-
-    registros: list[dict[str, object]] = []
-    for row in db.execute(query, params).mappings().all():
-        registro = dict(row)
-        registro["contato"] = registro.pop("nome")
-        registros.append(registro)
-
-    return registros
+    return [dict(row) for row in db.execute(stmt).mappings().all()]
 
 
 def _listar_modelos_base(
@@ -86,46 +78,33 @@ def _listar_modelos_base(
     utilizacao: str | None,
     org_id: str,
 ) -> list[dict[str, object]]:
-    filtros: list[str] = ["org_id = :org_id::uuid"]
-    params: dict[str, object] = {"org_id": org_id}
+    stmt = (
+        select(
+            Modelo.id,
+            Modelo.modelo.label("modelo"),
+            Modelo.descricao.label("descricao"),
+            Modelo.utilizacao.label("utilizacao"),
+            Modelo.created_at,
+            Modelo.updated_at,
+        )
+        .where(Modelo.org_id == org_id)
+    )
 
     if search:
-        params["search"] = f"%{search}%"
-        filtros.append(
-            "(" "modelo ILIKE :search OR "
-            "coalesce(descricao,'') ILIKE :search)"
+        pattern = f"%{search}%"
+        stmt = stmt.where(
+            or_(
+                Modelo.modelo.ilike(pattern),
+                Modelo.descricao.ilike(pattern),
+            )
         )
 
     if utilizacao:
-        params["utilizacao"] = utilizacao
-        filtros.append("utilizacao = :utilizacao")
+        stmt = stmt.where(Modelo.utilizacao == utilizacao)
 
-    where_clause = " WHERE " + " AND ".join(filtros) if filtros else ""
+    stmt = stmt.order_by(Modelo.utilizacao, Modelo.modelo)
 
-    query = text(
-        """
-        SELECT
-            id,
-            modelo AS titulo,
-            descricao AS conteudo,
-            utilizacao AS categoria,
-            created_at,
-            updated_at
-        FROM modelos
-        {where}
-        ORDER BY categoria, modelo
-        """.format(where=where_clause)
-    )
-
-    registros: list[dict[str, object]] = []
-    for row in db.execute(query, params).mappings().all():
-        registro = dict(row)
-        registro["modelo"] = registro.pop("titulo")
-        registro["descricao"] = registro.pop("conteudo")
-        registro["utilizacao"] = registro.pop("categoria")
-        registros.append(registro)
-
-    return registros
+    return [dict(row) for row in db.execute(stmt).mappings().all()]
 
 
 @router.get("")
@@ -136,10 +115,12 @@ def listar_uteis(
     db: Session = Depends(db_with_org),
     user: User = Depends(require_role(Role.VIEWER)),
 ):
+    org_id = str(user.org_id)
+
     contatos: list[dict[str, object]] = []
     if _relation_exists(db, "v_contatos_uteis"):
-        filtros_contatos: list[str] = []
-        params_contatos: dict[str, object] = {}
+        filtros_contatos: list[str] = ["org_id = CAST(:org_id AS uuid)"]
+        params_contatos: dict[str, object] = {"org_id": org_id}
 
         if search:
             params_contatos["search"] = f"%{search}%"
@@ -153,7 +134,9 @@ def listar_uteis(
 
         if categoria:
             params_contatos["categoria"] = categoria
-            filtros_contatos.append("categoria = :categoria::categoria_contato_enum")
+            filtros_contatos.append(
+                "categoria = CAST(:categoria AS categoria_contato_enum)"
+            )
 
         where_clause_contatos = ""
         if filtros_contatos:
@@ -185,16 +168,16 @@ def listar_uteis(
                 contatos.append(registro)
         except ProgrammingError as exc:
             if _is_permission_error(exc):
-                contatos = _listar_contatos_base(db, search, categoria, str(user.org_id))
+                contatos = _listar_contatos_base(db, search, categoria, org_id)
             else:  # pragma: no cover - propagates unexpected SQL errors
                 raise
     elif _relation_exists(db, "contatos"):
-        contatos = _listar_contatos_base(db, search, categoria, str(user.org_id))
+        contatos = _listar_contatos_base(db, search, categoria, org_id)
 
     modelos: list[dict[str, object]] = []
     if _relation_exists(db, "v_modelos_uteis"):
-        filtros_modelos: list[str] = []
-        params_modelos: dict[str, object] = {}
+        filtros_modelos: list[str] = ["org_id = CAST(:org_id AS uuid)"]
+        params_modelos: dict[str, object] = {"org_id": org_id}
 
         if search:
             params_modelos["search"] = f"%{search}%"
@@ -235,10 +218,10 @@ def listar_uteis(
                 modelos.append(registro)
         except ProgrammingError as exc:
             if _is_permission_error(exc):
-                modelos = _listar_modelos_base(db, search, utilizacao, str(user.org_id))
+                modelos = _listar_modelos_base(db, search, utilizacao, org_id)
             else:  # pragma: no cover - unexpected SQL errors
                 raise
     elif _relation_exists(db, "modelos"):
-        modelos = _listar_modelos_base(db, search, utilizacao, str(user.org_id))
+        modelos = _listar_modelos_base(db, search, utilizacao, org_id)
 
     return {"contatos": contatos, "modelos": modelos}

--- a/backend/db/models_sql.py
+++ b/backend/db/models_sql.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ENUM as PGEnum, UUID
 from sqlalchemy.orm import declarative_base, relationship
@@ -183,22 +184,36 @@ class Contato(Base):
     __tablename__ = "contatos"
 
     id = Column(Integer, primary_key=True)
+    org_id = Column(UUID(as_uuid=False), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
     contato = Column(String(255), nullable=False)
     municipio = Column(String(120))
     telefone = Column(String(60))
-    whatsapp = Column(String(10), nullable=False, default="NÃO")
+    whatsapp = Column(String(10), nullable=False, server_default=text("'NÃO'"))
     email = Column(String(255))
     categoria = Column(pg_enum("categorias_contato"), nullable=False)
+    obs = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
-    __table_args__ = (Index("idx_contatos_categoria", "categoria"),)
+    __table_args__ = (
+        Index("idx_contatos_categoria", "categoria"),
+        Index("idx_contatos_org_nome", "org_id", func.lower(func.immutable_unaccent(contato))),
+        Index("idx_contatos_org_email", "org_id", func.lower(email)),
+    )
 
 
 class Modelo(Base):
     __tablename__ = "modelos"
 
     id = Column(Integer, primary_key=True)
+    org_id = Column(UUID(as_uuid=False), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
     modelo = Column(Text, nullable=False)
     descricao = Column(String(255))
     utilizacao = Column(String(120), nullable=False, default="WhatsApp")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
-    __table_args__ = (Index("idx_modelos_utilizacao", "utilizacao"),)
+    __table_args__ = (
+        Index("idx_modelos_utilizacao", "utilizacao"),
+        Index("idx_modelos_org_titulo", "org_id", func.lower(func.immutable_unaccent(modelo))),
+    )


### PR DESCRIPTION
## Summary
- add helpers that fall back to the base contatos/modelos tables when the úteis views are inaccessible
- keep the multi-tenant filters and response shaping consistent whether the views or tables are used
- reuse the same search/category filters while enforcing organization scoping with the authenticated user context

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e2d194d8832687defbeb0d0f372b)