### PR TITLE
Mask CNPJ display in identifiers

### DIFF
--- a/frontend/src/components/CopyableIdentifier.jsx
+++ b/frontend/src/components/CopyableIdentifier.jsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { Clipboard } from "lucide-react";
-import { normalizeIdentifier } from "@/lib/text";
+import { formatCnpj, normalizeIdentifier } from "@/lib/text";
 
 function CopyableIdentifier({ label, value, onCopy }) {
   const normalizedValue = normalizeIdentifier(value);
-  const displayValue = normalizedValue || "—";
+  const formattedCnpj = label === "CNPJ" ? formatCnpj(value) : undefined;
+  const displayValue = formattedCnpj || normalizedValue || "—";
   return (
     <button
       type="button"

--- a/frontend/src/lib/text.js
+++ b/frontend/src/lib/text.js
@@ -21,6 +21,13 @@ export const normalizeDocumentDigits = (value) => {
   return digits === "" ? undefined : digits;
 };
 
+export const formatCnpj = (value) => {
+  const digits = normalizeDocumentDigits(value);
+  if (!digits) return undefined;
+  if (digits.length !== 14) return digits;
+  return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8, 12)}-${digits.slice(12, 14)}`;
+};
+
 export const buildNormalizedSearchKey = (value) => {
   const normalized = removeDiacritics(normalizeTextLower(value));
   const sanitized = normalized.replace(NON_ALPHANUMERIC_REGEX, "");


### PR DESCRIPTION
## Summary
- add helper to format CNPJ numbers centrally
- display masked CNPJ values through CopyableIdentifier while keeping copy behavior unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a2d3da2083269e4e4d31c02e130b)