### PR TITLE
Reset úteis fallbacks after permission errors

### DIFF
--- a/backend/app/api/v1/endpoints/uteis.py
+++ b/backend/app/api/v1/endpoints/uteis.py
@@ -1,60 +1,231 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
-from sqlalchemy import text
-from sqlalchemy.orm import Session
+from uuid import UUID
 
-from app.api.deps import get_db
+from fastapi import APIRouter, Depends, Query
+from psycopg.errors import InsufficientPrivilege
+from sqlalchemy import cast, or_, select, text
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.orm import Session
+from sqlalchemy.types import String
+
+from app.deps.auth import Role, User, db_with_org, require_role
+from db.models_sql import Contato, Modelo
 
 router = APIRouter(prefix="/uteis", tags=["Uteis"])
 
 
-def _table_exists(db: Session, name: str) -> bool:
+def _relation_exists(db: Session, name: str) -> bool:
+    """Return True when the given table or view exists in the public schema."""
+
     return bool(
         db.execute(
-            text(
-                """
-                SELECT 1
-                FROM information_schema.tables
-                WHERE table_schema = 'public' AND table_name = :t
-                LIMIT 1
-                """
-            ),
-            {"t": name},
+            text("SELECT to_regclass(:relname)"),
+            {"relname": f"public.{name}"},
         ).scalar()
     )
 
 
-@router.get("")
-def listar_uteis(db: Session = Depends(get_db)):
-    contatos = []
-    if _table_exists(db, "contatos"):
-        contatos = [
-            dict(row)
-            for row in db.execute(
-                text(
-                    """
-                    SELECT id, contato, municipio, telefone, whatsapp, email, categoria
-                    FROM contatos
-                    ORDER BY categoria, contato
-                    """
-                )
-            ).mappings().all()
-        ]
+def _is_permission_error(exc: ProgrammingError) -> bool:
+    """Detecta se a exceção foi causada por falta de permissão em uma view."""
 
-    modelos = []
-    if _table_exists(db, "modelos"):
-        modelos = [
-            dict(row)
-            for row in db.execute(
-                text(
-                    """
-                    SELECT id, titulo, categoria, caminho
-                    FROM modelos
-                    ORDER BY categoria, titulo
-                    """
-                )
-            ).mappings().all()
-        ]
+    return isinstance(exc.orig, InsufficientPrivilege) if exc.orig else False
+
+
+def _listar_contatos_base(
+    db: Session,
+    search: str | None,
+    categoria: str | None,
+    org_id: UUID,
+) -> list[dict[str, object]]:
+    categoria_text = cast(Contato.categoria, String)
+    stmt = (
+        select(
+            Contato.id,
+            Contato.contato.label("contato"),
+            Contato.municipio,
+            Contato.telefone,
+            Contato.whatsapp,
+            Contato.email,
+            categoria_text.label("categoria"),
+            Contato.created_at,
+            Contato.updated_at,
+        )
+        .where(Contato.org_id == org_id)
+    )
+
+    if search:
+        pattern = f"%{search}%"
+        stmt = stmt.where(
+            or_(
+                Contato.contato.ilike(pattern),
+                Contato.email.ilike(pattern),
+                Contato.telefone.ilike(pattern),
+                Contato.municipio.ilike(pattern),
+                Contato.whatsapp.ilike(pattern),
+            )
+        )
+
+    if categoria:
+        stmt = stmt.where(Contato.categoria == categoria)
+
+    stmt = stmt.order_by(categoria_text, Contato.contato)
+
+    return [dict(row) for row in db.execute(stmt).mappings().all()]
+
+
+def _listar_modelos_base(
+    db: Session,
+    search: str | None,
+    utilizacao: str | None,
+    org_id: UUID,
+) -> list[dict[str, object]]:
+    stmt = (
+        select(
+            Modelo.id,
+            Modelo.modelo.label("modelo"),
+            Modelo.descricao.label("descricao"),
+            Modelo.utilizacao.label("utilizacao"),
+            Modelo.created_at,
+            Modelo.updated_at,
+        )
+        .where(Modelo.org_id == org_id)
+    )
+
+    if search:
+        pattern = f"%{search}%"
+        stmt = stmt.where(
+            or_(
+                Modelo.modelo.ilike(pattern),
+                Modelo.descricao.ilike(pattern),
+            )
+        )
+
+    if utilizacao:
+        stmt = stmt.where(Modelo.utilizacao == utilizacao)
+
+    stmt = stmt.order_by(Modelo.utilizacao, Modelo.modelo)
+
+    return [dict(row) for row in db.execute(stmt).mappings().all()]
+
+
+@router.get("")
+def listar_uteis(
+    search: str | None = Query(None, description="Texto para filtrar contatos e modelos."),
+    categoria: str | None = Query(None, description="Filtrar contatos por categoria."),
+    utilizacao: str | None = Query(None, description="Filtrar modelos pela utilização."),
+    db: Session = Depends(db_with_org),
+    user: User = Depends(require_role(Role.VIEWER)),
+):
+    org_id = user.org_id
+
+    contatos: list[dict[str, object]] = []
+    if _relation_exists(db, "v_contatos_uteis"):
+        filtros_contatos: list[str] = ["org_id = :org_id"]
+        params_contatos: dict[str, object] = {"org_id": org_id}
+
+        if search:
+            params_contatos["search"] = f"%{search}%"
+            filtros_contatos.append(
+                "(nome ILIKE :search OR "
+                "coalesce(email,'') ILIKE :search OR "
+                "coalesce(telefone,'') ILIKE :search OR "
+                "coalesce(municipio,'') ILIKE :search OR "
+                "coalesce(whatsapp,'') ILIKE :search)"
+            )
+
+        if categoria:
+            params_contatos["categoria"] = categoria
+            filtros_contatos.append(
+                "categoria = CAST(:categoria AS categoria_contato_enum)"
+            )
+
+        where_clause_contatos = ""
+        if filtros_contatos:
+            where_clause_contatos = " WHERE " + " AND ".join(filtros_contatos)
+
+        query_contatos = text(
+            """
+            SELECT
+                id,
+                nome,
+                municipio,
+                telefone,
+                whatsapp,
+                email,
+                categoria::text AS categoria,
+                created_at,
+                updated_at
+            FROM v_contatos_uteis
+            {where}
+            ORDER BY categoria, nome
+            """.format(where=where_clause_contatos)
+        )
+
+        try:
+            contatos = []
+            for row in db.execute(query_contatos, params_contatos).mappings().all():
+                registro = dict(row)
+                registro["contato"] = registro.pop("nome")
+                contatos.append(registro)
+        except ProgrammingError as exc:
+            if _is_permission_error(exc):
+                db.rollback()
+                contatos = _listar_contatos_base(db, search, categoria, org_id)
+            else:  # pragma: no cover - propagates unexpected SQL errors
+                raise
+    elif _relation_exists(db, "contatos"):
+        contatos = _listar_contatos_base(db, search, categoria, org_id)
+
+    modelos: list[dict[str, object]] = []
+    if _relation_exists(db, "v_modelos_uteis"):
+        filtros_modelos: list[str] = ["org_id = :org_id"]
+        params_modelos: dict[str, object] = {"org_id": org_id}
+
+        if search:
+            params_modelos["search"] = f"%{search}%"
+            filtros_modelos.append(
+                "(titulo ILIKE :search OR coalesce(conteudo,'') ILIKE :search)"
+            )
+
+        if utilizacao:
+            params_modelos["utilizacao"] = utilizacao
+            filtros_modelos.append("categoria = :utilizacao")
+
+        where_clause_modelos = ""
+        if filtros_modelos:
+            where_clause_modelos = " WHERE " + " AND ".join(filtros_modelos)
+
+        query_modelos = text(
+            """
+            SELECT
+                id,
+                titulo,
+                conteudo,
+                categoria,
+                created_at,
+                updated_at
+            FROM v_modelos_uteis
+            {where}
+            ORDER BY categoria, titulo
+            """.format(where=where_clause_modelos)
+        )
+
+        try:
+            modelos = []
+            for row in db.execute(query_modelos, params_modelos).mappings().all():
+                registro = dict(row)
+                registro["modelo"] = registro.pop("titulo")
+                registro["descricao"] = registro.pop("conteudo")
+                registro["utilizacao"] = registro.pop("categoria")
+                modelos.append(registro)
+        except ProgrammingError as exc:
+            if _is_permission_error(exc):
+                db.rollback()
+                modelos = _listar_modelos_base(db, search, utilizacao, org_id)
+            else:  # pragma: no cover - unexpected SQL errors
+                raise
+    elif _relation_exists(db, "modelos"):
+        modelos = _listar_modelos_base(db, search, utilizacao, org_id)
 
     return {"contatos": contatos, "modelos": modelos}

--- a/backend/db/models_sql.py
+++ b/backend/db/models_sql.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ENUM as PGEnum, UUID
 from sqlalchemy.orm import declarative_base, relationship
@@ -183,22 +184,36 @@ class Contato(Base):
     __tablename__ = "contatos"
 
     id = Column(Integer, primary_key=True)
+    org_id = Column(UUID(as_uuid=False), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
     contato = Column(String(255), nullable=False)
     municipio = Column(String(120))
     telefone = Column(String(60))
-    whatsapp = Column(String(10), nullable=False, default="NÃO")
+    whatsapp = Column(String(10), nullable=False, server_default=text("'NÃO'"))
     email = Column(String(255))
     categoria = Column(pg_enum("categorias_contato"), nullable=False)
+    obs = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
-    __table_args__ = (Index("idx_contatos_categoria", "categoria"),)
+    __table_args__ = (
+        Index("idx_contatos_categoria", "categoria"),
+        Index("idx_contatos_org_nome", "org_id", func.lower(func.immutable_unaccent(contato))),
+        Index("idx_contatos_org_email", "org_id", func.lower(email)),
+    )
 
 
 class Modelo(Base):
     __tablename__ = "modelos"
 
     id = Column(Integer, primary_key=True)
+    org_id = Column(UUID(as_uuid=False), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
     modelo = Column(Text, nullable=False)
     descricao = Column(String(255))
     utilizacao = Column(String(120), nullable=False, default="WhatsApp")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
-    __table_args__ = (Index("idx_modelos_utilizacao", "utilizacao"),)
+    __table_args__ = (
+        Index("idx_modelos_utilizacao", "utilizacao"),
+        Index("idx_modelos_org_titulo", "org_id", func.lower(func.immutable_unaccent(modelo))),
+    )


### PR DESCRIPTION
## Summary
- ensure the úteis view queries bind the organization id directly and roll back the session when permission errors occur before falling back to the base tables
- keep the ORM-powered fallbacks using UUID-aware filters so multi-tenant scopes work without aborted transactions

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e2d194d8832687defbeb0d0f372b)