### PR TITLE
Add licencas tipo mapping and migration

### DIFF
--- a/FLUXO_INTEGRACOES.md
+++ b/FLUXO_INTEGRACOES.md
@@ -64,6 +64,7 @@
 
   * `id serial PK`, `org_id uuid FK`, `empresa_id int FK empresas(id) ON DELETE CASCADE`,
     `categoria varchar NOT NULL` (ex.: **ALVARÁ VIG SANITÁRIA**, **LICENÇA AMBIENTAL**),
+    `tipo_codigo text? FK licenca_tipos(codigo)` (código oficial: **ALF, AVS, AMB, CUSOLO, CERCON**),
     `tipo_documento varchar NOT NULL` (Definitivo, Provisório, Dispensa, etc.),
     `status varchar NOT NULL`, `status_bruto varchar?` (texto como "Possui. Val dd/mm/aaaa"),
     `municipio varchar?`, `fonte varchar NOT NULL DEFAULT 'ARQUIVO'` (ou `PROCESSO`),
@@ -77,6 +78,11 @@
     `tipo varchar NOT NULL`, `status varchar NOT NULL`, `data_envio date?`, `vencimento_tpi date?`, `obs text?`,
     `created_at timestamptz DEFAULT now()`, `updated_at timestamptz DEFAULT now()`,
     `created_by? int`, `updated_by? int`
+
+* **licenca_tipos**
+
+  * Tabela de apoio com códigos oficiais de licença: `codigo text PK` (**ALF, AVS, AMB, CUSOLO, CERCON**),
+    `nome text NOT NULL`, `descricao text?`, `ativo boolean NOT NULL DEFAULT true`.
 
 * **processos**
 
@@ -173,6 +179,7 @@
   * `ix_licencas_org_validade (org_id, validade)`
   * `ix_licencas_org_categoria (org_id, lower(immutable_unaccent(categoria)))`
   * `uq_licencas_org_empresa_categoria (org_id, empresa_id, categoria)` **UNIQUE** (categoria consolidada por empresa)
+  * `licencas_tipo_codigo_fkey` → `licenca_tipos(codigo)`
 * **taxas**
 
   * `ix_taxas_org_vencimento_tpi (org_id, vencimento_tpi)`

--- a/backend/app/services/licencas_ingest.py
+++ b/backend/app/services/licencas_ingest.py
@@ -90,6 +90,14 @@ _PATTERN_DEFINITIONS: Sequence[tuple[str, re.Pattern[str], str]] = (
 
 _CATEGORIAS_BASE = {categoria for categoria, _, _ in _PATTERN_DEFINITIONS}
 
+MAPEAMENTO_TIPO_ARQUIVO_PARA_CODIGO = {
+    "ALVARÁ BOMBEIROS": "CERCON",
+    "ALVARÁ FUNCIONAMENTO": "ALF",
+    "ALVARÁ VIG SANITÁRIA": "AVS",
+    "LICENÇA AMBIENTAL": "AMB",
+    "CERTIDÃO USO DO SOLO": "CUSOLO",
+}
+
 _CANONICAL_TIPO_ALIASES: dict[str, list[str]] = {
     "CERCON": ["CERCON"],
     "ALVARÁ VIG SANITÁRIA": ["ALVARÁ VIG SANITÁRIA", "SANITÁRIA", "SANITARIA"],
@@ -102,6 +110,13 @@ _CANONICAL_TIPO_ALIASES: dict[str, list[str]] = {
 def _aliases_for_categoria(categoria: str) -> list[str]:
     aliases = _CANONICAL_TIPO_ALIASES.get(categoria)
     return aliases if aliases else [categoria]
+
+
+def _tipo_codigo_para_categoria(categoria: str) -> str | None:
+    codigo = MAPEAMENTO_TIPO_ARQUIVO_PARA_CODIGO.get(categoria)
+    if codigo:
+        return codigo
+    return categoria if categoria in MAPEAMENTO_TIPO_ARQUIVO_PARA_CODIGO.values() else None
 
 _SUJEITO_ALWAYS = {
     "ALVARÁ FUNCIONAMENTO",
@@ -379,6 +394,7 @@ def ingest_licencas_from_fs(db: Session, org_id: UUID | None = None, empresa_id:
                 )
 
             aliases = _aliases_for_categoria(categoria)
+            tipo_codigo = _tipo_codigo_para_categoria(categoria)
             stmt_existente = select(Licenca).where(
                 Licenca.org_id == empresa.org_id,
                 Licenca.empresa_id == empresa.id,
@@ -410,6 +426,7 @@ def ingest_licencas_from_fs(db: Session, org_id: UUID | None = None, empresa_id:
                         """
                         UPDATE licencas
                         SET tipo     = :tipo,
+                            tipo_codigo = :tipo_codigo,
                             status   = :status,
                             validade = :validade,
                             obs      = :obs
@@ -419,6 +436,7 @@ def ingest_licencas_from_fs(db: Session, org_id: UUID | None = None, empresa_id:
                     {
                         "id": existente.id,
                         "tipo": categoria,
+                        "tipo_codigo": tipo_codigo,
                         "status": resultado.status,
                         "validade": resultado.validade,
                         "obs": resultado.status_bruto,
@@ -431,10 +449,10 @@ def ingest_licencas_from_fs(db: Session, org_id: UUID | None = None, empresa_id:
                     text(
                         """
                         INSERT INTO licencas (
-                            empresa_id, org_id, tipo, status,
+                            empresa_id, org_id, tipo, tipo_codigo, status,
                             validade, obs
                         ) VALUES (
-                            :empresa_id, :org_id, :tipo, :status,
+                            :empresa_id, :org_id, :tipo, :tipo_codigo, :status,
                             :validade, :obs
                         )
                         """
@@ -443,6 +461,7 @@ def ingest_licencas_from_fs(db: Session, org_id: UUID | None = None, empresa_id:
                         "empresa_id": empresa.id,
                         "org_id": empresa.org_id,
                         "tipo": categoria,
+                        "tipo_codigo": tipo_codigo,
                         "status": resultado.status,
                         "validade": resultado.validade,
                         "obs": resultado.status_bruto,

--- a/backend/db/models_sql.py
+++ b/backend/db/models_sql.py
@@ -118,6 +118,7 @@ class Licenca(Base):
     empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="CASCADE"), nullable=False)
     org_id = Column(UUID(as_uuid=False), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
     tipo = Column(String(50), nullable=False)
+    tipo_codigo = Column(Text, ForeignKey("licenca_tipos.codigo"))
     status = Column(String(120), nullable=False)
     validade = Column(Date)
     obs = Column(Text)

--- a/backend/migrations/versions/20251104_01_licencas_table_fix_and_update.py
+++ b/backend/migrations/versions/20251104_01_licencas_table_fix_and_update.py
@@ -1,0 +1,153 @@
+"""Normaliza tipos de licenças, padroniza CERCON e cria tabela licenca_tipos.
+
+Revision ID: 20251104_01_licencas_table_fix_and_update
+Revises: 20251212_02_cnds_add_cnpj
+Create Date: 2025-11-04 01:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20251104_01_licencas_table_fix_and_update"
+down_revision = "20251212_02_cnds_add_cnpj"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Aplica normalizações de tipos, cria licenca_tipos e adiciona tipo_codigo."""
+
+    conn = op.get_bind()
+
+    # 1) NORMALIZAÇÃO DOS TEXTOS EM licencas.tipo
+    conn.execute(
+        sa.text(
+            """
+            UPDATE licencas
+            SET tipo = 'ALVARÁ FUNCIONAMENTO'
+            WHERE tipo LIKE 'ALVAR%FUNCIONAMENTO%';
+            """
+        )
+    )
+
+    conn.execute(
+        sa.text(
+            """
+            UPDATE licencas
+            SET tipo = 'ALVARÁ VIG SANITÁRIA'
+            WHERE tipo LIKE 'ALVAR%VIG%SANIT%';
+            """
+        )
+    )
+
+    conn.execute(
+        sa.text(
+            """
+            UPDATE licencas
+            SET tipo = 'LICENÇA AMBIENTAL'
+            WHERE tipo LIKE 'LICEN%A AMBIENTAL%';
+            """
+        )
+    )
+
+    conn.execute(
+        sa.text(
+            """
+            UPDATE licencas
+            SET tipo = 'CERTIDÃO USO DO SOLO'
+            WHERE tipo LIKE 'CERTID%O USO DO SOLO%';
+            """
+        )
+    )
+
+    # 2) PADRONIZAÇÃO PARA CERCON
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM licencas l
+            WHERE l.tipo = 'ALVARÁ BOMBEIROS'
+              AND EXISTS (
+                  SELECT 1
+                  FROM licencas l2
+                  WHERE l2.org_id = l.org_id
+                    AND l2.empresa_id = l.empresa_id
+                    AND l2.tipo = 'CERCON'
+              );
+            """
+        )
+    )
+
+    conn.execute(
+        sa.text(
+            """
+            UPDATE licencas
+            SET tipo = 'CERCON'
+            WHERE tipo = 'ALVARÁ BOMBEIROS';
+            """
+        )
+    )
+
+    # 3) CRIAÇÃO DA TABELA licenca_tipos
+    op.create_table(
+        "licenca_tipos",
+        sa.Column("codigo", sa.Text(), primary_key=True),
+        sa.Column("nome", sa.Text(), nullable=False),
+        sa.Column("descricao", sa.Text(), nullable=True),
+        sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+    )
+
+    licenca_tipos_table = sa.table(
+        "licenca_tipos",
+        sa.column("codigo", sa.Text()),
+        sa.column("nome", sa.Text()),
+        sa.column("descricao", sa.Text()),
+        sa.column("ativo", sa.Boolean()),
+    )
+
+    op.bulk_insert(
+        licenca_tipos_table,
+        [
+            {"codigo": "ALF", "nome": "ALVARÁ FUNCIONAMENTO", "descricao": None, "ativo": True},
+            {"codigo": "AVS", "nome": "ALVARÁ VIG SANITÁRIA", "descricao": None, "ativo": True},
+            {"codigo": "AMB", "nome": "LICENÇA AMBIENTAL", "descricao": None, "ativo": True},
+            {"codigo": "CUSOLO", "nome": "CERTIDÃO USO DO SOLO", "descricao": None, "ativo": True},
+            {"codigo": "CERCON", "nome": "ALVARÁ BOMBEIROS", "descricao": None, "ativo": True},
+        ],
+    )
+
+    # 4) ADICIONA COLUNA tipo_codigo EM licencas
+    op.add_column("licencas", sa.Column("tipo_codigo", sa.Text(), nullable=True))
+
+    conn.execute(
+        sa.text(
+            """
+            UPDATE licencas
+            SET tipo_codigo = CASE
+                WHEN tipo = 'ALVARÁ FUNCIONAMENTO' THEN 'ALF'
+                WHEN tipo = 'ALVARÁ VIG SANITÁRIA' THEN 'AVS'
+                WHEN tipo = 'LICENÇA AMBIENTAL'    THEN 'AMB'
+                WHEN tipo = 'CERTIDÃO USO DO SOLO' THEN 'CUSOLO'
+                WHEN tipo = 'CERCON'               THEN 'CERCON'
+                ELSE NULL
+            END;
+            """
+        )
+    )
+
+    # 5) CRIA CONSTRAINT DE FK licencas.tipo_codigo -> licenca_tipos.codigo
+    op.create_foreign_key(
+        "licencas_tipo_codigo_fkey",
+        source_table="licencas",
+        referent_table="licenca_tipos",
+        local_cols=["tipo_codigo"],
+        remote_cols=["codigo"],
+    )
+
+
+def downgrade():
+    """Downgrade best-effort removendo estruturas criadas."""
+
+    op.drop_constraint("licencas_tipo_codigo_fkey", "licencas", type_="foreignkey")
+    op.drop_column("licencas", "tipo_codigo")
+    op.drop_table("licenca_tipos")


### PR DESCRIPTION
## Summary
- normalize licenca types, add licenca_tipos table, and add tipo_codigo references through new migration
- map ingested licenca categories to official codes and persist tipo_codigo in upserts
- extend Licenca model with tipo_codigo to reflect the new schema
- document licenca tipo codes and foreign key in the integration flow schema

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931eecb6864832684e4aec4c6daeb74)