### PR TITLE
Atualiza layout base e paleta

### DIFF
--- a/frontend/public/logo-econtrole-branca.svg
+++ b/frontend/public/logo-econtrole-branca.svg
@@ -1,0 +1,10 @@
+<svg width="160" height="40" viewBox="0 0 160 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="40" rx="10" fill="url(#paint0_linear)" fill-opacity="0.18"/>
+  <path d="M22 10h4l4 8 4-8h4l-6 12v8h-4v-8L22 10Zm38 6c2.5 0 4.5 2 4.5 4.5v5c0 2.5-2 4.5-4.5 4.5h-9V10h4v6h5Zm0 4h-5v6h5v-6Zm22-10v18h-4v-1.8c-.8 1.2-2.3 2.1-4.2 2.1-3.4 0-6.2-2.8-6.2-6.3v-1.7c0-3.5 2.8-6.3 6.2-6.3 1.9 0 3.4.9 4.2 2.1V10h4Zm-7.1 8.5c-1.4 0-2.7 1.1-2.7 2.7v1.5c0 1.6 1.3 2.7 2.7 2.7 1.5 0 2.8-1.1 2.8-2.7v-1.5c0-1.6-1.3-2.7-2.8-2.7ZM104 20c0-5.5 4.4-10 10-10s10 4.5 10 10-4.4 10-10 10-10-4.5-10-10Zm15.7 0c0-3.2-2.5-5.7-5.7-5.7-3.1 0-5.7 2.5-5.7 5.7 0 3.2 2.6 5.7 5.7 5.7 3.2 0 5.7-2.5 5.7-5.7ZM134 10h4v9.2l7-9.2h5l-7.5 9.6 8.2 10.4H145l-7-9.1V30h-4V10Z" fill="white"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="0" y1="0" x2="160" y2="40" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF" stop-opacity="0.6"/>
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.2"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,12 +21,7 @@ import {
   getProcessBaseType,
   normalizeProcessType,
 } from "@/lib/process";
-import {
-  MUNICIPIO_ALL,
-  TAB_BACKGROUNDS,
-  TAB_SHORTCUTS,
-  TAXA_TYPE_KEYS,
-} from "@/lib/constants";
+import { MUNICIPIO_ALL, TAB_SHORTCUTS, TAXA_TYPE_KEYS } from "@/lib/constants";
 import { fetchJson } from "@/lib/api";
 import { isAlertStatus, isProcessStatusInactive } from "@/lib/status";
 import {
@@ -578,7 +573,7 @@ function AppContent() {
   );
 
   return (
-    <>
+    <div className="min-h-screen bg-surface-body text-slate-900">
       <HeaderMenuPro
         tab={tab}
         onTabChange={setTab}
@@ -595,113 +590,111 @@ function AppContent() {
         modoFoco={modoFoco}
         onModoFocoChange={setModoFoco}
       />
-      <div className={`p-4 md:p-6 max-w-[1400px] mx-auto rounded-2xl ${TAB_BACKGROUNDS[tab]}`}>
-        {loading ? (
-          <div className="p-6 text-center">Carregando dados...</div>
-        ) : (
-          <Tabs value={tab} onValueChange={setTab}>
-            <TabsContent value="painel">
-              <PainelScreen
-                query={query}
-                municipio={municipio}
-                soAlertas={somenteAlertas}
-                kpis={kpis}
-                empresas={empresasComCertificados}
-                licencas={licencas}
-                taxas={taxas}
-                certificados={certificados}
-                filteredLicencas={filteredLicencas}
-                processosNormalizados={processosNormalizados}
-                filterEmpresas={filterEmpresas}
-                companyHasAlert={companyHasAlert}
-                licencasByEmpresa={licencasByEmpresa}
-                extractEmpresaId={extractEmpresaId}
-              />
-            </TabsContent>
+      <main className="pt-20 px-4 pb-8 lg:px-8">
+        <div className="mx-auto max-w-7xl space-y-6">
+          {loading ? (
+            <div className="p-6 text-center">Carregando dados...</div>
+          ) : (
+            <Tabs value={tab} onValueChange={setTab}>
+              <TabsContent value="painel">
+                <PainelScreen
+                  query={query}
+                  municipio={municipio}
+                  soAlertas={somenteAlertas}
+                  kpis={kpis}
+                  empresas={empresasComCertificados}
+                  licencas={licencas}
+                  taxas={taxas}
+                  certificados={certificados}
+                  filteredLicencas={filteredLicencas}
+                  processosNormalizados={processosNormalizados}
+                  filterEmpresas={filterEmpresas}
+                  companyHasAlert={companyHasAlert}
+                  licencasByEmpresa={licencasByEmpresa}
+                  extractEmpresaId={extractEmpresaId}
+                />
+              </TabsContent>
 
-            <TabsContent value="empresas" className="mt-4 space-y-3">
-              <EmpresasScreen
-                filteredEmpresas={filteredEmpresas}
-                empresas={empresasComCertificados}
-                soAlertas={somenteAlertas}
-                extractEmpresaId={extractEmpresaId}
-                licencasByEmpresa={licencasByEmpresa}
-                taxasByEmpresa={taxasByEmpresa}
-                processosByEmpresa={processosByEmpresa}
-                handleCopy={handleCopy}
-                enqueueToast={enqueueToast}
-              />
-            </TabsContent>
+              <TabsContent value="empresas" className="mt-4 space-y-3">
+                <EmpresasScreen
+                  filteredEmpresas={filteredEmpresas}
+                  empresas={empresasComCertificados}
+                  soAlertas={somenteAlertas}
+                  extractEmpresaId={extractEmpresaId}
+                  licencasByEmpresa={licencasByEmpresa}
+                  taxasByEmpresa={taxasByEmpresa}
+                  processosByEmpresa={processosByEmpresa}
+                  handleCopy={handleCopy}
+                  enqueueToast={enqueueToast}
+                />
+              </TabsContent>
 
-            <TabsContent value="licencas" className="mt-4">
-              <LicencasScreen licencas={licencas} filteredLicencas={filteredLicencas} modoFoco={modoFoco} />
-            </TabsContent>
+              <TabsContent value="licencas" className="mt-4">
+                <LicencasScreen licencas={licencas} filteredLicencas={filteredLicencas} modoFoco={modoFoco} />
+              </TabsContent>
 
-            <TabsContent value="taxas" className="mt-4">
-              <TaxasScreen
-                taxas={taxas}
-                modoFoco={modoFoco}
-                matchesMunicipioFilter={matchesMunicipioFilter}
-                matchesQuery={matchesQuery}
-              />
-            </TabsContent>
+              <TabsContent value="taxas" className="mt-4">
+                <TaxasScreen
+                  taxas={taxas}
+                  modoFoco={modoFoco}
+                  matchesMunicipioFilter={matchesMunicipioFilter}
+                  matchesQuery={matchesQuery}
+                />
+              </TabsContent>
 
-            <TabsContent value="processos">
-              <ProcessosScreen
-                processosNormalizados={processosNormalizados}
-                modoFoco={modoFoco}
-                matchesMunicipioFilter={matchesMunicipioFilter}
-                matchesQuery={matchesQuery}
-                handleCopy={handleCopy}
-              />
-            </TabsContent>
+              <TabsContent value="processos">
+                <ProcessosScreen
+                  processosNormalizados={processosNormalizados}
+                  modoFoco={modoFoco}
+                  matchesMunicipioFilter={matchesMunicipioFilter}
+                  matchesQuery={matchesQuery}
+                  handleCopy={handleCopy}
+                />
+              </TabsContent>
 
-            <TabsContent value="uteis">
-              <UteisScreen
-                query={query}
-                municipio={municipio}
-                soAlertas={somenteAlertas}
-                contatos={contatos}
-                modelos={modelos}
-                matchesMunicipioFilter={matchesMunicipioFilter}
-                handleCopy={handleCopy}
-              />
-            </TabsContent>
+              <TabsContent value="uteis">
+                <UteisScreen
+                  query={query}
+                  municipio={municipio}
+                  soAlertas={somenteAlertas}
+                  contatos={contatos}
+                  modelos={modelos}
+                  matchesMunicipioFilter={matchesMunicipioFilter}
+                  handleCopy={handleCopy}
+                />
+              </TabsContent>
 
-            <TabsContent value="certificados" className="mt-4">
-              <CertificadosScreen
-                certificados={certificados}
-                agendamentos={agendamentos}
-                soAlertas={somenteAlertas}
-              />
-            </TabsContent>
-          </Tabs>
-        )}
+              <TabsContent value="certificados" className="mt-4">
+                <CertificadosScreen certificados={certificados} agendamentos={agendamentos} soAlertas={somenteAlertas} />
+              </TabsContent>
+            </Tabs>
+          )}
+        </div>
+      </main>
 
-        <div className="pointer-events-none fixed inset-x-0 bottom-4 flex justify-center sm:justify-end px-4">
-          <div className="w-full sm:max-w-sm space-y-2">
-            {toasts.map((toast) => (
-              <div
-                key={toast.id}
-                className="pointer-events-auto rounded-xl border border-slate-200 bg-white shadow-lg px-4 py-3 flex items-start gap-3"
-              >
-                <div className="mt-0.5">
-                  <Sparkles className="h-4 w-4 text-amber-500" />
-                </div>
-                <div className="text-sm text-slate-700 flex-1">{toast.message}</div>
-                <button
-                  type="button"
-                  className="text-slate-400 hover:text-slate-600"
-                  onClick={() => dismissToast(toast.id)}
-                >
-                  <X className="h-4 w-4" />
-                </button>
+      <div className="pointer-events-none fixed inset-x-0 bottom-4 flex justify-center sm:justify-end px-4">
+        <div className="w-full sm:max-w-sm space-y-2">
+          {toasts.map((toast) => (
+            <div
+              key={toast.id}
+              className="pointer-events-auto rounded-xl border border-slate-200 bg-white shadow-lg px-4 py-3 flex items-start gap-3"
+            >
+              <div className="mt-0.5">
+                <Sparkles className="h-4 w-4 text-amber-500" />
               </div>
-            ))}
-          </div>
+              <div className="text-sm text-slate-700 flex-1">{toast.message}</div>
+              <button
+                type="button"
+                className="text-slate-400 hover:text-slate-600"
+                onClick={() => dismissToast(toast.id)}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
         </div>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/components/Chip.jsx
+++ b/frontend/src/components/Chip.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const baseChip = "inline-flex items-center gap-1 border text-xs font-medium rounded-lg";
+
+const chipSizeClasses = {
+  sm: "px-2 py-0.5",
+  md: "px-2.5 py-1",
+};
+
+const chipVariantClasses = {
+  neutral: "bg-slate-100 text-slate-600 border-slate-200",
+  success: "bg-green-50 text-green-700 border-green-100",
+  danger: "bg-red-50 text-red-700 border-red-100",
+  warning: "bg-amber-50 text-amber-700 border-amber-100",
+  outline: "bg-transparent text-slate-600 border-slate-300",
+};
+
+export function Chip({ children, variant = "neutral", size = "sm", className = "" }) {
+  return (
+    <span className={[baseChip, chipSizeClasses[size], chipVariantClasses[variant], className].join(" ")}>
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/HeaderMenuPro.jsx
+++ b/frontend/src/components/HeaderMenuPro.jsx
@@ -38,20 +38,16 @@ function Brand() {
   return (
     <div className="flex items-center gap-2">
       {failed ? (
-        <Crown aria-label="eControle" className="h-8 w-8 text-indigo-600" />
+        <Crown aria-label="eControle" className="h-8 w-8 text-white" />
       ) : (
         <img
-          src="/favicons/crown/favicon-coroa-gradient.svg"
+          src="/logo-econtrole-branca.svg"
           alt="eControle"
-          className="h-8 w-8"
+          className="h-8 w-auto"
           onError={() => setFailed(true)}
         />
       )}
-      <div className="text-xl md:text-2xl font-extrabold tracking-tight">
-        <span className="bg-gradient-to-r from-indigo-600 via-sky-500 to-emerald-500 bg-clip-text text-transparent">
-          eControle
-        </span>
-      </div>
+      <div className="text-xl md:text-2xl font-extrabold tracking-tight text-white">eControle</div>
     </div>
   );
 }
@@ -101,8 +97,10 @@ export default function HeaderMenuPro({
   const handleNew = (type) => console.log(`[Novo] criar ${type}`);
 
   return (
-    <header className="sticky top-0 z-40 w-full border-b bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/60">
-      <div className="max-w-[1400px] mx-auto px-4">
+    <header
+      className="fixed inset-x-0 top-0 z-40 border-b border-white/10 bg-brand-900/85 backdrop-blur-xl text-slate-50"
+    >
+      <div className="mx-auto max-w-7xl px-4 lg:px-6">
         {/* Linha 1: marca + busca + ações + perfil */}
         <div className="h-16 flex items-center gap-3">
           <Brand />

--- a/frontend/src/components/InlineBadge.jsx
+++ b/frontend/src/components/InlineBadge.jsx
@@ -1,39 +1,19 @@
 import React from "react";
+import { Chip } from "@/components/Chip";
 
 function InlineBadge({ children, className = "", variant = "solid", ...props }) {
-  const base =
-    "inline-flex items-center justify-center gap-1 rounded-full border px-2 py-0.5 text-center text-xs font-medium";
-  
-  const variants = {
-    solid: "bg-slate-100 border-transparent text-slate-700",
-    outline: "bg-white border-slate-200 text-slate-600",
-    plain: "bg-transparent border-transparent text-slate-500",
+  const variantMap = {
+    solid: "neutral",
+    outline: "outline",
+    plain: "outline",
   };
 
-  const variantClasses = variants[variant] || variants.solid;
+  const resolvedVariant = variantMap[variant] || "neutral";
 
-  const hasCustomBg = /\bbg-[\w/-]+/.test(className);
-  const hasCustomBorder = /\bborder-[\w/-]+/.test(className);
-  const hasCustomText = /\btext-[\w/-]+/.test(className);
-
-  const pickVariantPart = (pattern) =>
-    (variantClasses.match(pattern) || []).join(" ");
-
-  const composedVariantClasses =
-    hasCustomBg || hasCustomBorder || hasCustomText
-      ? [
-          hasCustomBg ? "" : pickVariantPart(/\bbg-[^\s]+/g),
-          hasCustomBorder ? "" : pickVariantPart(/\bborder-[^\s]+/g),
-          hasCustomText ? "" : pickVariantPart(/\btext-[^\s]+/g),
-        ]
-          .filter(Boolean)
-          .join(" ")
-      : variantClasses;
-  
   return (
-    <span className={`${base} ${composedVariantClasses} ${className}`} {...props}>
+    <Chip variant={resolvedVariant} className={className} {...props}>
       {children}
-    </span>
+    </Chip>
   );
 }
 

--- a/frontend/src/components/ui/card.jsx
+++ b/frontend/src/components/ui/card.jsx
@@ -2,7 +2,15 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 export function Card({ className, ...props }) {
-  return <div className={cn("rounded-2xl border bg-card text-card-foreground shadow-sm", className)} {...props} />;
+  return (
+    <div
+      className={cn(
+        "bg-surface-card rounded-2xl shadow-soft border border-slate-100",
+        className,
+      )}
+      {...props}
+    />
+  );
 }
 
 export function CardHeader({ className, ...props }) {
@@ -14,7 +22,7 @@ export function CardTitle({ className, ...props }) {
 }
 
 export function CardContent({ className, ...props }) {
-  return <div className={cn("p-4 pt-0", className)} {...props} />;
+  return <div className={cn("p-4 pt-0 lg:p-5 lg:pt-0", className)} {...props} />;
 }
 
 export function CardFooter({ className, ...props }) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,5 +37,5 @@
 
 @layer base {
   * { @apply border-border; }
-  body { @apply bg-background text-foreground; }
+  body { @apply bg-surface-body text-slate-900; }
 }

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -1,16 +1,6 @@
 export const MUNICIPIO_ALL = "__ALL__";
 export const PROCESS_ALL = "__PROCESS_ALL__";
 
-export const TAB_BACKGROUNDS = {
-  painel: "bg-sky-50",
-  empresas: "bg-indigo-50",
-  certificados: "bg-teal-50",
-  licencas: "bg-emerald-50",
-  taxas: "bg-amber-50",
-  processos: "bg-violet-50",
-  uteis: "bg-slate-50",
-};
-
 export const TAB_SHORTCUTS = {
   1: "painel",
   2: "empresas",

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,11 +1,12 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+const config = {
   darkMode: ["class"],
   content: [
-    './pages/**/*.{js,jsx}',
-    './components/**/*.{js,jsx}',
-    './app/**/*.{js,jsx}',
-    './src/**/*.{js,jsx}',
+    "./index.html",
+    "./pages/**/*.{js,jsx}",
+    "./components/**/*.{js,jsx}",
+    "./app/**/*.{js,jsx}",
+    "./src/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
     extend: {
@@ -43,13 +44,36 @@ export default {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        brand: {
+          900: "#22489c",
+          700: "#2857b8",
+          600: "#2f66d4",
+          100: "#e3ebff",
+        },
+        surface: {
+          body: "#F5F7FB",
+          card: "#FFFFFF",
+        },
+        status: {
+          success: "#16A34A",
+          warning: "#F97316",
+          danger: "#EF4444",
+          neutral: "#6B7280",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+        xl: "0.75rem",
+        "2xl": "1rem",
+      },
+      boxShadow: {
+        soft: "0 18px 45px rgba(15, 23, 42, 0.06)",
       },
     },
   },
   plugins: [],
-}
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- adiciona tokens de marca, superfícies e estados no Tailwind e cria componente Chip para padronizar pílulas
- aplica novo layout base com fundo claro, header vidro azul e padding para acomodar topo fixo
- atualiza cards para sombra suave e integra logotipo branco de placeholder no cabeçalho

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693964156e8c83269c0401663f979063)