### PR TITLE
Increase pagination limits to 2000 items

### DIFF
--- a/backend/app/api/v1/endpoints/agendamentos.py
+++ b/backend/app/api/v1/endpoints/agendamentos.py
@@ -11,7 +11,7 @@ router = APIRouter(prefix="/agendamentos", tags=["Agendamentos"])
 @router.get("/")
 def listar_agendamentos(
     page: int = Query(1, ge=1),
-    size: int = Query(20, ge=1, le=200),
+    size: int = Query(20, ge=1, le=2000),
     _: object = Depends(require_org),
 ) -> dict[str, int | list[dict]]:
     """Stub de agendamentos para evitar 404 até que o domínio seja implementado."""

--- a/backend/app/api/v1/endpoints/alertas.py
+++ b/backend/app/api/v1/endpoints/alertas.py
@@ -31,7 +31,7 @@ def listar_alertas(
     tipo_alerta: str | None = Query(None),
     empresa_id: int | None = Query(None),
     page: int = Query(1, ge=1),
-    size: int = Query(20, ge=1, le=100),
+    size: int = Query(20, ge=1, le=2000),
     sort: str | None = Query(None),
     db: Session = Depends(db_with_org),
     _: User = Depends(require_role(Role.VIEWER)),

--- a/backend/app/api/v1/endpoints/certificados.py
+++ b/backend/app/api/v1/endpoints/certificados.py
@@ -29,7 +29,7 @@ ALLOWED_SORTS: Dict[str, str] = {
 def listar_certificados(
     q: str | None = Query(None, description="Busca por empresa ou CNPJ"),
     page: int = Query(1, ge=1),
-    size: int = Query(20, ge=1, le=100),
+    size: int = Query(20, ge=1, le=2000),
     sort: str | None = Query(None, description="Campo de ordenação"),
     db: Session = Depends(db_with_org),
     _: User = Depends(require_role(Role.VIEWER)),

--- a/backend/app/api/v1/endpoints/empresas.py
+++ b/backend/app/api/v1/endpoints/empresas.py
@@ -44,7 +44,7 @@ def listar_empresas(
     porte: str | None = Query(None),
     categoria: str | None = Query(None),
     page: int = Query(1, ge=1),
-    size: int = Query(20, ge=1, le=100),
+    size: int = Query(20, ge=1, le=2000),
     sort: str | None = Query(None, description="Campo de ordenação"),
     db: Session = Depends(db_with_org),
     _: User = Depends(require_role(Role.VIEWER)),

--- a/backend/app/api/v1/endpoints/grupos.py
+++ b/backend/app/api/v1/endpoints/grupos.py
@@ -34,12 +34,12 @@ KPI_LABELS: Dict[tuple[str, str], str] = {
 def listar_kpis(
     grupo: str | None = Query(None),
     page: int = Query(1, ge=1),
-    size: int = Query(50, ge=1, le=200),
+    size: int = Query(50, ge=1, le=2000),
     sort: str | None = Query(None),
     db: Session = Depends(db_with_org),
     _: User = Depends(require_role(Role.VIEWER)),
 ) -> GrupoKPIListResponse:
-    page, size = ensure_positive_pagination(page, size, max_size=500)
+    page, size = ensure_positive_pagination(page, size, max_size=2000)
     params: Dict[str, object] = {}
     filters: list[str] = []
 

--- a/backend/app/api/v1/endpoints/licencas.py
+++ b/backend/app/api/v1/endpoints/licencas.py
@@ -43,7 +43,7 @@ def listar_licencas(
     municipio: str | None = Query(None),
     vencer_em_dias: int | None = Query(None, ge=0),
     page: int = Query(1, ge=1),
-    size: int = Query(20, ge=1, le=100),
+    size: int = Query(20, ge=1, le=2000),
     sort: str | None = Query(None),
     db: Session = Depends(db_with_org),
     _: User = Depends(require_role(Role.VIEWER)),

--- a/backend/app/api/v1/endpoints/processos.py
+++ b/backend/app/api/v1/endpoints/processos.py
@@ -59,7 +59,7 @@ def listar_processos(
     situacao: str | None = Query(None),
     status_padrao: str | None = Query(None),
     page: int = Query(1, ge=1),
-    size: int = Query(20, ge=1, le=100),
+    size: int = Query(20, ge=1, le=2000),
     sort: str | None = Query(None),
     db: Session = Depends(db_with_org),
     _: User = Depends(require_role(Role.VIEWER)),

--- a/backend/app/api/v1/endpoints/taxas.py
+++ b/backend/app/api/v1/endpoints/taxas.py
@@ -42,7 +42,7 @@ def listar_taxas(
     status_filtro: str | None = Query(None, alias="status"),
     esta_pago: bool | None = Query(None),
     page: int = Query(1, ge=1),
-    size: int = Query(20, ge=1, le=100),
+    size: int = Query(20, ge=1, le=2000),
     sort: str | None = Query(None),
     db: Session = Depends(db_with_org),
     _: User = Depends(require_role(Role.VIEWER)),

--- a/backend/app/api/v1/endpoints/utils.py
+++ b/backend/app/api/v1/endpoints/utils.py
@@ -36,7 +36,7 @@ def paginate_query(
     return {"items": items, "total": total, "page": page, "size": size}
 
 
-def ensure_positive_pagination(page: int, size: int, max_size: int = 100) -> Tuple[int, int]:
+def ensure_positive_pagination(page: int, size: int, max_size: int = 2000) -> Tuple[int, int]:
     if page < 1:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="page deve ser >= 1")
     if size < 1:


### PR DESCRIPTION
## Summary
- raise the default backend pagination cap to 2000 items
- align all list endpoints to accept page sizes up to 2000 entries

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69160693c47c832696c5dfabdc05286b)