### PR TITLE
Handle definitive licenses with dates and show raw status details

### DIFF
--- a/backend/app/services/licencas_ingest.py
+++ b/backend/app/services/licencas_ingest.py
@@ -228,7 +228,15 @@ def _interpretar_documentos(documentos: Iterable[DocumentoArquivo]) -> list[Inte
     resultados: list[InterpretedLicenca] = []
 
     for categoria, docs in agrupado.items():
-        definitivo = next((d for d in docs if d.tipo_documento.lower() == "definitivo"), None)
+        # Trata "Definitivo" como sem vencimento apenas quando não houver data
+        definitivo = next(
+            (
+                d
+                for d in docs
+                if d.tipo_documento.lower() == "definitivo" and d.validade is None
+            ),
+            None,
+        )
         if definitivo:
             resultados.append(
                 InterpretedLicenca(

--- a/frontend/src/features/licencas/LicencasScreen.jsx
+++ b/frontend/src/features/licencas/LicencasScreen.jsx
@@ -316,11 +316,18 @@ export default function LicencasScreen({ licencas, filteredLicencas, modoFoco })
                           <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
                             {display}
                           </p>
-                          <div className="flex items-center gap-2 flex-wrap">
-                            <StatusBadge status={chosen?.status} />
-                            {chosen && (
-                              <span className="text-[11px] text-slate-600">
-                                Vencimento: {renderValidade(chosen)}
+                          <div className="flex flex-col gap-0.5">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <StatusBadge status={chosen?.status} />
+                              {chosen && (
+                                <span className="text-[11px] text-slate-600">
+                                  Vencimento: {renderValidade(chosen)}
+                                </span>
+                              )}
+                            </div>
+                            {chosen?.status_bruto && (
+                              <span className="text-[11px] text-slate-500">
+                                {chosen.status_bruto}
                               </span>
                             )}
                           </div>


### PR DESCRIPTION
## Summary
- treat definitive documents as no-expiry only when they lack a validity date so dated entries are processed with their expirations
- surface the raw status text on the company view cards so definitive/condicionado/provisório labels are visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938611ee0bc8326be3c8c6f5183764f)