### PR TITLE
Add obs/status_bruto to licencas API responses

### DIFF
--- a/backend/app/api/v1/endpoints/licencas.py
+++ b/backend/app/api/v1/endpoints/licencas.py
@@ -29,7 +29,26 @@ ALLOWED_SORTS: Dict[str, str] = {
 
 
 def _fetch_licenca_view(db: Session, licenca_id: int) -> LicencaView:
-    query = text("SELECT * FROM v_licencas_api WHERE licenca_id = :licenca_id")
+    query = text(
+        """
+        SELECT
+            licenca_id,
+            empresa_id,
+            org_id,
+            empresa,
+            cnpj,
+            municipio,
+            tipo,
+            status,
+            validade,
+            validade_br,
+            dias_para_vencer,
+            obs,
+            obs AS status_bruto
+        FROM v_licencas_api
+        WHERE licenca_id = :licenca_id
+        """
+    )
     row = db.execute(query, {"licenca_id": licenca_id}).mappings().first()
     if not row:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Licença não encontrada")
@@ -70,7 +89,23 @@ def listar_licencas(
         filters.append("dias_para_vencer IS NOT NULL AND dias_para_vencer <= :vencer_em_dias")
 
     where_clause = build_where_clause(filters)
-    base_query = f"SELECT * FROM v_licencas_api{where_clause}"
+    base_query = f"""
+        SELECT
+            licenca_id,
+            empresa_id,
+            org_id,
+            empresa,
+            cnpj,
+            municipio,
+            tipo,
+            status,
+            validade,
+            validade_br,
+            dias_para_vencer,
+            obs,
+            obs AS status_bruto
+        FROM v_licencas_api{where_clause}
+    """
     sort_column, direction = resolve_sort(sort, ALLOWED_SORTS, "validade")
     data = paginate_query(db, base_query, params, sort_column, direction, page, size)
     return LicencaListResponse(**data)

--- a/backend/app/schemas/licencas.py
+++ b/backend/app/schemas/licencas.py
@@ -21,6 +21,8 @@ class LicencaView(BaseModel):
     validade: Optional[date] = None
     validade_br: Optional[str] = None
     dias_para_vencer: Optional[int] = None
+    obs: Optional[str] = None
+    status_bruto: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
## Summary
- include obs/status_bruto columns in licenças listing and detail queries
- expose new fields on the LicencaView response schema

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69387b229e8c8326a02ac89fac63af4f)