### PR TITLE
Normalize search matching for labeled queries

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,12 @@ import PainelScreen from "@/features/painel/PainelScreen";
 import CertificadosScreen from "@/features/certificados/CertificadosScreen";
 import ToastProvider, { useToast } from "@/providers/ToastProvider.jsx";
 import { Sparkles, X } from "lucide-react";
-import { normalizeIdentifier, normalizeText, normalizeTextLower } from "@/lib/text";
+import {
+  buildNormalizedSearchKey,
+  normalizeIdentifier,
+  normalizeText,
+  normalizeTextLower,
+} from "@/lib/text";
 import {
   PROCESS_DIVERSOS_LABEL,
   buildDiversosOperacaoKey,
@@ -375,9 +380,9 @@ function AppContent() {
 
       const directiveField = commandKey ? resolveFieldKey(commandKey) : undefined;
       const resolvedField = directiveField ?? (queryField !== "all" ? queryField : undefined);
-      const searchValue = normalizeTextLower(commandValue ?? normalizedQueryValue).trim();
+      const searchKey = buildNormalizedSearchKey(commandValue ?? normalizedQueryValue);
 
-      if (searchValue === "") {
+      if (!searchKey) {
         return true;
       }
 
@@ -398,7 +403,10 @@ function AppContent() {
 
       return collectCandidates()
         .filter((field) => field !== null && field !== undefined)
-        .some((field) => normalizeTextLower(field).includes(searchValue));
+        .some((field) => {
+          const normalizedField = buildNormalizedSearchKey(field);
+          return normalizedField?.includes(searchKey);
+        });
     },
     [normalizedQueryValue, queryField],
   );


### PR DESCRIPTION
## Summary
- normalize global search matching to use sanitized keys when using labeled filters
- ensure empresa queries match even when input formatting differs (e.g., CNPJ or Razão Social)

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d8e45e2f0832686f5589a711d0b72)