### PR TITLE
Format process dates with dayjs helper

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
+        "dayjs": "^1.11.13",
         "lucide-react": "^0.454.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2590,6 +2591,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-separator": "^1.0.3",
+    "dayjs": "^1.11.13",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "tailwind-merge": "^2.0.0"

--- a/frontend/src/features/processos/ProcessosScreen.jsx
+++ b/frontend/src/features/processos/ProcessosScreen.jsx
@@ -18,8 +18,10 @@ import {
   DIVERSOS_OPERACAO_SEM,
   PROCESS_BASE_COLUMNS,
   PROCESS_DIVERSOS_LABEL,
+  PROCESS_DATE_COLUMNS,
   resolveProcessExtraColumns,
   getDiversosOperacaoLabel,
+  formatProcessDate,
 } from "@/lib/process";
 import { PROCESS_ALL } from "@/lib/constants";
 import { normalizeIdentifier, normalizeText } from "@/lib/text";
@@ -208,6 +210,9 @@ export default function ProcessosScreen({
   const renderProcessValue = useCallback(
     (proc, column) => {
       const rawValue = proc?.[column.key];
+      if (PROCESS_DATE_COLUMNS.has(column.key)) {
+        return formatProcessDate(rawValue);
+      }
       if (column.isStatus) {
         return <StatusBadge status={proc.situacao ?? rawValue} />;
       }

--- a/frontend/src/lib/process.js
+++ b/frontend/src/lib/process.js
@@ -1,4 +1,5 @@
-import { normalizeText, removeDiacritics } from "@/lib/text";
+import dayjs from "dayjs";
+import { normalizeText, parsePtDate, removeDiacritics } from "@/lib/text";
 
 export const PROCESS_DIVERSOS_LABEL = "Diversos";
 export const DIVERSOS_OPERACAO_ALL = "__PROCESS_DIVERSOS_ALL__";
@@ -9,6 +10,25 @@ export const PROCESS_BASE_COLUMNS = [
   { key: "data_solicitacao", label: "Data de Solicitação" },
   { key: "situacao", label: "Situação", isStatus: true },
 ];
+
+export const PROCESS_DATE_COLUMNS = new Set([
+  "data_solicitacao",
+  "prazo",
+  "data_val",
+]);
+
+export const formatProcessDate = (value) => {
+  const normalized = normalizeText(value).trim();
+  if (normalized === "") return "—";
+
+  const parsedPtDate = parsePtDate(normalized);
+  if (parsedPtDate) {
+    return dayjs(parsedPtDate).format("DD/MM/YYYY");
+  }
+
+  const parsed = dayjs(normalized);
+  return parsed.isValid() ? parsed.format("DD/MM/YYYY") : "—";
+};
 
 const normalizeProcessColumnKey = (value) =>
   removeDiacritics(String(value ?? "").toLowerCase()).replace(/[^a-z0-9]+/g, "_");


### PR DESCRIPTION
## Summary
- add dayjs dependency for consistent date formatting
- introduce shared process date formatter and metadata
- apply date formatting in Processos screen columns

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928a4d1f05483269c9f6fa85a1f2f30)