### PR TITLE
Hook dashboard alert trend to backend data

### DIFF
--- a/backend/app/api/v1/endpoints/alertas.py
+++ b/backend/app/api/v1/endpoints/alertas.py
@@ -5,6 +5,7 @@ from typing import Dict
 import hashlib
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.api.v1.endpoints.utils import (
@@ -14,7 +15,7 @@ from app.api.v1.endpoints.utils import (
     resolve_sort,
 )
 from app.deps.auth import Role, User, db_with_org, require_role
-from app.schemas.alertas import AlertaListResponse
+from app.schemas.alertas import AlertaListResponse, AlertaTrendResponse
 
 router = APIRouter(prefix="/alertas", tags=["Alertas"])
 
@@ -63,3 +64,40 @@ def listar_alertas(
     data["items"] = items
 
     return AlertaListResponse(**data)
+
+
+@router.get("/tendencia", response_model=AlertaTrendResponse)
+def tendencia_alertas(
+    db: Session = Depends(db_with_org),
+    _: User = Depends(require_role(Role.VIEWER)),
+) -> AlertaTrendResponse:
+    """Retorna a evolução mensal de alertas de licenças vencendo ou vencidas."""
+
+    sql = text(
+        """
+        SELECT
+            date_trunc('month', validade)::date AS mes,
+            count(*) FILTER (WHERE validade >= CURRENT_DATE) AS alertas_vencendo,
+            count(*) FILTER (WHERE validade < CURRENT_DATE) AS alertas_vencidas
+        FROM licencas
+        WHERE validade IS NOT NULL
+          AND date_trunc('month', validade) >= date_trunc('month', CURRENT_DATE) - interval '11 months'
+          AND (current_setting('app.current_org', true) IS NULL OR org_id = (current_setting('app.current_org'))::uuid)
+        GROUP BY mes
+        ORDER BY mes
+        """
+    )
+
+    rows = db.execute(sql).mappings().all()
+    items = [
+        {
+            "mes": row["mes"],
+            "alertas_vencendo": int(row.get("alertas_vencendo", 0) or 0),
+            "alertas_vencidas": int(row.get("alertas_vencidas", 0) or 0),
+            "total_alertas": int(row.get("alertas_vencendo", 0) or 0)
+            + int(row.get("alertas_vencidas", 0) or 0),
+        }
+        for row in rows
+    ]
+
+    return AlertaTrendResponse(items=items)

--- a/backend/app/schemas/alertas.py
+++ b/backend/app/schemas/alertas.py
@@ -24,3 +24,16 @@ class AlertaView(BaseModel):
 
 class AlertaListResponse(PaginatedResponse[AlertaView]):
     pass
+
+
+class AlertaTrendItem(BaseModel):
+    mes: date
+    alertas_vencendo: int
+    alertas_vencidas: int
+    total_alertas: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AlertaTrendResponse(BaseModel):
+    items: list[AlertaTrendItem]

--- a/frontend/src/features/painel/PainelScreen.jsx
+++ b/frontend/src/features/painel/PainelScreen.jsx
@@ -32,8 +32,8 @@ import {
   isAlertStatus,
   isProcessStatusInactive,
 } from "@/lib/status";
+import { listarTendenciaAlertas } from "@/services/alertas";
 
-const MONTHS_WINDOW = 12;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 const parseDateToLocalDay = (value) => {
@@ -96,6 +96,7 @@ export default function PainelScreen(props) {
   void soAlertas;
 
   const [todayKey, setTodayKey] = useState(() => new Date().toDateString());
+  const [alertTrendData, setAlertTrendData] = useState([]);
 
   useEffect(() => {
     const update = () => setTodayKey(new Date().toDateString());
@@ -123,74 +124,57 @@ export default function PainelScreen(props) {
     );
   }, [filteredLicencas]);
 
-  const alertTrendData = useMemo(() => {
-    if (!Array.isArray(filteredLicencas) || filteredLicencas.length === 0) {
-      return [];
-    }
+  useEffect(() => {
+    let active = true;
 
-    const now = new Date();
-    const end = new Date(now.getFullYear(), now.getMonth(), 1);
-    const start = new Date(end.getFullYear(), end.getMonth() - (MONTHS_WINDOW - 1), 1);
+    listarTendenciaAlertas()
+      .then((response) => {
+        const items = Array.isArray(response?.items)
+          ? response.items
+          : Array.isArray(response)
+            ? response
+            : [];
 
-    const counts = new Map();
+        const normalized = items
+          .map((item) => {
+            const monthDate = parseDateToLocalDay(item?.mes);
+            if (!(monthDate instanceof Date) || Number.isNaN(monthDate.getTime())) {
+              return null;
+            }
+            const vencendo = Number(item?.alertas_vencendo) || 0;
+            const vencidas = Number(item?.alertas_vencidas) || 0;
+            const monthLabel = monthDate
+              .toLocaleDateString("pt-BR", { month: "short" })
+              .replace(/\./g, "")
+              .toLowerCase();
 
-    filteredLicencas.forEach((lic) => {
-      if (!lic || !isAlertStatus(lic.status)) return;
+            return {
+              date: monthDate,
+              ts: monthDate.getTime(),
+              label: `${monthLabel}/${String(monthDate.getFullYear()).slice(-2)}`,
+              total_alertas: vencendo + vencidas,
+              alertas_vencendo: vencendo,
+              alertas_vencidas: vencidas,
+            };
+          })
+          .filter(Boolean)
+          .sort((a, b) => a.ts - b.ts);
 
-      const statusKey = getStatusKey(lic.status);
-      if (!statusKey) return;
-
-      let bucket = null;
-      if (statusKey.includes("vencid")) bucket = "vencidas";
-      else if (statusKey.includes("vence")) bucket = "vencendo";
-      if (!bucket) return;
-
-      const validade = parseDateToLocalDay(lic.validade);
-      if (!(validade instanceof Date) || Number.isNaN(validade.getTime())) {
-        return;
-      }
-
-      const monthDate = new Date(validade.getFullYear(), validade.getMonth(), 1);
-      if (monthDate < start || monthDate > end) {
-        return;
-      }
-
-      const key = `${monthDate.getFullYear()}-${monthDate.getMonth()}`;
-      const previous = counts.get(key) ?? { vencendo: 0, vencidas: 0 };
-      counts.set(key, { ...previous, [bucket]: previous[bucket] + 1 });
-    });
-
-    const data = [];
-    for (
-      let year = start.getFullYear(), month = start.getMonth();
-      year < end.getFullYear() || (year === end.getFullYear() && month <= end.getMonth());
-    ) {
-      const currentDate = new Date(year, month, 1);
-      const key = `${year}-${month}`;
-      const monthCounts = counts.get(key) ?? { vencendo: 0, vencidas: 0 };
-      const monthLabel = currentDate
-        .toLocaleDateString("pt-BR", { month: "short" })
-        .replace(/\./g, "")
-        .toLowerCase();
-
-      data.push({
-        date: currentDate,
-        ts: currentDate.getTime(),
-        label: `${monthLabel}/${String(year).slice(-2)}`,
-        total_alertas: monthCounts.vencendo + monthCounts.vencidas,
-        alertas_vencendo: monthCounts.vencendo,
-        alertas_vencidas: monthCounts.vencidas,
+        if (active) {
+          setAlertTrendData(normalized);
+        }
+      })
+      .catch((error) => {
+        console.error("[Painel] Falha ao carregar tendência de alertas", error);
+        if (active) {
+          setAlertTrendData([]);
+        }
       });
 
-      month += 1;
-      if (month > 11) {
-        month = 0;
-        year += 1;
-      }
-    }
-
-    return data;
-  }, [filteredLicencas]);
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const processosAtivos = useMemo(() => {
     return processosNormalizados.filter((proc) => !isProcessStatusInactive(proc.status));

--- a/frontend/src/services/alertas.js
+++ b/frontend/src/services/alertas.js
@@ -6,3 +6,7 @@ export const listarAlertas = async (params = {}) => {
     query: { page, size, sort, tipo_alerta, empresa_id },
   });
 };
+
+export const listarTendenciaAlertas = async () => {
+  return fetchJson("/api/v1/alertas/tendencia");
+};


### PR DESCRIPTION
## Summary
- add backend endpoint to return monthly alert trend counts from the database
- expose an alert trend service and load the dashboard chart with backend data

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936fdafcf1c8326b6590a45a33f06a1)