### PR TITLE
Handle spaced label commands in search

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,12 @@ import PainelScreen from "@/features/painel/PainelScreen";
 import CertificadosScreen from "@/features/certificados/CertificadosScreen";
 import ToastProvider, { useToast } from "@/providers/ToastProvider.jsx";
 import { Sparkles, X } from "lucide-react";
-import { normalizeIdentifier, normalizeText, normalizeTextLower } from "@/lib/text";
+import {
+  buildNormalizedSearchKey,
+  normalizeIdentifier,
+  normalizeText,
+  normalizeTextLower,
+} from "@/lib/text";
 import {
   PROCESS_DIVERSOS_LABEL,
   buildDiversosOperacaoKey,
@@ -360,7 +365,7 @@ function AppContent() {
 
   const matchesQuery = useCallback(
     (fields, fieldMap = {}) => {
-      const commandMatch = normalizedQueryValue.match(/^([a-zçãõáéíóú]+):\s*(.+)$/i);
+      const commandMatch = normalizedQueryValue.match(/^([a-zçãõáéíóú\s_]+):\s*(.+)$/i);
       const commandKey = commandMatch?.[1];
       const commandValue = commandMatch?.[2];
 
@@ -375,9 +380,9 @@ function AppContent() {
 
       const directiveField = commandKey ? resolveFieldKey(commandKey) : undefined;
       const resolvedField = directiveField ?? (queryField !== "all" ? queryField : undefined);
-      const searchValue = normalizeTextLower(commandValue ?? normalizedQueryValue).trim();
+      const searchKey = buildNormalizedSearchKey(commandValue ?? normalizedQueryValue);
 
-      if (searchValue === "") {
+      if (!searchKey) {
         return true;
       }
 
@@ -398,7 +403,10 @@ function AppContent() {
 
       return collectCandidates()
         .filter((field) => field !== null && field !== undefined)
-        .some((field) => normalizeTextLower(field).includes(searchValue));
+        .some((field) => {
+          const normalizedField = buildNormalizedSearchKey(field);
+          return normalizedField?.includes(searchKey);
+        });
     },
     [normalizedQueryValue, queryField],
   );


### PR DESCRIPTION
## Summary
- allow search directives with spaces/underscores in the key (e.g., "razão social:") so labeled queries parse correctly

## Testing
- npm run build --prefix frontend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d8e45e2f0832686f5589a711d0b72)