### PR TITLE
Use subject fallback for certificate titular

### DIFF
--- a/backend/migrations/versions/20251212_00_certificados_view_include_unlinked.py
+++ b/backend/migrations/versions/20251212_00_certificados_view_include_unlinked.py
@@ -1,17 +1,19 @@
-"""Atualiza view v_certificados_status para incluir senha"""
+"""Include certificados without empresa in status view
 
+Revision ID: 20251212_00_certificados_view_include_unlinked
+Revises: 20251128_01_certificate_keys
+Create Date: 2025-12-12 00:00:00
+"""
 from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
-revision = "20251128_01_certificate_keys"
-down_revision = ("20251114_00_merge_status_view_clean", "20251207_01_unaccent_extension_indexes")
+revision = "20251212_00_certificados_view_include_unlinked"
+down_revision = "20251128_01_certificate_keys"
 branch_labels = None
 depends_on = None
-
 
 VIEW_SQL = """
 DROP VIEW IF EXISTS v_certificados_status;
@@ -20,7 +22,7 @@ CREATE VIEW v_certificados_status AS
 SELECT
     c.id AS cert_id,
     c.empresa_id,
-    c.org_id,
+    COALESCE(e.org_id, c.org_id) AS org_id,
     e.empresa,
     e.cnpj,
     c.valido_de,
@@ -39,7 +41,6 @@ LEFT JOIN public.empresas e ON (e.id = c.empresa_id AND e.org_id = c.org_id)
 WHERE current_setting('app.current_org', true) IS NULL
     OR COALESCE(e.org_id, c.org_id) = current_setting('app.current_org')::uuid;
 """
-
 
 def upgrade() -> None:
     op.execute(sa.text(VIEW_SQL))

--- a/backend/migrations/versions/20251212_01_certificados_view_titular_subject.py
+++ b/backend/migrations/versions/20251212_01_certificados_view_titular_subject.py
@@ -1,0 +1,86 @@
+"""Use subject as fallback for titular/cnpj in certificados view
+
+Revision ID: 20251212_01_certificados_view_titular_subject
+Revises: 20251212_00_certificados_view_include_unlinked
+Create Date: 2025-12-12 01:00:00
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20251212_01_certificados_view_titular_subject"
+down_revision = "20251212_00_certificados_view_include_unlinked"
+branch_labels = None
+depends_on = None
+
+VIEW_SQL = """
+DROP VIEW IF EXISTS v_certificados_status;
+
+CREATE VIEW v_certificados_status AS
+WITH base AS (
+    SELECT
+        c.id          AS cert_id,
+        c.empresa_id,
+        c.org_id      AS org_id_cert,
+        c.subject,
+        c.valido_de,
+        c.valido_ate,
+        c.senha,
+        e.org_id      AS org_id_emp,
+        e.empresa     AS empresa_db,
+        e.cnpj        AS cnpj_db,
+        -- trecho CN=... (antes da primeira vírgula)
+        regexp_replace(c.subject, '^CN=([^,]+).*$','\\1') AS cn_raw
+    FROM public.certificados c
+    LEFT JOIN public.empresas e
+      ON e.id = c.empresa_id
+     AND e.org_id = c.org_id
+)
+SELECT
+    cert_id,
+    empresa_id,
+    -- org_id: da empresa se existir, senão do certificado
+    COALESCE(org_id_emp, org_id_cert) AS org_id,
+
+    -- Titular / "Empresa" exibida no front:
+    -- 1) se tiver empresa ligada, usa e.empresa
+    -- 2) senão, usa a parte antes do ":" do CN
+    -- 3) se ainda assim ficar vazio, cai pro subject inteiro
+    COALESCE(
+        empresa_db,
+        NULLIF(split_part(cn_raw, ':', 1), ''),
+        NULLIF(subject, '')
+    ) AS empresa,
+
+    -- CPF/CNPJ:
+    -- 1) se tiver empresa ligada, usa e.cnpj
+    -- 2) senão, pega a parte depois do ":" do CN e deixa só dígitos
+    COALESCE(
+        cnpj_db,
+        NULLIF(regexp_replace(split_part(cn_raw, ':', 2), '\\D', '', 'g'), '')
+    ) AS cnpj,
+
+    valido_de,
+    valido_ate,
+    senha,
+    GREATEST(0, (valido_ate - CURRENT_DATE)) AS dias_restantes,
+    CASE
+        WHEN valido_ate IS NULL THEN 'INDEFINIDO'
+        WHEN valido_ate < CURRENT_DATE THEN 'VENCIDO'
+        WHEN valido_ate <= CURRENT_DATE + INTERVAL '7 days'  THEN 'VENCE EM 7 DIAS'
+        WHEN valido_ate <= CURRENT_DATE + INTERVAL '30 days' THEN 'VENCE EM 30 DIAS'
+        ELSE 'VÁLIDO'
+    END AS situacao
+FROM base
+WHERE current_setting('app.current_org', true) IS NULL
+   OR COALESCE(org_id_emp, org_id_cert) = current_setting('app.current_org')::uuid;
+"""
+
+def upgrade() -> None:
+    op.execute(sa.text(VIEW_SQL))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP VIEW IF EXISTS v_certificados_status"))

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -256,38 +256,35 @@ export const normalizeAlertaFromApi = (item) => {
 };
 
 export const normalizeCertificadoFromApi = (item) => {
-  if (!item || typeof item !== "object") {
-    return item;
-  }
-
+  if (!item || typeof item !== "object") return item;
   const normalized = { ...item };
 
-  // Normaliza id / cert_id
-  const idCandidates = [item.id, item.cert_id, item.certId];
-  let resolvedId;
+  // id / cert_id
+  const idCandidates = [item.id, item.cert_id];
   for (const candidate of idCandidates) {
     const parsed = toFiniteNumber(candidate);
     if (parsed !== undefined) {
-      resolvedId = parsed;
+      normalized.id = parsed;
+      normalized.cert_id = parsed;
       break;
     }
   }
-  if (resolvedId !== undefined) {
-    normalized.id = resolvedId;
-    normalized.cert_id = resolvedId;
-  }
 
-  // org_id sempre string
-  if (normalized.org_id !== undefined && normalized.org_id !== null) {
+  // org_id string
+  if (normalized.org_id != null) {
     normalized.org_id = String(normalized.org_id);
   }
 
-  // empresa → titular (o Card usa "titular")
-  if (normalized.titular === undefined && normalized.empresa !== undefined) {
-    normalized.titular = normalized.empresa;
-  }
+  // titular: usa empresa (que agora já é o "Emitido para" nos órfãos)
+  const titular =
+    normalized.titular ??
+    normalized.empresa ??
+    normalized.subject ??
+    "";
 
-  // Campos de data: tanto snake_case quanto camelCase
+  normalized.titular = titular;
+
+  // datas snake_case → camelCase
   if (normalized.validoDe === undefined && normalized.valido_de !== undefined) {
     normalized.validoDe = normalized.valido_de;
   }
@@ -295,7 +292,7 @@ export const normalizeCertificadoFromApi = (item) => {
     normalized.validoAte = normalized.valido_ate;
   }
 
-  // diasRestantes: número sempre
+  // diasRestantes
   const diasRestantes = toFiniteNumber(
     normalized.diasRestantes ?? normalized.dias_restantes,
   );


### PR DESCRIPTION
## Summary
- add migration rebuilding `v_certificados_status` to derive titular/cnpj from subject when no empresa link exists
- update certificate normalization to honor new titular fallback from API

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da18d6d708326b24e557e87b18ced)