### PR TITLE
Include unlinked certificates in certificados view

### DIFF
--- a/backend/migrations/versions/20251128_01_certificate_keys.py
+++ b/backend/migrations/versions/20251128_01_certificate_keys.py
@@ -36,7 +36,8 @@ SELECT
     END AS situacao
 FROM public.certificados c
 LEFT JOIN public.empresas e ON (e.id = c.empresa_id AND e.org_id = c.org_id)
-WHERE current_setting('app.current_org', true) IS NULL OR e.org_id = current_setting('app.current_org')::uuid;
+WHERE current_setting('app.current_org', true) IS NULL
+    OR COALESCE(e.org_id, c.org_id) = current_setting('app.current_org')::uuid;
 """
 
 


### PR DESCRIPTION
## Summary
- update the v_certificados_status view to fall back to the certificate org when no empresa is linked so unlinked certificates are returned

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da18d6d708326b24e557e87b18ced)