### PR TITLE
Alinha documentação ao uso da API v1 e schema

### DIFF
--- a/ESTRUTURA_PROJETO.md
+++ b/ESTRUTURA_PROJETO.md
@@ -1,56 +1,47 @@
 # Estrutura do Projeto eControle
 
-Visão rápida de onde cada responsabilidade mora. Use este guia como mapa para navegar no repositório.
+Mapa rápido das principais pastas e responsabilidades. Detalhes de execução estão no [`README.md`](README.md) e no [`GUIA_SETUP.md`](GUIA_SETUP.md).
 
 ```
 eControle/
-├── backend/                         # Backend FastAPI + integrações com Excel
-│   ├── api.py                       # Criação da app, cache de dados, endpoints REST
-│   ├── repo_excel.py                # Classe ExcelRepo (openpyxl + portalocker)
-│   ├── models.py                    # Dataclasses de domínio (Empresa, Licenca, ...)
-│   ├── services/
-│   │   ├── __init__.py              # Normalizações, filtros e cálculos de KPIs
-│   │   └── data_certificados.py     # Leitura da planilha de certificados/agendamentos
-│   ├── routes_certificados.py       # Rotas `/api/certificados` e `/api/agendamentos`
-│   ├── cnds/                        # Automatizações de CND (Playwright)
-│   │   ├── municipal/               # Workers por município + mapeamentos JSON
-│   │   └── __init__.py              # Router FastAPI
-│   ├── caes/                        # Automação de emissão de CAE
-│   │   ├── cae_worker_anapolis.py   # Worker Playwright para Anápolis
-│   │   └── routes.py                # Router `/api/cae`
-│   ├── config.yaml                  # Nomes de abas/tabelas e aliases de colunas
-│   └── requirements.txt             # Dependências Python (rodar `pip install -r`)
-│
-├── frontend/                        # Frontend React 18 + Vite + Tailwind
-│   ├── src/
-│   │   ├── App.jsx                  # Componente raiz com abas e estados globais
-│   │   ├── main.jsx                 # Entry point (ReactDOM.createRoot)
-│   │   ├── index.css                # Tailwind + estilos globais
-│   │   ├── components/              # shadcn/ui wrappers, badges, KPIs, HeaderMenu
-│   │   ├── features/                # Telas (painel, empresas, licenças, taxas, ...)
-│   │   ├── lib/                     # Helpers (API, certificados, texto, status)
-│   │   └── providers/               # ToastProvider e contexto de notificações
-│   ├── package.json                 # Dependências npm
-│   ├── vite.config.js               # Build + alias `@` + proxy /api
-│   ├── tailwind.config.js           # Design system utilitário
-│   ├── postcss.config.js            # Integração Tailwind
-│   └── index.html                   # HTML base
-│
-├── README.md                        # Visão geral e instruções rápidas
-├── GUIA_SETUP.md                    # Passo a passo detalhado de instalação
-└── ESTRUTURA_PROJETO.md             # Este mapa rápido
+├── backend/                        # Backend FastAPI + integrações
+│   ├── main.py                     # API v1 multi-tenant (uvicorn backend.main:app)
+│   ├── api.py                      # API legada baseada em planilha (opcional)
+│   ├── app/                        # Código da API v1 (rotas, deps, schemas, serviços)
+│   │   ├── api/v1/                 # Routers e endpoints (views/tabelas Postgres)
+│   │   ├── core/                   # Configurações e carregamento do config.yaml
+│   │   ├── db/                     # Sessão SQLAlchemy + enums
+│   │   └── deps/                   # Autenticação JWT + contexto multi-tenant
+│   ├── db/                         # Modelos SQLAlchemy
+│   ├── migrations/                 # Alembic (schema, enums, views, índices)
+│   ├── etl/                        # Extract/Transform/Load + CLI Typer (planilhas, opcional)
+│   ├── services/                   # Integrações com planilha de certificados e utilidades
+│   ├── cnds/, caes/                # Automação Playwright de CND/CAE
+│   ├── routes_certificados.py      # Rotas auxiliares do legado
+│   ├── scripts/dev/mint_jwt.py     # Gerador de tokens JWT para testes
+│   └── requirements.txt            # Dependências Python (API v1, ETL e legado)
+├── etl/__main__.py                 # Wrapper para `python -m etl` (legado)
+├── frontend/                       # Aplicação React 18 + Vite + Tailwind
+│   ├── src/features/               # Telas (empresas, licenças, taxas, processos, etc.)
+│   ├── src/lib/                    # Helpers de API e formatação
+│   ├── src/providers/              # Providers globais (toast, tema)
+│   └── package.json                # Dependências npm
+├── tests/                          # Pytest (API v1, ETL e smoke do legado)
+├── README.md                       # Visão geral e operação rápida
+├── GUIA_SETUP.md                   # Passo a passo de instalação e execução
+└── ESTRUTURA_PROJETO.md            # Este mapa
 ```
 
-## Fluxo resumido
+## Fluxos principais
 
-1. Planilhas `.xlsm` abastecem as entidades de negócio (empresas, licenças, taxas, processos, contatos, certificados).
-2. `backend/repo_excel.py` abre as planilhas com `keep_vba=True`, aplica aliases de `config.yaml` e gera estruturas normalizadas.
-3. `backend/api.py` carrega os dados para um cache em memória e expõe endpoints REST.
-4. `frontend/src/App.jsx` consome os endpoints via `fetchJson`, disponibilizando os dados para as telas em `features/`.
-5. Automação opcional (CND/CAE) usa Playwright para baixar PDFs e salvá-los em `CND_DIR_BASE`, servidos em `/cnds/*`.
+1. **Banco de dados** (PostgreSQL) é criado/sincronizado por Alembic: tabelas multi-tenant (`org_id`), enums, funções utilitárias, views (`v_empresas`, `v_licencas_status`, `v_taxas_status`, `v_processos_resumo`, `v_alertas_vencendo_30d`, `v_grupos_kpis`, `v_contatos_uteis`, `v_modelos_uteis`) e índices de busca normalizada (`immutable_unaccent`).
+2. **API v1** (`backend/main.py`) injeta `app.current_org` por requisição, aplica RBAC via `Role` em `app/deps/auth.py` e expõe `/api/v1/*` (empresas, licenças, taxas, processos, KPIs, alertas, municípios, úteis, stub de agendamentos) consumindo views/tabelas reais.
+3. **Frontend** (`frontend/`) consome `/api/v1/*` usando `VITE_API_URL` ou o proxy local do Vite.
+4. **Legado opcional**: ETL e `backend/api.py` permitem ingestão/leitura direta de planilhas `.xlsm` e automações de CND/CAE.
 
 ## Convenções
 
-- Arquivos `.xlsm` ficam fora do versionamento em `data/`.
-- Variáveis sensíveis (caminho da planilha, 2Captcha, etc.) vivem no `.env` do backend.
-- O frontend considera `VITE_API_URL` (ou o proxy do Vite em desenvolvimento) para apontar para o backend.
+- Alembic é o caminho suportado para criar/atualizar o schema; rode `alembic upgrade head` após atualizar o repositório.
+- Planilhas reais ficam fora do repositório; use uma pasta local `data/` apenas se recorrer ao legado/ETL.
+- Configure variáveis sensíveis no `.env` do backend (API v1) ou em um `.env` separado para o legado, conforme o fluxo em uso.
+- Playwright Chromium deve ser instalado manualmente: `python -m playwright install chromium`.

--- a/GUIA_SETUP.md
+++ b/GUIA_SETUP.md
@@ -1,26 +1,10 @@
 # Guia de Setup - eControle
 
-Este passo a passo leva do zero até o projeto rodando com backend FastAPI, integração com Excel macro-enabled (.xlsm), automação de CND/CAE via Playwright e frontend React.
+Passo a passo para sair do zero até a aplicação executando com o backend FastAPI multi-tenant (API v1), banco PostgreSQL versionado por Alembic, automação de CND/CAE e frontend React. O ETL/legado baseado em planilha é opcional e fica isolado ao final. A visão geral está no [`README.md`](README.md).
 
 ---
 
-## Pré-requisitos
-
-- **Python 3.10+** (recomendado 3.11)
-- **Node.js 18+** (o projeto usa Vite)
-- **npm** ou **pnpm** (os comandos abaixo usam npm)
-- **Git**
-- Arquivos Excel `.xlsm`:
-  - Planilha operacional (empresas/licenças/taxas/processos/contatos)
-  - Planilha de certificados/agendamentos
-
-> Mantenha as planilhas fora do versionamento. Crie `data/` localmente e copie os arquivos para lá.
-
----
-
-## 1. Backend (FastAPI)
-
-### 1.1 Criar ambiente virtual e instalar dependências
+## 1. Preparar ambiente Python (API v1)
 
 ```bash
 cd backend
@@ -28,157 +12,130 @@ python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install --upgrade pip
 pip install -r requirements.txt
-python -m playwright install chromium  # necessário para automações de CND/CAE
+python -m playwright install chromium  # requerido para CND/CAE
 ```
 
-O arquivo [`backend/requirements.txt`](backend/requirements.txt) já lista:
-- FastAPI, Uvicorn e Pydantic
-- openpyxl + portalocker para acessar `.xlsm`
-- PyYAML para ler `config.yaml`
-- python-dotenv para carregar `.env`
-- requests/aiofiles/playwright para automações e rota estática de CND
+### 1.1 Variáveis de ambiente (`backend/.env`)
 
-### 1.2 Configurar variáveis de ambiente
-
-Crie `backend/.env` com as chaves mínimas (ajuste conforme seu ambiente):
+Defina ao menos:
 
 ```ini
-EXCEL_PATH=../data/arquivo.xlsm         # planilha operacional
-CONFIG_PATH=./config.yaml               # opcional se usar outro mapeamento
-CORS_ORIGINS=http://localhost:5173      # origins permitidos
-API_HOST=0.0.0.0
-API_PORT=8000
-LOG_LEVEL=INFO
-CND_DIR_BASE=certidoes                  # onde os PDFs serão salvos
-CND_HEADLESS=true                       # false para acompanhar a automação
-CAPTCHA_MODE=manual                     # image_2captcha para resolver automaticamente
-API_KEY_2CAPTCHA=                       # obrigatório se usar 2Captcha
+DATABASE_URL=postgresql+psycopg://usuario:senha@localhost:5432/econtrole
+JWT_SECRET=troque-por-um-segredo
+JWT_ALG=HS256
+CONFIG_PATH=./config.yaml
+CORS_ORIGINS=["http://localhost:5173"]
+UTEIS_REQ_ROOT=G:/PMA/Requerimentos Word/Modelos
+UTEIS_ALLOWED_EXTS=.pdf,.doc,.docx,.xls,.xlsx,.png,.jpg,.jpeg
+UTEIS_REQ_MAX_DEPTH=4
 ```
 
-Em produção, considere chaves adicionais:
-- `CND_CHROME_PATH` para apontar para um executável Chromium customizado.
-- `PLANILHA_CERT_PATH` (ver abaixo) para centralizar o caminho da planilha de certificados.
+Outras chaves opcionais:
 
-### 1.3 Configurar `config.yaml` e planilhas
+- `CND_DIR_BASE`, `CND_HEADLESS`, `CND_CHROME_PATH`, `CAPTCHA_MODE`, `API_KEY_2CAPTCHA` – automações Playwright de CND/CAE.
+- `PLANILHA_CERT_PATH` somente se usar o fluxo legado de certificados/agendamentos via planilha (`backend/services/data_certificados.py`).
 
-- Atualize `backend/config.yaml` com os nomes de abas (`sheet_names`), tabelas (`table_names`) e aliases (`column_aliases`).
-- Use o endpoint `/api/diagnostico` para validar se todas as colunas obrigatórias foram reconhecidas.
-- Se a planilha mudar de layout, ajuste o YAML e recarregue o backend (`/api/refresh`).
+### 1.2 Banco de dados (PostgreSQL + Alembic)
 
-### 1.4 Planilha de certificados
-
-O arquivo [`backend/services/data_certificados.py`](backend/services/data_certificados.py) contém a constante `PLANILHA_CERT_PATH`. Altere-a para o caminho correto da planilha `.xlsm` que armazena certificados/agendamentos. Utilize caminhos absolutos em produção.
-
-### 1.5 Executar o backend
+Crie/atualize o schema com Alembic (tabelas, enums, views, índices e funções utilitárias):
 
 ```bash
-uvicorn api:app --reload --host $API_HOST --port $API_PORT
+cd backend
+alembic upgrade head
 ```
 
-Testes rápidos:
+Após isso, o banco já terá as views consumidas pelo front (`v_empresas`, `v_licencas_status`, `v_taxas_status`, `v_processos_resumo`, `v_alertas_vencendo_30d`, `v_grupos_kpis`, `v_contatos_uteis`, `v_modelos_uteis`) e índices de busca normalizada.
+
+### 1.3 Executar a API v1
 
 ```bash
-curl http://localhost:8000/health
-curl "http://localhost:8000/api/empresas?query=&municipio=&so_alertas=false"
+cd backend
+uvicorn backend.main:app --reload
 ```
 
-Para recarregar a planilha sem reiniciar o servidor use `POST /api/refresh`.
+- Healthcheck: `GET /healthz`.
+- Debug multi-tenant: `GET /__debug/guc`.
+- Rotas principais em `/api/v1/*` exigem JWT (`Authorization: Bearer ...`).
+
+Para gerar um token de desenvolvimento:
+
+```bash
+cd backend
+python scripts/dev/mint_jwt.py --org-id 00000000-0000-0000-0000-000000000001 --sub 1 --role ADMIN
+```
 
 ---
 
 ## 2. Frontend (React + Vite)
 
-### 2.1 Instalar dependências
-
 ```bash
 cd frontend
 npm install
-```
-
-Principais dependências:
-- React 18 + React DOM
-- Tailwind CSS + postcss/autoprefixer
-- shadcn/ui (componentes Radix `.jsx` adaptados)
-- Recharts, lucide-react, clsx, tailwind-merge
-
-### 2.2 Variáveis de ambiente
-
-Durante o desenvolvimento o proxy do Vite (configurado em `vite.config.js`) redireciona `/api` para `http://localhost:8000`. Para apontar para outra origem (ex.: homologação), crie `frontend/.env.local` com:
-
-```
-VITE_API_URL=https://sua.api/econtrole
-```
-
-### 2.3 Rodar o frontend
-
-```bash
 npm run dev
 ```
 
-A aplicação abrirá em `http://localhost:5173`. A aba **Painel** usa os KPIs do backend; as demais abas (Empresas, Licenças, Taxas, Processos, Úteis, Certificados) consomem os demais endpoints.
+- O servidor abre em `http://localhost:5173`.
+- Para apontar para outro backend, crie `frontend/.env.local` com `VITE_API_URL=https://sua.api/econtrole`.
+- O proxy padrão do Vite redireciona `/api` para `http://localhost:8000` durante o desenvolvimento.
 
 ---
 
-## 3. Automação de CND/CAE (Playwright)
+## 3. Legado opcional (planilhas)
 
-- Execute `python -m playwright install chromium` sempre que atualizar o Playwright.
-- Ajuste `CND_HEADLESS=false` para depurar captchas manualmente.
-- Para habilitar resolução automática de captcha configure:
-  ```ini
-  CAPTCHA_MODE=image_2captcha
-  API_KEY_2CAPTCHA=sua-chave
-  ```
-- Os PDFs ficam em `CND_DIR_BASE` e são servidos em `/cnds/<arquivo>.pdf`.
-- A emissão de CAE (`POST /api/cae/emitir`) espera município `Anápolis`, CNPJ com 14 dígitos e inscrição municipal normalizada.
+Use apenas se precisar integrar uma planilha `.xlsm` existente.
 
----
+### 3.1 ETL (Excel → Postgres)
 
-## 4. Integração com VS Code (opcional)
+Compartilha o mesmo `.env` da API v1.
 
-`.vscode/launch.json` sugerido para debug:
+```bash
+# Ajuda geral
+python -m etl
 
-```json
-{
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "name": "Backend: Uvicorn",
-      "type": "python",
-      "request": "launch",
-      "module": "uvicorn",
-      "args": ["api:app", "--reload", "--host", "0.0.0.0", "--port", "8000"],
-      "envFile": "${workspaceFolder}/backend/.env",
-      "cwd": "${workspaceFolder}/backend"
-    },
-    {
-      "name": "Frontend: Vite",
-      "type": "node",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/frontend",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"]
-    }
-  ]
-}
+# Validar mapeamento da planilha vs config.yaml
+python -m etl debug-source caminho/planilha.xlsm
+
+# Importação idempotente
+python -m etl import caminho/planilha.xlsm --dry-run   # simulação
+python -m etl import caminho/planilha.xlsm --apply     # grava no banco
 ```
 
-`.vscode/settings.json` mínimo:
+O contrato do ETL fica em `backend/etl/contracts.py` e usa as configurações de `config.yaml` para mapear abas, tabelas e aliases.
 
-```json
-{
-  "python.defaultInterpreterPath": "${workspaceFolder}/backend/.venv/bin/python",
-  "python.terminal.activateEnvironment": true,
-  "editor.formatOnSave": true
-}
+### 3.2 Backend legado baseado em Excel
+
+Para leitura direta da planilha (sem banco), configure outro `.env` em `backend/` com os valores mínimos:
+
+```ini
+EXCEL_PATH=../data/operacional.xlsm
+CONFIG_PATH=./config.yaml
+CORS_ORIGINS=http://localhost:5173
+API_HOST=0.0.0.0
+API_PORT=8000
+LOG_LEVEL=INFO
+CND_DIR_BASE=certidoes
+CND_HEADLESS=true
+CAPTCHA_MODE=manual
+API_KEY_2CAPTCHA=
 ```
+
+Execute com:
+
+```bash
+cd backend
+uvicorn backend.api:app --reload --host $API_HOST --port $API_PORT
+```
+
+As rotas `/api/*`, `/api/cnds`, `/api/cae` e `/api/certificados` ficarão disponíveis; os PDFs gerados ficam em `CND_DIR_BASE`.
 
 ---
 
-## 5. Dúvidas frequentes
+## 4. Dicas rápidas e troubleshooting
 
-- **Planilha não carrega?** Confira `EXCEL_PATH`, permissões de leitura e se outra pessoa não está com a planilha aberta (o lock usa `portalocker`).
-- **Coluna não aparece?** Rode `/api/diagnostico` e veja se o alias está no `config.yaml`.
-- **Playwright reclama de dependências?** Execute novamente `python -m playwright install chromium`. Em ambientes Linux, confirme se bibliotecas do Chromium estão instaladas.
-- **Frontend não acha a API?** Verifique `VITE_API_URL` ou o proxy no `vite.config.js`.
+- **Planilha não carrega?** Verifique `EXCEL_PATH`, permissões e se o arquivo não está aberto por outra pessoa (lock via `portalo
+cker`).
+- **Coluna ausente?** Rode `python -m etl debug-source` ou `/api/diagnostico` (legado) e ajuste `backend/config.yaml`.
+- **Problemas com Playwright?** Reinstale `python -m playwright install chromium` e valide dependências do Chromium no sistema.
+- **JWT inválido?** Confira `JWT_SECRET`, `JWT_ALG` e o payload usado pelo script `mint_jwt.py`.
 
-Pronto! O eControle deve estar acessível em `http://localhost:5173` utilizando o backend em `http://localhost:8000`.
+Pronto! O eControle deve responder na porta 8000 (API) e 5173 (frontend) usando o banco configurado em `DATABASE_URL`.

--- a/README.md
+++ b/README.md
@@ -1,278 +1,128 @@
 # eControle
 
-Plataforma interna para acompanhar empresas, licenças, taxas, processos administrativos, certificados digitais e materiais de apoio. Os dados operacionais nascem em planilhas Excel macro-enabled (`.xlsm`), são normalizados por um ETL idempotente e ficam disponíveis em um banco PostgreSQL consumido por uma API FastAPI multi-tenant e pelo frontend React.
+Plataforma interna multi-tenant para acompanhar empresas, licenças, taxas, processos administrativos, certificados digitais, alertas e materiais de apoio. O portal opera diretamente sobre um PostgreSQL versionado via Alembic (schema, enums, views e índices), exposto por uma API FastAPI v1 e consumido pelo frontend React. A leitura direta de planilhas Excel e o ETL permanecem apenas como compatibilidade legada.
 
-> ⚠️ As planilhas reais **não são versionadas**. Crie a pasta `data/` localmente e armazene os arquivos apenas em ambientes controlados.
-
----
-
-## Arquitetura em alto nível
-
-```
-Excel (.xlsm/.csv) ──▶ backend/etl ──▶ PostgreSQL ──▶ backend/main.py (FastAPI v1)
-          │                                       │
-          └──────────── backend/api.py ───────────┘  (API legada baseada em planilha)
-                                                    ▼
-                                               frontend (React 18 + Vite)
-```
-
-- **Planilhas** – abas e ListObjects são mapeados via `backend/config.yaml`.
-- **ETL (`backend/etl/`)** – CLI `python -m etl` carrega planilhas para staging (`stg_*`) e aplica UPSERT idempotente.
-- **API multi-tenant (`backend/main.py`)** – lê do PostgreSQL, injeta `app.current_org` por request e expõe endpoints `/api/v1/*`.
-- **API legada (`backend/api.py`)** – ainda serve leitura direta do Excel, automações CND/CAE e planilha de certificados.
-- **Frontend (`frontend/`)** – React + Vite, consome a API configurada em `VITE_API_URL`.
-
-Documentos auxiliares:
-- [`GUIA_SETUP.md`](GUIA_SETUP.md) – passo a passo detalhado de instalação.
-- [`ESTRUTURA_PROJETO.md`](ESTRUTURA_PROJETO.md) – blueprint resumido das pastas.
+> ⚠️ Planilhas operacionais **não são versionadas**. Caso ainda utilize o legado, crie a pasta `data/` localmente e mantenha os arquivos apenas em ambientes controlados.
 
 ---
 
-## Estrutura do repositório
+## Visão geral
+
+- **Base de dados:** schema multi-tenant com `org_id`, enums (`user_role_enum`, `situacao_processo_enum`, etc.), triggers de `updated_at`, views consolidadas (`v_empresas`, `v_licencas_status`, `v_taxas_status`, `v_processos_resumo`, `v_alertas_vencendo_30d`, `v_grupos_kpis`, `v_contatos_uteis`, `v_modelos_uteis`, entre outras) e índices funcionais para busca normalizada (`immutable_unaccent`). Tudo é criado por Alembic em `backend/migrations`.
+- **API v1 (multi-tenant):** `backend/main.py` injeta `app.current_org` por requisição e aplica RBAC (`Role.VIEWER`, `Role.ADMIN`, etc.) via JWT. Endpoints estáveis em `/api/v1/*` cobrem empresas, licenças, taxas, processos, KPIs, alertas, municípios, úteis e um stub de agendamentos.
+- **Frontend:** React + Vite, consumindo `/api/v1/*` via `VITE_API_URL` ou proxy do Vite; o layout atual já espera as views e contratos da API v1.
+- **Legado opcional:**
+  - **ETL** (`python -m etl`): importa planilhas `.xlsm` para staging (`stg_*`) e aplica UPSERT idempotente.
+  - **API baseada em planilha** (`backend/api.py`): leitura direta do Excel e automações de CND/CAE.
+
+Arquitetura resumida:
 
 ```
-.
-├── backend/
-│   ├── main.py                  # Entrada da API multi-tenant (uvicorn backend.main:app)
-│   ├── api.py                   # API legada baseada em planilha + automações
-│   ├── app/                     # Código da API v1 (rotas, deps, schemas, serviços)
-│   ├── db/                      # Modelos SQLAlchemy e sessão
-│   ├── etl/                     # Extract/Transform/Load e CLI Typer
-│   ├── migrations/              # Alembic (schema + staging)
-│   ├── services/                # Integração com planilha de certificados
-│   ├── cnds/, caes/             # Automação Playwright para CND/CAE
-│   ├── scripts/dev/mint_jwt.py  # Utilitário para gerar JWT de desenvolvimento
-│   ├── config.yaml              # Mapeamentos de abas/tabelas/aliases/enums
-│   └── requirements.txt         # Dependências Python do backend/ETL
-├── etl/__main__.py              # Wrapper para `python -m etl`
-├── frontend/                    # Aplicação React 18 + Vite + Tailwind
-├── tests/                       # Pytest (API v1, ETL e smoke tests)
-├── README.md
-├── GUIA_SETUP.md
-└── ESTRUTURA_PROJETO.md
+PostgreSQL (schema + views Alembic) ──▶ backend/main.py (FastAPI v1) ──▶ frontend (React 18 + Vite)
+                     │
+                     └── backend/api.py + ETL (compatibilidade com planilha, opcional)
 ```
 
 ---
 
-## Pré-requisitos
+## Componentes
 
-- **Python 3.10+** (recomendado 3.11) – backend, ETL e automações.
-- **Node.js 18+** – frontend com Vite.
-- **PostgreSQL 14+** – armazenamento do schema `s1`/`s2` (tabelas e views).
-- **Playwright Chromium** – obrigatório para emissões de CND/CAE (`python -m playwright install chromium`).
-- Planilhas `.xlsm` originais (operacional + certificados/agendamentos).
+### Backend – API v1 (`backend/main.py`)
 
----
+- Entrada da aplicação FastAPI com middleware CORS e healthcheck (`/healthz`).
+- Contexto multi-tenant aplicado por `db_with_org`, usando `app.current_org` e RBAC (`Role.VIEWER`, `Role.ADMIN`, etc.).
+- Endpoints em `backend/app/api/v1/` baseados em views e tabelas reais do Postgres (`empresas`, `licencas`, `taxas`, `processos`, `alertas`, `grupos/KPIs`, `municipios`, `uteis`, stub de `agendamentos`).
+- Variáveis obrigatórias: `DATABASE_URL` e `JWT_SECRET`. Outras úteis: `JWT_ALG`, `CORS_ORIGINS`, `CONFIG_PATH`, `UTEIS_REQ_ROOT`, `UTEIS_ALLOWED_EXTS`, `UTEIS_REQ_MAX_DEPTH`.
+- Script auxiliar: `backend/scripts/dev/mint_jwt.py` gera tokens JWT de desenvolvimento.
 
-## Backend – API multi-tenant (`backend/main.py`)
+### Automação de CND/CAE (Playwright)
 
-### Instalação e dependências
+- Módulos `backend/cnds/` e `backend/caes/` utilizam Chromium headless para emissão de documentos.
+- Após instalar as dependências Python, execute `python -m playwright install chromium`.
+- Configure `CND_DIR_BASE`, `CND_HEADLESS`, `CND_CHROME_PATH`, `CAPTCHA_MODE` e `API_KEY_2CAPTCHA` conforme o ambiente.
 
-```bash
-cd backend
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
-pip install --upgrade pip
-pip install -r requirements.txt
-python -m playwright install chromium  # necessário para automações CND/CAE
-```
+### Frontend (`frontend/`)
 
-`requirements.txt` inclui FastAPI/Uvicorn, SQLAlchemy, Alembic, `email-validator` (requerido por `EmailStr`), openpyxl/portalocker, Playwright e utilitários como Typer e python-dotenv.【F:backend/requirements.txt†L1-L25】
+- React 18 + Vite + Tailwind + Radix UI.
+- `npm run dev` levanta o servidor em `http://localhost:5173`; `VITE_API_URL` pode apontar para outro backend.
+- Estrutura por features (`src/features/*`), provedores em `src/providers/` e utilitários em `src/lib/`.
 
-### Variáveis de ambiente (`backend/.env`)
+### Legado/compatibilidade com planilhas (opcional)
 
-A API lê as configurações por meio de `app.core.config.Settings`. Crie um `.env` contendo, no mínimo:
-
-```ini
-DATABASE_URL=postgresql+psycopg://usuario:senha@localhost:5432/econtrole
-JWT_SECRET=troque-por-um-segredo
-JWT_ALG=HS256
-CORS_ORIGINS=["http://localhost:5173"]
-CONFIG_PATH=./config.yaml
-UTEIS_REQ_ROOT=G:/PMA/Requerimentos Word/Modelos   # diretório dos materiais de apoio
-UTEIS_ALLOWED_EXTS=.pdf,.doc,.docx,.xls,.xlsx,.png,.jpg,.jpeg
-UTEIS_REQ_MAX_DEPTH=4
-```
-
-- `DATABASE_URL` é obrigatório e também usado pelo Alembic/ETL.【F:backend/app/core/config.py†L14-L107】
-- `CONFIG_PATH` aponta para o YAML de aliases/enums carregado por `Settings` e pelos modelos SQL.【F:backend/app/core/config.py†L18-L106】【F:backend/db/models_sql.py†L23-L44】
-- Os parâmetros `UTEIS_*` alimentam o serviço de navegação de arquivos em `/api/v1/uteis` (listagem e download).【F:backend/app/services/file_browse.py†L1-L120】【F:backend/app/api/v1/endpoints/uteis.py†L1-L174】
-
-Outras variáveis suportadas incluem `CND_DIR_BASE`, `CND_HEADLESS`, `CAPTCHA_MODE` e `API_KEY_2CAPTCHA` para automações Playwright (ver seção específica abaixo). O carregamento do `.env` é feito automaticamente por `python-dotenv` nas migrations, na CLI e em scripts auxiliares.【F:backend/migrations/env.py†L18-L34】【F:backend/etl/cli.py†L16-L19】【F:backend/scripts/dev/mint_jwt.py†L1-L37】
-
-### Criar/atualizar o schema
-
-```bash
-cd backend
-alembic upgrade head
-```
-
-As migrations criam o schema operacional, views (`v_empresas`, `v_licencas_status`, `v_taxas_status`, `v_processos_resumo`, `v_alertas_vencendo_30d`, `v_grupos_kpis`) e índices multi-tenant utilizados pelas rotas da API.【F:tests/test_api_v1.py†L33-L119】【F:backend/app/api/v1/endpoints/empresas.py†L1-L84】
-
-### Executar a API v1
-
-```bash
-cd backend
-uvicorn backend.main:app --reload
-```
-
-- Healthcheck: `GET /healthz`.
-- Debug do contexto multi-tenant: `GET /__debug/guc` (retorna o valor atual de `app.current_org`).【F:backend/main.py†L20-L42】
-- Endpoints principais (`/api/v1`): empresas, licenças, taxas, processos, alertas, grupos (KPIs) e materiais de apoio/contatos/modelos.【F:backend/app/api/v1/api.py†L1-L21】【F:backend/app/api/v1/endpoints】
-
-Todos os endpoints autenticados utilizam JWT (`Authorization: Bearer <token>`) e aplicam RBAC com `Role.VIEWER` ou `Role.ADMIN`. A dependência `db_with_org` garante isolamento por organização via `SET app.current_org = :org_id`.【F:backend/app/deps/auth.py†L1-L104】
-
-### Gerar um JWT de desenvolvimento
-
-```bash
-cd backend
-python scripts/dev/mint_jwt.py --org-id 00000000-0000-0000-0000-000000000001 --sub 1 --role ADMIN
-```
-
-O script exibe o fingerprint do segredo carregado e o token já assinado, pronto para testes manuais ou para o botão **Authorize** do Swagger.【F:backend/scripts/dev/mint_jwt.py†L1-L66】
+- **ETL (`backend/etl/`)**: CLI Typer acessível por `python -m etl`, compartilhando `.env` com a API v1. Útil para importar planilhas `.xlsm` para staging e aplicar UPSERT.
+- **API baseada em Excel (`backend/api.py`)**: leitura direta da planilha, rotas `/api/*`, `/api/cnds`, `/api/cae`, `/api/certificados` e serviço estático `/cnds/*` para PDFs emitidos. Configure `EXCEL_PATH`, `CONFIG_PATH`, `CND_DIR_BASE`, `CND_HEADLESS`, `CAPTCHA_MODE`, `API_KEY_2CAPTCHA`.
 
 ---
 
-## Stages da migração
+## Operação rápida
 
-> A migração do legado baseado em planilha para a API multi-tenant está sendo conduzida em etapas. Utilize os checkpoints abaixo para acompanhar o progresso do ambiente.
+Use este resumo para validar o ambiente com a API v1 (PostgreSQL + Alembic) e o frontend; o passo a passo completo está em [`GUIA_SETUP.md`](GUIA_SETUP.md).
 
-### S1 – Schema versionado (PostgreSQL)
+1. **Instalar dependências Python e Playwright**
+   ```bash
+   cd backend
+   python -m venv .venv && source .venv/bin/activate
+   pip install --upgrade pip
+   pip install -r requirements.txt
+   python -m playwright install chromium
+   ```
+2. **Configurar `.env`** (API v1): defina `DATABASE_URL`, `JWT_SECRET`, `CONFIG_PATH` e demais chaves necessárias.
+3. **Criar/atualizar schema**
+   ```bash
+   cd backend
+   alembic upgrade head
+   ```
+4. **Executar API v1**
+   ```bash
+   cd backend
+   uvicorn backend.main:app --reload
+   ```
+5. **Frontend**
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
 
-1. **Configuração** – garanta que `DATABASE_URL` e `CONFIG_PATH` estejam definidos no `backend/.env` (ver seção [Variáveis de ambiente](#variáveis-de-ambiente-backendenv)).
-2. **Criar/atualizar o schema** – rode `alembic upgrade head` dentro de `backend/` para criar tabelas, enums, views e índices necessários.【F:backend/migrations/env.py†L18-L34】
-3. **Smoke tests** – execute `psql "$DATABASE_URL" -c "SELECT * FROM v_empresas LIMIT 5;"` e demais views para validar seeds e permissões.
-
-Critérios de pronto: migrations sem erros, views populadas (via seeds) e enums coerentes com o `config.yaml`.
-
-### S2 – ETL idempotente (Excel → Postgres)
-
-1. **Dependências** – use o mesmo ambiente virtual do backend (`pip install -r requirements.txt`).
-2. **Staging** – mantenha o schema atualizado (S1) para assegurar a existência das tabelas `stg_*` e constraints de suporte.【F:backend/etl/cli.py†L1-L120】
-3. **Execução** – acione `python -m etl import caminho/planilha.xlsm --apply` (ou `--dry-run`) para carregar planilhas conforme o contrato definido em `backend/etl/contracts.py`.
-4. **Validação** – analise a saída JSONL (`action: insert/update/skip`) e verifique a consistência via consultas nas views (`v_licencas_status`, `v_taxas_status`, etc.).
-
-Critérios de pronto: execução idempotente (execuções repetidas retornando `skip`), diffs consistentes e staging preservando `run_id`/`row_hash`.
-
-### S3 – API FastAPI multi-tenant
-
-1. **Aplicação** – suba `uvicorn backend.main:app --reload` com o `.env` configurado (JWT, CORS, etc.).【F:backend/main.py†L20-L42】
-2. **Autenticação** – gere tokens com `scripts/dev/mint_jwt.py` e teste os endpoints `/api/v1/*` autenticados.
-3. **Multi-tenant** – confirme, via `GET /__debug/guc`, que o `org_id` está sendo injetado corretamente e que as views filtram os registros conforme a organização.【F:backend/app/deps/auth.py†L1-L104】
-
-Critérios de pronto: saúde do healthcheck (`/healthz`), endpoints críticos respondendo com paginação esperada e RBAC (`Role.ADMIN`/`Role.VIEWER`) validado nos fluxos principais.
-
----
-
-## Backend legado baseado em planilha (`backend/api.py`)
-
-A versão antiga do backend continua disponível para cenários em que a leitura seja feita diretamente da planilha Excel (sem banco). Ela mantém o cache em memória, as rotas `/api/*`, `/api/cnds`, `/api/cae`, `/api/certificados` e o serviço estático `/cnds` para PDFs.
-
-Variáveis mínimas no `.env` (além das utilizadas pela API v1):
-
-```ini
-EXCEL_PATH=../data/operacional.xlsm
-API_HOST=0.0.0.0
-API_PORT=8000
-LOG_LEVEL=INFO
-CND_DIR_BASE=certidoes
-CND_HEADLESS=true
-CAPTCHA_MODE=manual
-API_KEY_2CAPTCHA=
-```
-
-Execute com:
-
-```bash
-cd backend
-uvicorn backend.api:app --reload --host $API_HOST --port $API_PORT
-```
-
-O módulo usa `ExcelRepo` para mapear abas/tabelas conforme `config.yaml`, expõe diagnósticos (`/api/diagnostico`), agenda recargas (`/api/refresh`) e integra as automações Playwright herdadas.【F:backend/api.py†L1-L120】【F:backend/repo_excel.py†L1-L160】 O arquivo `backend/services/data_certificados.py` lê a planilha dedicada de certificados/agendamentos; ajuste a constante `PLANILHA_CERT_PATH` ao seu ambiente.【F:backend/services/data_certificados.py†L1-L60】
-
----
-
-## ETL (Excel → Postgres)
-
-A CLI em `backend/etl/cli.py` implementa o fluxo Extract/Transform/Load usado nas fases S2/S3.
-
-```bash
-# Ajuda
-python -m etl
-
-# Diagnóstico do arquivo x contrato
-python -m etl debug-source caminho/planilha.xlsm
-
-# Importação idempotente
-python -m etl import caminho/planilha.xlsm --dry-run   # simulação
-python -m etl import caminho/planilha.xlsm --apply     # grava no banco
-```
-
-- O contrato (`backend/etl/contracts.py`) mapeia `sheet_names`, `table_names` e aliases com base no `config.yaml`.
-- `extract_xlsm.py` lê abas/ListObjects respeitando o mapeamento; `transform_normalize.py` padroniza cabeçalhos, datas, CNPJ e enums; `load_upsert.py` grava em staging com `run_id`/`row_hash` e aplica UPSERT idempotente usando SQLAlchemy core.【F:backend/etl/cli.py†L1-L120】
-- As mesmas variáveis de ambiente da API (`DATABASE_URL`, `CONFIG_PATH`) são usadas durante a execução (carregadas via `python-dotenv`).【F:backend/etl/cli.py†L16-L72】
-
-Testes direcionados ao ETL estão em `tests/test_etl_basic.py` e cobrem duplicidade, enums inválidos, datas inválidas e updates parciais.
-
----
-
-## Automação de CND/CAE (Playwright)
-
-Os módulos em `backend/cnds/` e `backend/caes/` utilizam Playwright Chromium para emitir CNDs municipais e CAE de Anápolis.
-
-Configurações úteis no `.env`:
-
-```ini
-CND_DIR_BASE=certidoes
-CND_HEADLESS=true               # defina false para depurar
-CND_CHROME_PATH=                # opcional: caminho para executável Chromium customizado
-CAPTCHA_MODE=manual             # ou image_2captcha
-API_KEY_2CAPTCHA=               # obrigatório se usar 2Captcha
-```
-
-Após instalar as dependências Python, execute `python -m playwright install chromium`. Os PDFs gerados ficam em `CND_DIR_BASE` e são servidos pela API legada em `/cnds/<arquivo>.pdf`. As rotas disponíveis estão em `backend/cnds/municipal/routes.py` e `backend/caes/routes.py`.
-
----
-
-## Frontend (React + Vite)
-
-```bash
-cd frontend
-npm install
-npm run dev
-```
-
-- O servidor de desenvolvimento sobe em `http://localhost:5173` e proxia `/api` para `http://localhost:8000` durante o desenvolvimento.
-- Defina `VITE_API_URL` em `frontend/.env.local` se precisar apontar para outro backend em produção/homologação.
-- A estrutura de componentes está organizada por feature (`src/features/*`), com provedores em `src/providers/` e utilitários em `src/lib/`.
-
-Dependências principais: React 18, Vite 5, Tailwind 3, Radix UI (shadcn), lucide-react e Recharts.【F:frontend/package.json†L1-L33】
-
----
-
-## Testes automatizados
-
-A suíte de testes utiliza Pytest:
-
-```bash
-pytest
-```
-
-- `tests/test_api_v1.py` valida autenticação, paginação e filtros da API multi-tenant usando sessões fake in-memory.
-- `tests/test_auth_smoke.py` cobre parsing de JWT e hierarquia de roles.
-- `tests/test_etl_basic.py` garante a idempotência do ETL.
-- `tests/test_smoke.py` mantém verificações básicas da API legada.
+6. **Opcional – ETL para planilhas**
+   ```bash
+   cd backend
+   python -m etl import caminho/planilha.xlsm --apply
+   ```
 
 ---
 
 ## Dados e configuração
 
-- Atualize `backend/config.yaml` sempre que as planilhas mudarem de layout (novos cabeçalhos, tabelas ou enums). As rotas `/api/diagnostico` (legado) e `python -m etl debug-source` ajudam a validar o mapeamento.【F:backend/config.yaml†L1-L160】
-- Ajuste `PLANILHA_CERT_PATH` em `backend/services/data_certificados.py` para apontar para a planilha real de certificados/agendamentos.【F:backend/services/data_certificados.py†L1-L60】
-- Os arquivos Excel permanecem fora do repositório; use `data/` apenas localmente.
+- Alembic cria o schema completo (tabelas, enums, views, índices e funções utilitárias). Rode `alembic upgrade head` sempre que atualizar o repositório.
+- `backend/config.yaml` centraliza enums e, no legado, aliases de abas; ajuste apenas se ainda usar o ETL/planilhas.
+- Planilhas reais não são versionadas; mantenha-as fora do repositório (`data/`) quando precisar do legado.
+- Certificados/agendamentos no legado: ajuste `PLANILHA_CERT_PATH` em `backend/services/data_certificados.py`.
 
 ---
 
-## Licença
+## Testes automatizados
+
+Os testes usam Pytest:
+
+- `tests/test_api_v1.py` cobre autenticação, paginação e filtros da API multi-tenant.
+- `tests/test_auth_smoke.py` valida parsing de JWT e hierarquia de roles.
+- `tests/test_etl_basic.py` garante idempotência do ETL.
+- `tests/test_smoke.py` mantém verificações básicas da API legada.
+
+Execute com:
+
+```bash
+pytest
+```
+
+---
+
+## Documentação auxiliar
+
+- [`GUIA_SETUP.md`](GUIA_SETUP.md) – passo a passo detalhado de instalação e execução.
+- [`ESTRUTURA_PROJETO.md`](ESTRUTURA_PROJETO.md) – mapa rápido das pastas e responsabilidades.
+
+---
 
 Projeto interno. Consulte o time responsável antes de distribuir.


### PR DESCRIPTION
## Summary
- Atualiza o README para refletir que o portal opera sobre PostgreSQL/Alembic e API v1, mantendo o ETL/planilhas apenas como legado
- Revê o GUIA_SETUP priorizando a API v1 com banco versionado e separando passos opcionais do legado
- Ajusta o ESTRUTURA_PROJETO para destacar fluxos centrados em schema/views e consumo via endpoints

## Testing
- Not run (documentação)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692879f652408326836326b55ee78671)