### PR TITLE
Corrige cálculo de vencimentos e leitura do painel

### DIFF
--- a/frontend/src/features/certificados/CertificadoCard.jsx
+++ b/frontend/src/features/certificados/CertificadoCard.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import CopyableIdentifier from "@/components/CopyableIdentifier";
 import StatusBadge from "@/components/StatusBadge";
@@ -48,6 +48,15 @@ const buildPrazoLabel = (diasRestantes) => {
 };
 
 export default function CertificadoCard({ certificado }) {
+  const [todayKey, setTodayKey] = useState(() => new Date().toDateString());
+
+  useEffect(() => {
+    const update = () => setTodayKey(new Date().toDateString());
+    update();
+    const interval = setInterval(update, 60 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
   const titular = certificado?.titular ?? "";
   const validoDe = extractDateLabel(certificado?.validoDe ?? "");
   const validoAte = extractDateLabel(certificado?.validoAte ?? "");
@@ -64,7 +73,7 @@ export default function CertificadoCard({ certificado }) {
     const end = new Date(target.getFullYear(), target.getMonth(), target.getDate());
     const diffMs = end.getTime() - start.getTime();
     return Math.trunc(diffMs / MS_PER_DAY);
-  }, [certificado?.validoAte]);
+  }, [certificado?.validoAte, todayKey]);
 
   const prazoLabel = useMemo(() => buildPrazoLabel(diasRestantes), [diasRestantes]);
 

--- a/frontend/src/features/painel/PainelScreen.jsx
+++ b/frontend/src/features/painel/PainelScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import InlineBadge from "@/components/InlineBadge";
@@ -71,6 +71,15 @@ export default function PainelScreen(props) {
   void query;
   void municipio;
   void soAlertas;
+
+  const [todayKey, setTodayKey] = useState(() => new Date().toDateString());
+
+  useEffect(() => {
+    const update = () => setTodayKey(new Date().toDateString());
+    update();
+    const interval = setInterval(update, 60 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
 
   const licencaResumo = useMemo(() => {
     return filteredLicencas.reduce(
@@ -197,23 +206,23 @@ export default function PainelScreen(props) {
 
     return lista
       .map((cert) => {
-        let diasRestantes = Number.isFinite(cert?.diasRestantes) ? cert.diasRestantes : null;
-        if (diasRestantes === null) {
-          let validade = parsePtDate(cert?.validoAte);
-          if (!(validade instanceof Date) || Number.isNaN(validade.getTime())) {
-            if (typeof cert?.validoAte === "string") {
-              const isoCandidate = new Date(cert.validoAte);
-              if (!Number.isNaN(isoCandidate?.getTime())) {
-                validade = isoCandidate;
-              }
+        let diasRestantes = null;
+        let validade = parsePtDate(cert?.validoAte);
+        if (!(validade instanceof Date) || Number.isNaN(validade.getTime())) {
+          if (typeof cert?.validoAte === "string") {
+            const isoCandidate = new Date(cert.validoAte);
+            if (!Number.isNaN(isoCandidate?.getTime())) {
+              validade = isoCandidate;
             }
           }
+        }
 
-          if (validade instanceof Date && !Number.isNaN(validade.getTime())) {
-            const end = new Date(validade.getFullYear(), validade.getMonth(), validade.getDate());
-            const diffMs = end.getTime() - start.getTime();
-            diasRestantes = Math.trunc(diffMs / MS_PER_DAY);
-          }
+        if (validade instanceof Date && !Number.isNaN(validade.getTime())) {
+          const end = new Date(validade.getFullYear(), validade.getMonth(), validade.getDate());
+          const diffMs = end.getTime() - start.getTime();
+          diasRestantes = Math.trunc(diffMs / MS_PER_DAY);
+        } else if (Number.isFinite(cert?.diasRestantes)) {
+          diasRestantes = cert.diasRestantes;
         }
 
         return {
@@ -221,9 +230,9 @@ export default function PainelScreen(props) {
           diasRestantes,
         };
       })
-      .filter((cert) => cert.diasRestantes !== null && cert.diasRestantes >= 0 && cert.diasRestantes <= 7)
+      .filter((cert) => cert.diasRestantes !== null && cert.diasRestantes <= 7)
       .sort((a, b) => a.diasRestantes - b.diasRestantes);
-  }, [certificados]);
+  }, [certificados, todayKey]);
 
   return (
     <div className="mt-4 space-y-4">

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,3 +1,6 @@
+import { getStatusKey } from "@/lib/status";
+import { parsePtDate } from "@/lib/text";
+
 const DEFAULT_API_BASE = "http://localhost:8000";
 
 export const normalizeApiBase = (rawBase) => {
@@ -49,6 +52,38 @@ const CANONICAL_ENDPOINT_MAP = {
 };
 
 const ensureLeadingSlash = (path = "") => (path.startsWith("/") ? path : `/${path}`);
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const parseDateValue = (value) => {
+  if (!value) return null;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const ptDate = parsePtDate(value);
+    if (ptDate instanceof Date && !Number.isNaN(ptDate.getTime())) {
+      return ptDate;
+    }
+    const isoCandidate = new Date(value);
+    if (!Number.isNaN(isoCandidate.getTime())) {
+      return isoCandidate;
+    }
+  }
+  return null;
+};
+
+const computeDiasRestantes = (dateValue) => {
+  const target = parseDateValue(dateValue);
+  if (!(target instanceof Date)) {
+    return null;
+  }
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const end = new Date(target.getFullYear(), target.getMonth(), target.getDate());
+  const diffMs = end.getTime() - start.getTime();
+  return Math.trunc(diffMs / MS_PER_DAY);
+};
 
 const toFiniteNumber = (value) => {
   if (typeof value === "number" && Number.isFinite(value)) {
@@ -281,6 +316,40 @@ export const normalizeAlertaFromApi = (item) => {
   return normalized;
 };
 
+export const normalizeLicencaFromApi = (item) => {
+  if (!item || typeof item !== "object") return item;
+
+  const normalized = { ...item };
+  const validade =
+    normalized.validade ??
+    normalized.data_validade ??
+    normalized.dataVencimento ??
+    normalized.data_vencimento;
+
+  if (validade !== undefined) {
+    normalized.validade = validade;
+  }
+
+  const diasRestantes = computeDiasRestantes(validade);
+  if (diasRestantes !== null) {
+    normalized.diasRestantes = diasRestantes;
+    normalized.dias_restantes = diasRestantes;
+
+    const statusKey = getStatusKey(normalized.status);
+    if (!statusKey || statusKey.includes("venc") || statusKey === "valido") {
+      if (diasRestantes < 0) {
+        normalized.status = "Vencido";
+      } else if (diasRestantes <= 30) {
+        normalized.status = "Vence≤30d";
+      } else if (!statusKey) {
+        normalized.status = "Válido";
+      }
+    }
+  }
+
+  return normalized;
+};
+
 export const normalizeCertificadoFromApi = (item) => {
   if (!item || typeof item !== "object") return item;
   const normalized = { ...item };
@@ -327,12 +396,22 @@ export const normalizeCertificadoFromApi = (item) => {
     normalized.validoAte = normalized.valido_ate;
   }
 
-  // diasRestantes
-  const diasRestantes = toFiniteNumber(
-    normalized.diasRestantes ?? normalized.dias_restantes,
-  );
-  if (diasRestantes !== undefined) {
+  // diasRestantes recalculado pela data de validade
+  const diasRestantes = computeDiasRestantes(normalized.validoAte ?? normalized.valido_ate);
+  if (diasRestantes !== null) {
     normalized.diasRestantes = diasRestantes;
+    normalized.dias_restantes = diasRestantes;
+
+    const situacaoKey = getStatusKey(normalized.situacao);
+    if (diasRestantes < 0) {
+      normalized.situacao = "Vencido";
+    } else if (diasRestantes <= 7) {
+      if (!situacaoKey || situacaoKey.includes("venc") || situacaoKey.includes("valido")) {
+        normalized.situacao = "Vencendo em breve";
+      }
+    } else if (!situacaoKey) {
+      normalized.situacao = "Válido";
+    }
   }
 
   return normalized;
@@ -506,7 +585,7 @@ const normalizeTaxasFromApi = (payload) => {
 const DEFAULT_TRANSFORMS = {
   "/empresas": (payload) => normalizeCollectionPayload(payload, normalizeEmpresaFromApi),
   "/alertas": (payload) => normalizeCollectionPayload(payload, normalizeAlertaFromApi),
-  "/licencas": (payload) => normalizeCollectionPayload(payload),
+  "/licencas": (payload) => normalizeCollectionPayload(payload, normalizeLicencaFromApi),
   "/processos": (payload) => normalizeCollectionPayload(payload),
   "/taxas": (payload) => normalizeTaxasFromApi(payload),
   "/certificados": (payload) =>


### PR DESCRIPTION
## Resumo
- recalcula e expõe a validade das licenças ao normalizar os dados para manter status e métricas consistentes
- força o painel a recomputar os dias restantes dos certificados usando a data atual e inclui os vencidos na lista de alerta

## Testes
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936b7a65e848326b7670db3c2e5754e)