### PR TITLE
Treat slash-based taxa statuses as open

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -275,31 +275,157 @@ export const mapKpiItemsToRecord = (items) => {
   }, {});
 };
 
+const normalizeCollectionPayload = (payload, mapper) => {
+  const itemsSource = Array.isArray(payload?.items)
+    ? payload.items
+    : Array.isArray(payload)
+      ? payload
+      : [];
+  const normalizedItems = mapper ? itemsSource.map((item) => mapper(item)) : itemsSource;
+  const total = toFiniteNumber(payload?.total) ?? normalizedItems.length;
+  const page = toFiniteNumber(payload?.page) ?? 1;
+  const size = toFiniteNumber(payload?.size) ?? normalizedItems.length;
+  return attachPaginationInfo(normalizedItems, { total, page, size });
+};
+
+const TAXA_TIPO_TO_KEY = {
+  TPI: "tpi",
+  Funcionamento: "func",
+  Publicidade: "publicidade",
+  "Sanitária": "sanitaria",
+  "Localização/Instalação": "localizacao_instalacao",
+  "Área Pública": "area_publica",
+  Bombeiros: "bombeiros",
+  "Status Geral": "status_geral",
+};
+
+const normalizeTaxaTipo = (tipo) => {
+  if (typeof tipo !== "string") return "";
+  return tipo
+    .trim()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .toLowerCase()
+    .replace(/\s+/gu, " ")
+    .trim();
+};
+
+const NORMALIZED_TAXA_TIPO_TO_KEY = Object.entries(TAXA_TIPO_TO_KEY).reduce(
+  (acc, [label, key]) => {
+    const normalized = normalizeTaxaTipo(label);
+    if (normalized) {
+      acc[normalized] = key;
+    }
+    return acc;
+  },
+  {},
+);
+
+const TAXA_COLUMN_KEYS = Object.values(TAXA_TIPO_TO_KEY);
+const TAXA_STATUS_GERAL_KEYS = Object.entries(TAXA_TIPO_TO_KEY)
+  .filter(([label]) => label !== "TPI" && label !== "Bombeiros" && label !== "Status Geral")
+  .map(([, key]) => key);
+
+const isTaxaEmAberto = (status) => {
+  if (status === undefined || status === null) return false;
+  const normalized = String(status)
+    .trim()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+  if (!normalized || normalized === "*" || normalized === "-" || normalized === "—") {
+    return false;
+  }
+  const hasSlashRatio = /\d+\s*\/\s*\d+/u.test(normalized);
+  return hasSlashRatio || normalized.includes("abert");
+};
+
+const applyTaxaStatusGeral = (collection) => {
+  if (!Array.isArray(collection)) return collection;
+  collection.forEach((item) => {
+    if (!item || typeof item !== "object") return;
+    const hasAberta = TAXA_STATUS_GERAL_KEYS.some((key) => isTaxaEmAberto(item[key]));
+    item.status_geral = hasAberta ? "Irregular" : "Regular";
+  });
+  return collection;
+};
+
+const normalizeTaxasFromApi = (payload) => {
+  const collection = normalizeCollectionPayload(payload);
+  const metadata = {
+    total: collection.total,
+    page: collection.page,
+    size: collection.size,
+  };
+
+  const itemsSource = Array.isArray(payload?.items)
+    ? payload.items
+    : Array.isArray(payload)
+      ? payload
+      : [];
+
+  const hasTipoEntries = itemsSource.some(
+    (item) => item && typeof item === "object" && Object.hasOwn(item, "tipo"),
+  );
+  const alreadyWide = itemsSource.some(
+    (item) => item && typeof item === "object" && TAXA_COLUMN_KEYS.some((key) => key in item),
+  );
+
+  if (!hasTipoEntries || alreadyWide) {
+    return applyTaxaStatusGeral(collection);
+  }
+
+  const grouped = [];
+  const byEmpresa = new Map();
+
+  itemsSource.forEach((item) => {
+    if (!item || typeof item !== "object") return;
+
+    const empresaId = toFiniteNumber(item.empresa_id ?? item.empresaId ?? item.id);
+    if (empresaId === undefined) return;
+
+    let group = byEmpresa.get(empresaId);
+    if (!group) {
+      group = {
+        ...item,
+        empresaId,
+        empresa_id: empresaId,
+      };
+      byEmpresa.set(empresaId, group);
+      grouped.push(group);
+    }
+
+    const mappedKey = NORMALIZED_TAXA_TIPO_TO_KEY[normalizeTaxaTipo(item.tipo)];
+    const statusValue =
+      item.status ?? item.status_taxas ?? item.statusTaxa ?? item.status_tipo ?? item.statusTipo;
+    if (mappedKey && statusValue !== undefined) {
+      group[mappedKey] = statusValue;
+    }
+
+    if (group.empresa === undefined && item.empresa !== undefined) {
+      group.empresa = item.empresa;
+    }
+    if (group.cnpj === undefined && item.cnpj !== undefined) {
+      group.cnpj = item.cnpj;
+    }
+    if (group.municipio === undefined && item.municipio !== undefined) {
+      group.municipio = item.municipio;
+    }
+    if (!group.data_envio && item.data_envio) {
+      group.data_envio = item.data_envio;
+    }
+  });
+
+  return applyTaxaStatusGeral(attachPaginationInfo(grouped, metadata));
+};
+
 const DEFAULT_TRANSFORMS = {
-  "/empresas": (payload) => {
-    const itemsSource = Array.isArray(payload?.items)
-      ? payload.items
-      : Array.isArray(payload)
-        ? payload
-        : [];
-    const normalizedItems = itemsSource.map((item) => normalizeEmpresaFromApi(item));
-    const total = toFiniteNumber(payload?.total) ?? normalizedItems.length;
-    const page = toFiniteNumber(payload?.page) ?? 1;
-    const size = toFiniteNumber(payload?.size) ?? normalizedItems.length;
-    return attachPaginationInfo(normalizedItems, { total, page, size });
-  },
-  "/alertas": (payload) => {
-    const itemsSource = Array.isArray(payload?.items)
-      ? payload.items
-      : Array.isArray(payload)
-        ? payload
-        : [];
-    const normalizedItems = itemsSource.map((item) => normalizeAlertaFromApi(item));
-    const total = toFiniteNumber(payload?.total) ?? normalizedItems.length;
-    const page = toFiniteNumber(payload?.page) ?? 1;
-    const size = toFiniteNumber(payload?.size) ?? normalizedItems.length;
-    return attachPaginationInfo(normalizedItems, { total, page, size });
-  },
+  "/empresas": (payload) => normalizeCollectionPayload(payload, normalizeEmpresaFromApi),
+  "/alertas": (payload) => normalizeCollectionPayload(payload, normalizeAlertaFromApi),
+  "/licencas": (payload) => normalizeCollectionPayload(payload),
+  "/processos": (payload) => normalizeCollectionPayload(payload),
+  "/taxas": (payload) => normalizeTaxasFromApi(payload),
   "/kpis": (payload) => {
     if (payload && typeof payload === "object" && !Array.isArray(payload) && !payload.items) {
       return payload;


### PR DESCRIPTION
## Summary
- treat taxa statuses expressed as numeric ratios (e.g., 0/1) as open so they contribute to status_geral calculations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a955f4a883268b457736792dc376)