### PR TITLE
Add fiscal fields to empresa model and schema

### DIFF
--- a/backend/app/schemas/empresas.py
+++ b/backend/app/schemas/empresas.py
@@ -45,12 +45,17 @@ class EmpresaBase(BaseModel):
     certificado: Optional[str] = None
     ie: Optional[str] = None
     im: Optional[str] = None
+    inscricao_municipal: Optional[str] = None
+    inscricao_estadual: Optional[str] = None
     telefone: Optional[str] = None
     email: Optional[str] = None
     obs: Optional[str] = None
     proprietario: Optional[str] = None
     cpf: Optional[str] = None
     responsavel: Optional[str] = None
+    responsavel_legal: Optional[str] = None
+    cpf_responsavel_legal: Optional[str] = None
+    responsavel_fiscal: Optional[str] = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -71,11 +76,16 @@ class EmpresaUpdate(BaseModel):
     certificado: Optional[str] = None
     ie: Optional[str] = None
     im: Optional[str] = None
+    inscricao_municipal: Optional[str] = None
+    inscricao_estadual: Optional[str] = None
     telefone: Optional[str] = None
     email: Optional[str] = None
     obs: Optional[str] = None
     proprietario: Optional[str] = None
     cpf: Optional[str] = None
     responsavel: Optional[str] = None
+    responsavel_legal: Optional[str] = None
+    cpf_responsavel_legal: Optional[str] = None
+    responsavel_fiscal: Optional[str] = None
 
     model_config = ConfigDict(extra="forbid")

--- a/backend/db/models_sql.py
+++ b/backend/db/models_sql.py
@@ -1,6 +1,7 @@
 """SQLAlchemy models for the eControle schema v1."""
 from __future__ import annotations
 
+import enum
 import os
 from pathlib import Path
 from typing import Dict
@@ -10,6 +11,7 @@ from sqlalchemy import (
     Column,
     Date,
     DateTime,
+    Enum as SAEnum,
     ForeignKey,
     Index,
     Integer,
@@ -58,6 +60,12 @@ def pg_enum(enum_key: str) -> PGEnum:
     return PGEnum(*values, name=ENUM_NAME_MAP[enum_key], create_type=False)
 
 
+class ResponsavelFiscalEnum(str, enum.Enum):
+    CARLA = "Carla"
+    DENISE = "Denise"
+    FERNANDO = "Fernando"
+
+
 class Empresa(Base):
     __tablename__ = "empresas"
 
@@ -71,6 +79,8 @@ class Empresa(Base):
     categoria = Column(String(120))
     ie = Column(String(50))
     im = Column(String(50))
+    inscricao_municipal = Column(String(50))
+    inscricao_estadual = Column(String(50))
     situacao = Column(String(120))
     debito = Column(String(120))
     certificado = Column(String(120))
@@ -80,6 +90,12 @@ class Empresa(Base):
     telefone = Column(String(60))
     email = Column(String(255))
     responsavel = Column(String(255))
+    responsavel_legal = Column(String(255))
+    cpf_responsavel_legal = Column(String(14))
+    responsavel_fiscal = Column(
+        SAEnum(ResponsavelFiscalEnum, name="responsavel_fiscal_enum", create_type=False),
+        nullable=True,
+    )
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
     created_by = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"))


### PR DESCRIPTION
## Summary
- add the ResponsavelFiscalEnum and related column to the Empresa SQLAlchemy model
- include new registration and responsible information fields on Empresa
- expose the new fields through the Pydantic Empresa schemas

## Testing
- pytest *(fails: tests/test_api_v1.py::test_agendamentos_stub expects size 20 instead of 2000)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924be36beac832695ef9b6e6c6db650)