### PR TITLE
Add status_detalhe display for licencas

### DIFF
--- a/backend/app/api/v1/endpoints/licencas.py
+++ b/backend/app/api/v1/endpoints/licencas.py
@@ -29,7 +29,26 @@ ALLOWED_SORTS: Dict[str, str] = {
 
 
 def _fetch_licenca_view(db: Session, licenca_id: int) -> LicencaView:
-    query = text("SELECT * FROM v_licencas_api WHERE licenca_id = :licenca_id")
+    query = text(
+        """
+        SELECT
+            licenca_id,
+            empresa_id,
+            org_id,
+            empresa,
+            cnpj,
+            municipio,
+            tipo,
+            status,
+            validade,
+            validade_br,
+            dias_para_vencer,
+            obs,
+            obs AS status_bruto
+        FROM v_licencas_api
+        WHERE licenca_id = :licenca_id
+        """
+    )
     row = db.execute(query, {"licenca_id": licenca_id}).mappings().first()
     if not row:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Licença não encontrada")
@@ -70,7 +89,23 @@ def listar_licencas(
         filters.append("dias_para_vencer IS NOT NULL AND dias_para_vencer <= :vencer_em_dias")
 
     where_clause = build_where_clause(filters)
-    base_query = f"SELECT * FROM v_licencas_api{where_clause}"
+    base_query = f"""
+        SELECT
+            licenca_id,
+            empresa_id,
+            org_id,
+            empresa,
+            cnpj,
+            municipio,
+            tipo,
+            status,
+            validade,
+            validade_br,
+            dias_para_vencer,
+            obs,
+            obs AS status_bruto
+        FROM v_licencas_api{where_clause}
+    """
     sort_column, direction = resolve_sort(sort, ALLOWED_SORTS, "validade")
     data = paginate_query(db, base_query, params, sort_column, direction, page, size)
     return LicencaListResponse(**data)

--- a/backend/app/schemas/licencas.py
+++ b/backend/app/schemas/licencas.py
@@ -21,6 +21,8 @@ class LicencaView(BaseModel):
     validade: Optional[date] = None
     validade_br: Optional[str] = None
     dias_para_vencer: Optional[int] = None
+    obs: Optional[str] = None
+    status_bruto: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/frontend/src/features/licencas/LicencasScreen.jsx
+++ b/frontend/src/features/licencas/LicencasScreen.jsx
@@ -318,7 +318,14 @@ export default function LicencasScreen({ licencas, filteredLicencas, modoFoco })
                           </p>
                           <div className="flex flex-col gap-0.5">
                             <div className="flex items-center gap-2 flex-wrap">
-                              <StatusBadge status={chosen?.status} />
+                              <div className="flex items-center gap-1">
+                                <StatusBadge status={chosen?.status} />
+                                {chosen?.status_detalhe && (
+                                  <span className="text-[10px] uppercase tracking-wide text-slate-600">
+                                    ({chosen.status_detalhe})
+                                  </span>
+                                )}
+                              </div>
                               {chosen && (
                                 <span className="text-[11px] text-slate-600">
                                   Vencimento: {renderValidade(chosen)}
@@ -463,7 +470,7 @@ export default function LicencasScreen({ licencas, filteredLicencas, modoFoco })
                                 </TableCell>
                                 <TableCell>{renderValidade(lic)}</TableCell>
                                 <TableCell className="text-xs text-slate-600">
-                                  {lic.status_bruto || lic.obs || "—"}
+                                  {lic.status_detalhe || "—"}
                                 </TableCell>
                               </TableRow>
                             ))}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -349,6 +349,31 @@ export const normalizeLicencaFromApi = (item) => {
   const statusBruto =
     normalized.status_bruto ?? normalized.statusBruto ?? normalized.obs ?? normalized.observacao;
 
+  // ----------------------------------------------------------
+  // Extrai um "detalhe" amigável do status:
+  //   - "Definitivo"
+  //   - "Condicionado"
+  //   - "Provisório"
+  // Usado só para UI: badge ao lado do status.
+  // ----------------------------------------------------------
+  if (typeof statusBruto === "string") {
+    const lower = statusBruto.toLowerCase();
+    let detalhe = undefined;
+
+    if (lower.includes("condicionad")) {
+      detalhe = "Condicionado";
+    } else if (lower.includes("provis")) {
+      // cobre "provisório" / "provisorio"
+      detalhe = "Provisório";
+    } else if (lower.includes("definitiv")) {
+      detalhe = "Definitivo";
+    }
+
+    if (detalhe) {
+      normalized.status_detalhe = detalhe;
+    }
+  }
+
   const validade =
     normalized.validade ??
     normalized.data_validade ??


### PR DESCRIPTION
## Summary
- extract a cleaned status_detalhe from raw license status text during API normalization
- show the status_detalhe badge alongside statuses and in the per-type observation column on licenças screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69387b229e8c8326a02ac89fac63af4f)