### PR TITLE
Add chip-based sorting UI to certificados screen

### DIFF
--- a/frontend/src/features/certificados/CertificadosScreen.jsx
+++ b/frontend/src/features/certificados/CertificadosScreen.jsx
@@ -13,8 +13,14 @@ import CertificadoCard from "@/features/certificados/CertificadoCard";
 import AgendamentosTable from "@/features/certificados/AgendamentosTable";
 import { categorizeCertificadoSituacao } from "@/lib/certificados";
 import { normalizeTextLower } from "@/lib/text";
+import { cn } from "@/lib/utils";
 
 const DATE_REGEX = /(\d{2}\/\d{2}\/\d{4})/;
+
+const SORT_FIELDS = [
+  { value: "vencimento", label: "Vencimento" },
+  { value: "nome", label: "Nome" },
+];
 
 const extractDate = (value) => {
   if (typeof value !== "string") {
@@ -29,10 +35,48 @@ const extractDate = (value) => {
 
 const SITUACAO_OPTIONS = ["Todos", "Válido", "Vencendo em breve", "Vencido"];
 
+const getDateTimestamp = (value) => {
+  const date = extractDate(value);
+  if (!date) return null;
+  const [day, month, year] = date.split("/").map((item) => Number.parseInt(item, 10));
+  const timestamp = new Date(year, month - 1, day).getTime();
+  return Number.isNaN(timestamp) ? null : timestamp;
+};
+
+const compareByDate = (a, b, direction) => {
+  const timeA = getDateTimestamp(a?.validoAte ?? "");
+  const timeB = getDateTimestamp(b?.validoAte ?? "");
+  if (timeA === null && timeB === null) return 0;
+  if (timeA === null) return 1;
+  if (timeB === null) return -1;
+  return direction === "desc" ? timeB - timeA : timeA - timeB;
+};
+
+const compareByName = (a, b, direction) => {
+  const nameA = normalizeTextLower(a?.titular ?? "").trim();
+  const nameB = normalizeTextLower(b?.titular ?? "").trim();
+  if (!nameA && !nameB) return 0;
+  if (!nameA) return 1;
+  if (!nameB) return -1;
+  const result = nameA.localeCompare(nameB);
+  return direction === "desc" ? result * -1 : result;
+};
+
 export default function CertificadosScreen({ certificados, agendamentos, soAlertas }) {
   const [subTab, setSubTab] = useState("certificados");
   const [search, setSearch] = useState("");
   const [situacao, setSituacao] = useState("Todos");
+  const [sortField, setSortField] = useState("vencimento");
+  const [sortDir, setSortDir] = useState("asc");
+
+  const handleSortClick = (field) => {
+    if (field === sortField) {
+      setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortField(field);
+    setSortDir("asc");
+  };
 
   const certificadosLista = useMemo(
     () => (Array.isArray(certificados) ? certificados : []),
@@ -63,19 +107,14 @@ export default function CertificadosScreen({ certificados, agendamentos, soAlert
   }, [certificadosLista, search, situacao, soAlertas]);
 
   const orderedCertificados = useMemo(() => {
-    return [...filteredCertificados].sort((a, b) => {
-      const dateA = extractDate(a?.validoAte ?? "");
-      const dateB = extractDate(b?.validoAte ?? "");
-      if (!dateA && !dateB) return 0;
-      if (!dateA) return 1;
-      if (!dateB) return -1;
-      const [dayA, monthA, yearA] = dateA.split("/").map((value) => Number.parseInt(value, 10));
-      const [dayB, monthB, yearB] = dateB.split("/").map((value) => Number.parseInt(value, 10));
-      const timeA = new Date(yearA, monthA - 1, dayA).getTime();
-      const timeB = new Date(yearB, monthB - 1, dayB).getTime();
-      return timeA - timeB;
-    });
-  }, [filteredCertificados]);
+    const comparator = (a, b) => {
+      if (sortField === "nome") {
+        return compareByName(a, b, sortDir);
+      }
+      return compareByDate(a, b, sortDir);
+    };
+    return [...filteredCertificados].sort(comparator);
+  }, [filteredCertificados, sortDir, sortField]);
 
   return (
     <Tabs value={subTab} onValueChange={setSubTab} className="space-y-4">
@@ -103,6 +142,28 @@ export default function CertificadosScreen({ certificados, agendamentos, soAlert
               ))}
             </SelectContent>
           </Select>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-slate-600">Ordenar por</span>
+            {SORT_FIELDS.map((option) => {
+              const isActive = sortField === option.value;
+              const directionSymbol = isActive ? (sortDir === "asc" ? "↑" : "↓") : null;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => handleSortClick(option.value)}
+                  className={cn(
+                    "flex items-center gap-1 rounded-full border px-3 py-1.5 text-sm transition-colors",
+                    "border-slate-200 bg-white text-slate-600 hover:bg-slate-50",
+                    isActive && "border-primary/60 bg-primary/5 text-primary font-semibold"
+                  )}
+                >
+                  <span>{option.label}</span>
+                  {directionSymbol && <span className="text-xs">{directionSymbol}</span>}
+                </button>
+              );
+            })}
+          </div>
           {soAlertas && (
             <InlineBadge variant="outline" className="uppercase tracking-wide">
               Modo foco ativo

--- a/frontend/src/features/certificados/CertificadosScreen.jsx
+++ b/frontend/src/features/certificados/CertificadosScreen.jsx
@@ -38,9 +38,15 @@ const SITUACAO_OPTIONS = ["Todos", "Válido", "Vencendo em breve", "Vencido"];
 const getDateTimestamp = (value) => {
   const date = extractDate(value);
   if (!date) return null;
-  const [day, month, year] = date.split("/").map((item) => Number.parseInt(item, 10));
-  const timestamp = new Date(year, month - 1, day).getTime();
-  return Number.isNaN(timestamp) ? null : timestamp;
+
+  if (DATE_REGEX.test(date)) {
+    const [day, month, year] = date.split("/").map((item) => Number.parseInt(item, 10));
+    const timestamp = new Date(year, month - 1, day).getTime();
+    return Number.isNaN(timestamp) ? null : timestamp;
+  }
+
+  const parsed = Date.parse(date);
+  return Number.isNaN(parsed) ? null : parsed;
 };
 
 const compareByDate = (a, b, direction) => {


### PR DESCRIPTION
## Summary
- replace certificados sorting dropdown with chip-based control for vencimento and nome
- implement toggleable sort direction with visual indicators for the active field
- keep filtered results sorted according to the selected field and direction

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692def5b5e008326b855343b905f219a)