### PR TITLE
Normalize responsavel fiscal names

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -253,8 +253,12 @@ export const normalizeEmpresaFromApi = (item) => {
   ) {
     normalized.cpfResponsavelLegal = normalized.cpf_responsavel_legal;
   }
-  if (normalized.responsavel_fiscal !== undefined && normalized.responsavelFiscal === undefined) {
-    normalized.responsavelFiscal = normalized.responsavel_fiscal;
+  const responsavelFiscalRaw =
+    normalized.responsavelFiscal ?? normalized.responsavel_fiscal;
+  if (responsavelFiscalRaw !== undefined) {
+    const responsavelFiscal = normalizeNomePessoa(responsavelFiscalRaw);
+    normalized.responsavelFiscal = responsavelFiscal;
+    normalized.responsavel_fiscal = responsavelFiscal;
   }
   return normalized;
 };


### PR DESCRIPTION
## Summary
- normalize responsible fiscal names during empresa normalization to use existing person-name formatter

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4be278508326a56000a0eacd46be)