### PR TITLE
Expose novos campos das empresas na API e no painel

### DIFF
--- a/backend/app/api/v1/endpoints/empresas.py
+++ b/backend/app/api/v1/endpoints/empresas.py
@@ -19,18 +19,53 @@ from db.models_sql import Empresa
 router = APIRouter(prefix="/empresas", tags=["Empresas"])
 
 ALLOWED_SORTS: Dict[str, str] = {
-    "empresa": "empresa",
-    "cnpj": "cnpj",
-    "municipio": "municipio",
-    "updated_at": "updated_at",
-    "total_licencas": "total_licencas",
-    "total_taxas": "total_taxas",
-    "processos_ativos": "processos_ativos",
+    "empresa": "v.empresa",
+    "cnpj": "v.cnpj",
+    "municipio": "v.municipio",
+    "updated_at": "v.updated_at",
+    "total_licencas": "v.total_licencas",
+    "total_taxas": "v.total_taxas",
+    "processos_ativos": "v.processos_ativos",
 }
 
 
+BASE_EMPRESA_QUERY = """
+SELECT
+    v.empresa_id,
+    v.org_id,
+    v.empresa,
+    v.cnpj,
+    v.municipio,
+    v.porte,
+    v.categoria,
+    v.situacao,
+    v.status_empresas,
+    v.debito,
+    v.certificado,
+    e.ie,
+    e.im,
+    e.inscricao_municipal,
+    e.inscricao_estadual,
+    e.telefone,
+    e.email,
+    e.obs,
+    e.proprietario,
+    e.cpf,
+    e.responsavel,
+    e.responsavel_legal,
+    e.cpf_responsavel_legal,
+    e.responsavel_fiscal,
+    v.total_licencas,
+    v.total_taxas,
+    v.processos_ativos,
+    v.updated_at
+FROM v_empresas v
+JOIN empresas e ON e.id = v.empresa_id AND e.org_id = v.org_id
+"""
+
+
 def _fetch_empresa_view(db: Session, empresa_id: int) -> EmpresaView:
-    query = text("SELECT * FROM v_empresas WHERE empresa_id = :empresa_id")
+    query = text(f"{BASE_EMPRESA_QUERY} WHERE v.empresa_id = :empresa_id")
     row = db.execute(query, {"empresa_id": empresa_id}).mappings().first()
     if not row:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Empresa não encontrada")
@@ -55,19 +90,19 @@ def listar_empresas(
 
     if q:
         params["q"] = f"%{q}%"
-        filters.append("(empresa ILIKE :q OR cnpj ILIKE :q)")
+        filters.append("(v.empresa ILIKE :q OR v.cnpj ILIKE :q)")
     if municipio:
         params["municipio"] = municipio
-        filters.append("municipio = :municipio")
+        filters.append("v.municipio = :municipio")
     if porte:
         params["porte"] = porte
-        filters.append("porte = :porte")
+        filters.append("v.porte = :porte")
     if categoria:
         params["categoria"] = categoria
-        filters.append("categoria = :categoria")
+        filters.append("v.categoria = :categoria")
 
     where_clause = build_where_clause(filters)
-    base_query = f"SELECT * FROM v_empresas{where_clause}"
+    base_query = f"{BASE_EMPRESA_QUERY}{where_clause}"
     sort_column, direction = resolve_sort(sort, ALLOWED_SORTS, "empresa")
     data = paginate_query(db, base_query, params, sort_column, direction, page, size)
     return EmpresaListResponse(**data)

--- a/backend/app/schemas/empresas.py
+++ b/backend/app/schemas/empresas.py
@@ -7,30 +7,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.schemas.common import PaginatedResponse
-
-
-class EmpresaView(BaseModel):
-    empresa_id: int = Field(..., description="Identificador interno da empresa")
-    org_id: UUID
-    empresa: str
-    cnpj: str
-    municipio: Optional[str] = None
-    porte: Optional[str] = None
-    categoria: Optional[str] = None
-    status_empresas: Optional[str] = None
-    situacao: Optional[str] = None
-    debito: Optional[str] = None
-    certificado: Optional[str] = None
-    total_licencas: int = 0
-    total_taxas: int = 0
-    processos_ativos: int = 0
-    updated_at: Optional[datetime] = None
-
-    model_config = ConfigDict(from_attributes=True)
-
-
-class EmpresaListResponse(PaginatedResponse[EmpresaView]):
-    pass
+from db.models_sql import ResponsavelFiscalEnum
 
 
 class EmpresaBase(BaseModel):
@@ -55,9 +32,24 @@ class EmpresaBase(BaseModel):
     responsavel: Optional[str] = None
     responsavel_legal: Optional[str] = None
     cpf_responsavel_legal: Optional[str] = None
-    responsavel_fiscal: Optional[str] = None
+    responsavel_fiscal: Optional[ResponsavelFiscalEnum] = None
 
     model_config = ConfigDict(extra="forbid")
+
+
+class EmpresaView(EmpresaBase):
+    empresa_id: int = Field(..., description="Identificador interno da empresa")
+    org_id: UUID
+    total_licencas: int = 0
+    total_taxas: int = 0
+    processos_ativos: int = 0
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class EmpresaListResponse(PaginatedResponse[EmpresaView]):
+    pass
 
 
 class EmpresaCreate(EmpresaBase):
@@ -86,6 +78,6 @@ class EmpresaUpdate(BaseModel):
     responsavel: Optional[str] = None
     responsavel_legal: Optional[str] = None
     cpf_responsavel_legal: Optional[str] = None
-    responsavel_fiscal: Optional[str] = None
+    responsavel_fiscal: Optional[ResponsavelFiscalEnum] = None
 
     model_config = ConfigDict(extra="forbid")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -82,11 +82,28 @@ const enhanceEmpresa = (empresa) => {
     normalizeIdentifier(empresa.inscricao_municipal) ||
     normalizeIdentifier(empresa.inscricaoMunicipal) ||
     normalizeIdentifier(empresa["inscrição_municipal"]);
+  const inscricaoMunicipal =
+    normalizeIdentifier(empresa.inscricaoMunicipal) ||
+    normalizeIdentifier(empresa.inscricao_municipal) ||
+    normalizeIdentifier(empresa["inscrição_municipal"]);
+  const inscricaoEstadual =
+    normalizeIdentifier(empresa.inscricaoEstadual) ||
+    normalizeIdentifier(empresa.inscricao_estadual) ||
+    normalizeIdentifier(empresa["inscrição_estadual"]);
+  const responsavelLegal = empresa.responsavelLegal ?? empresa.responsavel_legal;
+  const cpfResponsavelLegal =
+    normalizeIdentifier(empresa.cpfResponsavelLegal) || empresa.cpf_responsavel_legal;
+  const responsavelFiscal = empresa.responsavelFiscal ?? empresa.responsavel_fiscal;
   const empresaId = extractEmpresaId(empresa);
   return {
     ...empresa,
     ie,
     im,
+    inscricaoMunicipal: inscricaoMunicipal ?? im,
+    inscricaoEstadual: inscricaoEstadual ?? ie,
+    responsavelLegal,
+    cpfResponsavelLegal,
+    responsavelFiscal,
     empresaId: empresaId ?? empresa?.id,
     empresa_id: empresaId ?? empresa?.id,
   };
@@ -428,6 +445,10 @@ function AppContent() {
           empresa.email,
           empresa.ie,
           empresa.im,
+          empresa.telefone,
+          empresa.responsavel,
+          empresa.responsavelLegal,
+          empresa.responsavelFiscal,
         ]);
         const matchesMunicipio = matchesMunicipioFilter(empresa);
         const matchesAlert = !somenteAlertas || companyHasAlert(empresa);

--- a/frontend/src/features/empresas/EmpresasScreen.jsx
+++ b/frontend/src/features/empresas/EmpresasScreen.jsx
@@ -333,6 +333,35 @@ export default function EmpresasScreen({
                       <InlineBadge variant="outline" className="bg-white">
                         Débito: {empresa.debito}
                       </InlineBadge>
+                      {empresa.responsavelFiscal && (
+                        <InlineBadge variant="outline" className="bg-white">
+                          Resp. fiscal: {empresa.responsavelFiscal}
+                        </InlineBadge>
+                      )}
+                    </div>
+
+                    <div className="mt-3 grid gap-2 text-xs text-slate-700 sm:grid-cols-2">
+                      <div className="space-y-1">
+                        <p className="text-[11px] font-semibold uppercase text-slate-500">Contatos</p>
+                        <p>
+                          Telefone: <span className="font-medium">{empresa.telefone || "—"}</span>
+                        </p>
+                        <p>
+                          E-mail: <span className="font-medium">{empresa.email || "—"}</span>
+                        </p>
+                      </div>
+                      <div className="space-y-1">
+                        <p className="text-[11px] font-semibold uppercase text-slate-500">Responsáveis</p>
+                        <p>
+                          Legal: <span className="font-medium">{empresa.responsavelLegal || "—"}</span>
+                        </p>
+                        <p>
+                          CPF resp. legal: <span className="font-medium">{empresa.cpfResponsavelLegal || "—"}</span>
+                        </p>
+                        <p>
+                          Fiscal: <span className="font-medium">{empresa.responsavelFiscal || "—"}</span>
+                        </p>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -216,6 +216,24 @@ export const normalizeEmpresaFromApi = (item) => {
   if (normalized.org_id !== undefined && normalized.org_id !== null) {
     normalized.org_id = String(normalized.org_id);
   }
+  if (normalized.inscricao_municipal !== undefined && normalized.inscricaoMunicipal === undefined) {
+    normalized.inscricaoMunicipal = normalized.inscricao_municipal;
+  }
+  if (normalized.inscricao_estadual !== undefined && normalized.inscricaoEstadual === undefined) {
+    normalized.inscricaoEstadual = normalized.inscricao_estadual;
+  }
+  if (normalized.responsavel_legal !== undefined && normalized.responsavelLegal === undefined) {
+    normalized.responsavelLegal = normalized.responsavel_legal;
+  }
+  if (
+    normalized.cpf_responsavel_legal !== undefined &&
+    normalized.cpfResponsavelLegal === undefined
+  ) {
+    normalized.cpfResponsavelLegal = normalized.cpf_responsavel_legal;
+  }
+  if (normalized.responsavel_fiscal !== undefined && normalized.responsavelFiscal === undefined) {
+    normalized.responsavelFiscal = normalized.responsavel_fiscal;
+  }
   return normalized;
 };
 

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -21,6 +21,14 @@ export const TAB_SHORTCUTS = {
   7: "uteis",
 };
 
+export const RESPONSAVEL_FISCAL_OPTIONS = [
+  { value: "Carla", label: "Carla" },
+  { value: "Denise", label: "Denise" },
+  { value: "Fernando", label: "Fernando" },
+];
+
+export const RESPONSAVEL_FISCAL_VALUES = RESPONSAVEL_FISCAL_OPTIONS.map((item) => item.value);
+
 export const DEFAULT_LICENCA_TIPOS = [
   "Sanitária",
   "CERCON",

--- a/frontend/src/services/empresas.js
+++ b/frontend/src/services/empresas.js
@@ -6,3 +6,15 @@ export const listarEmpresas = async (params = {}) => {
     query: { page, size, sort, municipio, q, porte, categoria },
   });
 };
+
+export const obterEmpresa = async (empresaId) => {
+  return fetchJson(`/api/v1/empresas/${empresaId}`);
+};
+
+export const criarEmpresa = async (payload) => {
+  return fetchJson("/api/v1/empresas", { method: "POST", body: payload });
+};
+
+export const atualizarEmpresa = async (empresaId, payload) => {
+  return fetchJson(`/api/v1/empresas/${empresaId}`, { method: "PATCH", body: payload });
+};


### PR DESCRIPTION
## Summary
- adiciona o enum de responsável fiscal e novos campos de contato/responsáveis aos schemas de empresas
- ajusta consultas da API para retornar as colunas adicionais da tabela empresas
- normaliza e exibe os novos dados no frontend, incluindo serviços de criação/edição

## Testing
- python -m compileall backend/app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c140fc448326b806caed94422121)