### PR TITLE
Exibir documento nos certificados

### DIFF
--- a/frontend/src/components/CopyableIdentifier.jsx
+++ b/frontend/src/components/CopyableIdentifier.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { Clipboard } from "lucide-react";
-import { formatCnpj, normalizeIdentifier } from "@/lib/text";
+import { formatCpfCnpj, normalizeIdentifier } from "@/lib/text";
 
 function CopyableIdentifier({ label, value, onCopy }) {
   const normalizedValue = normalizeIdentifier(value);
-  const formattedCnpj = label === "CNPJ" ? formatCnpj(value) : undefined;
-  const displayValue = formattedCnpj || normalizedValue || "—";
+  const formattedDocument = formatCpfCnpj(value);
+  const displayValue = formattedDocument || normalizedValue || "—";
   return (
     <button
       type="button"

--- a/frontend/src/features/certificados/CertificadoCard.jsx
+++ b/frontend/src/features/certificados/CertificadoCard.jsx
@@ -76,6 +76,12 @@ export default function CertificadoCard({ certificado }) {
   const validoAte = extractDateLabel(certificado?.validoAte ?? "");
   const senha = certificado?.senha ?? "";
   const situacao = certificado?.situacao ?? "";
+  const cpfCnpj =
+    certificado?.cnpj ??
+    certificado?.cpf ??
+    certificado?.cpfCnpj ??
+    certificado?.documento ??
+    certificado?.document;
 
   const diasRestantes = useMemo(() => {
     const target = parseDateValue(certificado?.validoAte ?? "");
@@ -102,6 +108,7 @@ export default function CertificadoCard({ certificado }) {
         </div>
       </CardHeader>
       <CardContent className="space-y-3 text-sm text-slate-600">
+        <CopyableIdentifier label="CPF/CNPJ" value={cpfCnpj} />
         <CopyableIdentifier label="Senha" value={senha} />
         <div>
           <div className="text-xs uppercase tracking-wide text-slate-500">Prazo para vencimento</div>

--- a/frontend/src/features/certificados/CertificadosScreen.jsx
+++ b/frontend/src/features/certificados/CertificadosScreen.jsx
@@ -33,7 +33,13 @@ const extractDate = (value) => {
   return value.trim();
 };
 
-const SITUACAO_OPTIONS = ["Todos", "Válido", "Vencendo em breve", "Vencido"];
+const SITUACAO_OPTIONS = [
+  "Todos",
+  "VÁLIDO",
+  "VENCE DENTRO DE 7 DIAS",
+  "VENCE DENTRO DE 30 DIAS",
+  "VENCIDO",
+];
 
 const getDateTimestamp = (value) => {
   const date = extractDate(value);
@@ -102,7 +108,12 @@ export default function CertificadosScreen({ certificados, agendamentos, soAlert
       if (situacao !== "Todos" && categoria !== situacao) {
         return false;
       }
-      if (soAlertas && !["Vencido", "Vencendo em breve"].includes(categoria)) {
+      if (
+        soAlertas &&
+        !["VENCIDO", "VENCE DENTRO DE 7 DIAS", "VENCE DENTRO DE 30 DIAS"].includes(
+          categoria,
+        )
+      ) {
         return false;
       }
       if (query === "") {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -450,13 +450,17 @@ export const normalizeCertificadoFromApi = (item) => {
 
     const situacaoKey = getStatusKey(normalized.situacao);
     if (diasRestantes < 0) {
-      normalized.situacao = "Vencido";
+      normalized.situacao = "VENCIDO";
     } else if (diasRestantes <= 7) {
       if (!situacaoKey || situacaoKey.includes("venc") || situacaoKey.includes("valido")) {
-        normalized.situacao = "Vencendo em breve";
+        normalized.situacao = "VENCE DENTRO DE 7 DIAS";
+      }
+    } else if (diasRestantes <= 30) {
+      if (!situacaoKey || situacaoKey.includes("venc") || situacaoKey.includes("valido")) {
+        normalized.situacao = "VENCE DENTRO DE 30 DIAS";
       }
     } else if (!situacaoKey) {
-      normalized.situacao = "Válido";
+      normalized.situacao = "VÁLIDO";
     }
   }
 

--- a/frontend/src/lib/certificados.js
+++ b/frontend/src/lib/certificados.js
@@ -98,13 +98,22 @@ export const categorizeCertificadoSituacao = (situacao) => {
     return "Outros";
   }
   if (key.includes("vencid")) {
-    return "Vencido";
+    return "VENCIDO";
   }
-  if (key.includes("vencend") || key.includes("vence")) {
-    return "Vencendo em breve";
+  if (key.includes("30") || key.includes("trint")) {
+    return "VENCE DENTRO DE 30 DIAS";
+  }
+  if (
+    key.includes("7") ||
+    key.includes("sete") ||
+    key.includes("breve") ||
+    key.includes("vencend") ||
+    key.includes("vence")
+  ) {
+    return "VENCE DENTRO DE 7 DIAS";
   }
   if (key.includes("valido") || key.includes("vigent") || key.includes("ativo")) {
-    return "Válido";
+    return "VÁLIDO";
   }
   return "Outros";
 };
@@ -118,6 +127,8 @@ export const isCertificadoSituacaoAlert = (situacao) => {
     return true;
   }
   const categoria = categorizeCertificadoSituacao(situacao);
-  return categoria === "Vencido" || categoria === "Vencendo em breve";
+  return ["VENCIDO", "VENCE DENTRO DE 7 DIAS", "VENCE DENTRO DE 30 DIAS"].includes(
+    categoria,
+  );
 };
 

--- a/frontend/src/lib/text.js
+++ b/frontend/src/lib/text.js
@@ -28,6 +28,25 @@ export const formatCnpj = (value) => {
   return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8, 12)}-${digits.slice(12, 14)}`;
 };
 
+export const formatCpf = (value) => {
+  const digits = normalizeDocumentDigits(value);
+  if (!digits) return undefined;
+  if (digits.length !== 11) return digits;
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9, 11)}`;
+};
+
+export const formatCpfCnpj = (value) => {
+  const digits = normalizeDocumentDigits(value);
+  if (!digits) return undefined;
+  if (digits.length === 11) {
+    return formatCpf(digits);
+  }
+  if (digits.length === 14) {
+    return formatCnpj(digits);
+  }
+  return digits;
+};
+
 export const buildNormalizedSearchKey = (value) => {
   const normalized = removeDiacritics(normalizeTextLower(value));
   const sanitized = normalized.replace(NON_ALPHANUMERIC_REGEX, "");


### PR DESCRIPTION
## Summary
- adiciona utilitário para formatar CPF/CNPJ com máscara e reutiliza no CopyableIdentifier
- exibe o CPF/CNPJ de cada certificado na lista de cartões usando o identificador copiável
- atualiza os rótulos e a normalização de status dos certificados para VENCIDO, VENCE DENTRO DE 7 DIAS, VENCE DENTRO DE 30 DIAS e VÁLIDO

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69384decc504832695dec22a44fb7368)