### PR TITLE
Add migration to expose unlinked certificates

### DIFF
--- a/backend/migrations/versions/20251212_00_certificados_view_include_unlinked.py
+++ b/backend/migrations/versions/20251212_00_certificados_view_include_unlinked.py
@@ -1,17 +1,19 @@
-"""Atualiza view v_certificados_status para incluir senha"""
+"""Include certificados without empresa in status view
 
+Revision ID: 20251212_00_certificados_view_include_unlinked
+Revises: 20251128_01_certificate_keys
+Create Date: 2025-12-12 00:00:00
+"""
 from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
-revision = "20251128_01_certificate_keys"
-down_revision = ("20251114_00_merge_status_view_clean", "20251207_01_unaccent_extension_indexes")
+revision = "20251212_00_certificados_view_include_unlinked"
+down_revision = "20251128_01_certificate_keys"
 branch_labels = None
 depends_on = None
-
 
 VIEW_SQL = """
 DROP VIEW IF EXISTS v_certificados_status;
@@ -20,7 +22,7 @@ CREATE VIEW v_certificados_status AS
 SELECT
     c.id AS cert_id,
     c.empresa_id,
-    c.org_id,
+    COALESCE(e.org_id, c.org_id) AS org_id,
     e.empresa,
     e.cnpj,
     c.valido_de,
@@ -39,7 +41,6 @@ LEFT JOIN public.empresas e ON (e.id = c.empresa_id AND e.org_id = c.org_id)
 WHERE current_setting('app.current_org', true) IS NULL
     OR COALESCE(e.org_id, c.org_id) = current_setting('app.current_org')::uuid;
 """
-
 
 def upgrade() -> None:
     op.execute(sa.text(VIEW_SQL))


### PR DESCRIPTION
## Summary
- add a new Alembic migration that recreates `v_certificados_status` including org fallback for certificates without empresa

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da18d6d708326b24e557e87b18ced)