### PR TITLE
Centralize badge content alignment

### DIFF
--- a/frontend/src/components/InlineBadge.jsx
+++ b/frontend/src/components/InlineBadge.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 function InlineBadge({ children, className = "", variant = "solid", ...props }) {
   const base =
-    "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium";
+    "inline-flex items-center justify-center gap-1 rounded-full border px-2 py-0.5 text-center text-xs font-medium";
   
   const variants = {
     solid: "bg-slate-100 border-transparent text-slate-700",

--- a/frontend/src/components/ui/dropdown-menu.jsx
+++ b/frontend/src/components/ui/dropdown-menu.jsx
@@ -156,7 +156,7 @@ export function MiniBadge({ children, className }) {
   return (
     <span
       className={cn(
-        "ml-2 inline-flex items-center rounded-md bg-slate-100 px-1.5 py-0 text-[10px] font-medium text-slate-600",
+        "ml-2 inline-flex items-center justify-center rounded-md bg-slate-100 px-1.5 py-0 text-center text-[10px] font-medium text-slate-600",
         className
       )}
     >


### PR DESCRIPTION
## Summary
- center-align content inside InlineBadge to align all badges consistently
- center-align MiniBadge text within dropdown menus

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938575d96b48326a467e6c7f10e423b)