### PR TITLE
Refine layout, theme tokens, and chip system

### DIFF
--- a/frontend/public/logo-econtrole-branca.svg
+++ b/frontend/public/logo-econtrole-branca.svg
@@ -1,0 +1,12 @@
+<svg width="160" height="40" viewBox="0 0 160 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="40" rx="8" fill="url(#paint0)"/>
+  <path d="M24 10L14 20L24 30" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M36 10L46 20L36 30" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="55" y="25" fill="white" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">eControle</text>
+  <defs>
+    <linearGradient id="paint0" x1="0" y1="0" x2="160" y2="0" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#22489c"/>
+      <stop offset="1" stop-color="#2f66d4"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,7 +23,6 @@ import {
 } from "@/lib/process";
 import {
   MUNICIPIO_ALL,
-  TAB_BACKGROUNDS,
   TAB_SHORTCUTS,
   TAXA_TYPE_KEYS,
 } from "@/lib/constants";
@@ -588,7 +587,7 @@ function AppContent() {
   );
 
   return (
-    <>
+    <div className="min-h-screen bg-surface-body text-slate-900">
       <HeaderMenuPro
         tab={tab}
         onTabChange={setTab}
@@ -605,113 +604,115 @@ function AppContent() {
         modoFoco={modoFoco}
         onModoFocoChange={setModoFoco}
       />
-      <div className={`p-4 md:p-6 max-w-[1400px] mx-auto rounded-2xl ${TAB_BACKGROUNDS[tab]}`}>
-        {loading ? (
-          <div className="p-6 text-center">Carregando dados...</div>
-        ) : (
-          <Tabs value={tab} onValueChange={setTab}>
-            <TabsContent value="painel">
-              <PainelScreen
-                query={query}
-                municipio={municipio}
-                soAlertas={somenteAlertas}
-                kpis={kpis}
-                empresas={empresasComCertificados}
-                licencas={licencas}
-                taxas={taxas}
-                certificados={certificados}
-                filteredLicencas={filteredLicencas}
-                processosNormalizados={processosNormalizados}
-                filterEmpresas={filterEmpresas}
-                companyHasAlert={companyHasAlert}
-                licencasByEmpresa={licencasByEmpresa}
-                extractEmpresaId={extractEmpresaId}
-              />
-            </TabsContent>
+      <main className="pt-20 px-4 pb-8 lg:px-8">
+        <div className="mx-auto max-w-7xl space-y-4">
+          {loading ? (
+            <div className="p-6 text-center">Carregando dados...</div>
+          ) : (
+            <Tabs value={tab} onValueChange={setTab}>
+              <TabsContent value="painel">
+                <PainelScreen
+                  query={query}
+                  municipio={municipio}
+                  soAlertas={somenteAlertas}
+                  kpis={kpis}
+                  empresas={empresasComCertificados}
+                  licencas={licencas}
+                  taxas={taxas}
+                  certificados={certificados}
+                  filteredLicencas={filteredLicencas}
+                  processosNormalizados={processosNormalizados}
+                  filterEmpresas={filterEmpresas}
+                  companyHasAlert={companyHasAlert}
+                  licencasByEmpresa={licencasByEmpresa}
+                  extractEmpresaId={extractEmpresaId}
+                />
+              </TabsContent>
 
-            <TabsContent value="empresas" className="mt-4 space-y-3">
-              <EmpresasScreen
-                filteredEmpresas={filteredEmpresas}
-                empresas={empresasComCertificados}
-                soAlertas={somenteAlertas}
-                extractEmpresaId={extractEmpresaId}
-                licencasByEmpresa={licencasByEmpresa}
-                taxasByEmpresa={taxasByEmpresa}
-                processosByEmpresa={processosByEmpresa}
-                handleCopy={handleCopy}
-                enqueueToast={enqueueToast}
-              />
-            </TabsContent>
+              <TabsContent value="empresas" className="mt-4 space-y-3">
+                <EmpresasScreen
+                  filteredEmpresas={filteredEmpresas}
+                  empresas={empresasComCertificados}
+                  soAlertas={somenteAlertas}
+                  extractEmpresaId={extractEmpresaId}
+                  licencasByEmpresa={licencasByEmpresa}
+                  taxasByEmpresa={taxasByEmpresa}
+                  processosByEmpresa={processosByEmpresa}
+                  handleCopy={handleCopy}
+                  enqueueToast={enqueueToast}
+                />
+              </TabsContent>
 
-            <TabsContent value="licencas" className="mt-4">
-              <LicencasScreen licencas={licencas} filteredLicencas={filteredLicencas} modoFoco={modoFoco} />
-            </TabsContent>
+              <TabsContent value="licencas" className="mt-4">
+                <LicencasScreen licencas={licencas} filteredLicencas={filteredLicencas} modoFoco={modoFoco} />
+              </TabsContent>
 
-            <TabsContent value="taxas" className="mt-4">
-              <TaxasScreen
-                taxas={taxas}
-                modoFoco={modoFoco}
-                matchesMunicipioFilter={matchesMunicipioFilter}
-                matchesQuery={matchesQuery}
-              />
-            </TabsContent>
+              <TabsContent value="taxas" className="mt-4">
+                <TaxasScreen
+                  taxas={taxas}
+                  modoFoco={modoFoco}
+                  matchesMunicipioFilter={matchesMunicipioFilter}
+                  matchesQuery={matchesQuery}
+                />
+              </TabsContent>
 
-            <TabsContent value="processos">
-              <ProcessosScreen
-                processosNormalizados={processosNormalizados}
-                modoFoco={modoFoco}
-                matchesMunicipioFilter={matchesMunicipioFilter}
-                matchesQuery={matchesQuery}
-                handleCopy={handleCopy}
-              />
-            </TabsContent>
+              <TabsContent value="processos">
+                <ProcessosScreen
+                  processosNormalizados={processosNormalizados}
+                  modoFoco={modoFoco}
+                  matchesMunicipioFilter={matchesMunicipioFilter}
+                  matchesQuery={matchesQuery}
+                  handleCopy={handleCopy}
+                />
+              </TabsContent>
 
-            <TabsContent value="uteis">
-              <UteisScreen
-                query={query}
-                municipio={municipio}
-                soAlertas={somenteAlertas}
-                contatos={contatos}
-                modelos={modelos}
-                matchesMunicipioFilter={matchesMunicipioFilter}
-                handleCopy={handleCopy}
-              />
-            </TabsContent>
+              <TabsContent value="uteis">
+                <UteisScreen
+                  query={query}
+                  municipio={municipio}
+                  soAlertas={somenteAlertas}
+                  contatos={contatos}
+                  modelos={modelos}
+                  matchesMunicipioFilter={matchesMunicipioFilter}
+                  handleCopy={handleCopy}
+                />
+              </TabsContent>
 
-            <TabsContent value="certificados" className="mt-4">
-              <CertificadosScreen
-                certificados={certificados}
-                agendamentos={agendamentos}
-                soAlertas={somenteAlertas}
-              />
-            </TabsContent>
-          </Tabs>
-        )}
+              <TabsContent value="certificados" className="mt-4">
+                <CertificadosScreen
+                  certificados={certificados}
+                  agendamentos={agendamentos}
+                  soAlertas={somenteAlertas}
+                />
+              </TabsContent>
+            </Tabs>
+          )}
+        </div>
+      </main>
 
-        <div className="pointer-events-none fixed inset-x-0 bottom-4 flex justify-center sm:justify-end px-4">
-          <div className="w-full sm:max-w-sm space-y-2">
-            {toasts.map((toast) => (
-              <div
-                key={toast.id}
-                className="pointer-events-auto rounded-xl border border-slate-200 bg-white shadow-lg px-4 py-3 flex items-start gap-3"
-              >
-                <div className="mt-0.5">
-                  <Sparkles className="h-4 w-4 text-amber-500" />
-                </div>
-                <div className="text-sm text-slate-700 flex-1">{toast.message}</div>
-                <button
-                  type="button"
-                  className="text-slate-400 hover:text-slate-600"
-                  onClick={() => dismissToast(toast.id)}
-                >
-                  <X className="h-4 w-4" />
-                </button>
+      <div className="pointer-events-none fixed inset-x-0 bottom-4 flex justify-center sm:justify-end px-4">
+        <div className="w-full sm:max-w-sm space-y-2">
+          {toasts.map((toast) => (
+            <div
+              key={toast.id}
+              className="pointer-events-auto rounded-xl border border-slate-200 bg-white shadow-lg px-4 py-3 flex items-start gap-3"
+            >
+              <div className="mt-0.5">
+                <Sparkles className="h-4 w-4 text-amber-500" />
               </div>
-            ))}
-          </div>
+              <div className="text-sm text-slate-700 flex-1">{toast.message}</div>
+              <button
+                type="button"
+                className="text-slate-400 hover:text-slate-600"
+                onClick={() => dismissToast(toast.id)}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
         </div>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/components/Chip.jsx
+++ b/frontend/src/components/Chip.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+const baseChip = "inline-flex items-center gap-1 border text-xs font-medium rounded-lg";
+
+const chipSizeClasses = {
+  sm: "px-2 py-0.5",
+  md: "px-2.5 py-1",
+};
+
+const chipVariantClasses = {
+  neutral: "bg-slate-100 text-slate-600 border-slate-200",
+  success: "bg-green-50 text-green-700 border-green-100",
+  danger: "bg-red-50 text-red-700 border-red-100",
+  warning: "bg-amber-50 text-amber-700 border-amber-100",
+  outline: "bg-transparent text-slate-600 border-slate-300",
+};
+
+export function Chip({ children, variant = "neutral", size = "sm", className = "" }) {
+  return (
+    <span
+      className={[
+        baseChip,
+        chipSizeClasses[size] || chipSizeClasses.sm,
+        chipVariantClasses[variant] || chipVariantClasses.neutral,
+        className,
+      ].join(" ")}
+    >
+      {children}
+    </span>
+  );
+}
+
+export default Chip;

--- a/frontend/src/components/HeaderMenuPro.jsx
+++ b/frontend/src/components/HeaderMenuPro.jsx
@@ -36,23 +36,18 @@ const NAV_ITEMS = [
 function Brand() {
   const [failed, setFailed] = React.useState(false);
   return (
-    <div className="flex items-center gap-2">
+    <button className="flex items-center gap-2">
       {failed ? (
-        <Crown aria-label="eControle" className="h-8 w-8 text-indigo-600" />
+        <Crown aria-label="eControle" className="h-7 w-7 text-white" />
       ) : (
         <img
-          src="/favicons/crown/favicon-coroa-gradient.svg"
+          src="/logo-econtrole-branca.svg"
           alt="eControle"
-          className="h-8 w-8"
+          className="h-7 w-auto"
           onError={() => setFailed(true)}
         />
       )}
-      <div className="text-xl md:text-2xl font-extrabold tracking-tight">
-        <span className="bg-gradient-to-r from-indigo-600 via-sky-500 to-emerald-500 bg-clip-text text-transparent">
-          eControle
-        </span>
-      </div>
-    </div>
+    </button>
   );
 }
 
@@ -101,19 +96,27 @@ export default function HeaderMenuPro({
   const handleNew = (type) => console.log(`[Novo] criar ${type}`);
 
   return (
-    <header className="sticky top-0 z-40 w-full border-b bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/60">
-      <div className="max-w-[1400px] mx-auto px-4">
+    <header
+      className="
+        fixed inset-x-0 top-0 z-40
+        border-b border-white/10
+        bg-brand-900/85
+        backdrop-blur-xl
+        text-slate-50
+      "
+    >
+      <div className="mx-auto max-w-7xl px-4 lg:px-6">
         {/* Linha 1: marca + busca + ações + perfil */}
-        <div className="h-16 flex items-center gap-3">
+        <div className="flex h-16 items-center gap-6 justify-between">
           <Brand />
 
           {/* Busca global */}
           <div className="flex-1">
             <div className="relative flex items-end gap-3">
               <div className="flex w-36 md:w-40 flex-col gap-1">
-                <Label className="text-[11px] text-slate-500">Pesquisar por</Label>
+                <Label className="text-[11px] text-white/80">Pesquisar por</Label>
                 <Select value={searchField} onValueChange={onSearchFieldChange}>
-                  <SelectTrigger className="h-9 rounded-lg border border-slate-200 bg-white/70 px-3 text-[13px] shadow-sm">
+                  <SelectTrigger className="h-9 rounded-xl border border-white/15 bg-white/10 px-3 text-[13px] text-slate-50 shadow-inner">
                     <SelectValue placeholder="Campo" />
                   </SelectTrigger>
                   <SelectContent>
@@ -126,13 +129,13 @@ export default function HeaderMenuPro({
                 </Select>
               </div>
               <div className="relative flex-1">
-                <Search className="absolute left-2 top-2.5 h-4 w-4 text-slate-350" />
+                <Search className="absolute left-2 top-2.5 h-4 w-4 text-white/60" />
                 <Input
                   id="global-search-input"
                   placeholder="Buscar: Empresa, CNPJ ou comando (ex.: nome: Silva)  (Ctrl/Cmd + K)"
                   value={query}
                   onChange={(e) => onQueryChange?.(e.target.value)}
-                  className="pl-8"
+                  className="pl-8 border-white/15 bg-white/10 text-slate-50 placeholder:text-white/70 focus-visible:ring-white/30"
                 />
               </div>
             </div>
@@ -142,7 +145,14 @@ export default function HeaderMenuPro({
           <div className="flex items-center gap-2">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button size="sm" variant="secondary" title="Criar novo">+ Novo</Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  title="Criar novo"
+                  className="bg-white text-brand-900 shadow-soft hover:bg-slate-50"
+                >
+                  + Novo
+                </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-44">
                 <DropdownMenuItem onSelect={() => handleNew("empresa")}>
@@ -153,18 +163,32 @@ export default function HeaderMenuPro({
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <Button size="icon" variant="secondary" title="Notificações"><Bell className="h-4 w-4" /></Button>
-            <Button size="icon" variant="secondary" title="Favoritos"><Star className="h-4 w-4" /></Button>
+            <Button
+              size="icon"
+              variant="secondary"
+              title="Notificações"
+              className="border-white/20 bg-white/10 text-white hover:bg-white/15"
+            >
+              <Bell className="h-4 w-4" />
+            </Button>
+            <Button
+              size="icon"
+              variant="secondary"
+              title="Favoritos"
+              className="border-white/20 bg-white/10 text-white hover:bg-white/15"
+            >
+              <Star className="h-4 w-4" />
+            </Button>
           </div>
 
           {/* Perfil */}
-          <div className="flex items-center gap-2 rounded-xl border bg-white/70 backdrop-blur px-2 py-1">
-            <div className="h-7 w-7 rounded-full bg-gradient-to-tr from-indigo-500 to-sky-500 grid place-items-center text-white text-xs font-semibold">MC</div>
+          <div className="flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-2 py-1 text-xs text-slate-50">
+            <div className="h-7 w-7 rounded-full bg-white text-brand-900 grid place-items-center text-xs font-semibold">MC</div>
             <div className="hidden md:block leading-tight">
-              <div className="text-xs font-medium">Maria Clara</div>
-              <div className="text-[10px] text-slate-500">Neto Contabilidade</div>
+              <div className="text-xs font-semibold">Maria Clara</div>
+              <div className="text-[10px] text-white/80">Neto Contabilidade</div>
             </div>
-            <ChevronsUpDown className="h-4 w-4 text-slate-500" />
+            <ChevronsUpDown className="h-4 w-4 text-white/70" />
           </div>
         </div>
 
@@ -172,12 +196,12 @@ export default function HeaderMenuPro({
         <div className="pb-3 -mt-1">
           <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-y-2 lg:gap-y-1.5 gap-x-1">
             <Tabs value={tab} onValueChange={onTabChange} className="w-full lg:flex-1 min-w-0">
-              <TabsList className="flex w-full flex-nowrap items-stretch gap-1 overflow-x-auto lg:overflow-visible">
+              <TabsList className="flex w-full flex-nowrap items-stretch gap-1 overflow-x-auto rounded-2xl bg-white/10 lg:overflow-visible">
                 {NAV_ITEMS.map(({ key, label, icon: Icon }, index) => (
                   <TabsTrigger
                     key={key}
                     value={key}
-                    className="gap-2 whitespace-nowrap lg:flex-1 lg:basis-0 lg:justify-center"
+                    className="gap-2 whitespace-nowrap text-slate-100 lg:flex-1 lg:basis-0 lg:justify-center data-[state=active]:bg-white data-[state=active]:text-brand-900"
                     data-tab-target={key}
                     title={`Alt+${index + 1} para abrir | Alt+↑ para topo`}
                   >
@@ -187,13 +211,12 @@ export default function HeaderMenuPro({
               </TabsList>
               {NAV_ITEMS.map(({ key }) => <TabsContent key={key} value={key} />)}
             </Tabs>
-
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-y-2 sm:gap-y-0 sm:gap-x-1">
               {/* Municípios */}
               <div className="w-36 md:w-44 xl:w-45 shrink-0">
-                <Label className="text-[11px] text-slate-500 lg:inline xl:inline">Município</Label>
+                <Label className="text-[11px] text-white/80 lg:inline xl:inline">Município</Label>
                 <Select value={municipio} onValueChange={onMunicipioChange}>
-                  <SelectTrigger className="h-8 px-2 text-[13px]">
+                  <SelectTrigger className="h-8 px-2 text-[13px] border-white/20 bg-white/10 text-slate-50">
                     <SelectValue placeholder="Todos" />
                   </SelectTrigger>
                   <SelectContent>
@@ -203,39 +226,35 @@ export default function HeaderMenuPro({
               </div>
 
               {/* Somente alertas */}
-              <div className="inline-flex items-center gap-0.5 rounded-md border px-2 py-2 bg-white/60 shrink-0 min-w-[160px] justify-between">
+              <div className="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/10 px-3 py-2 shrink-0 min-w-[180px] justify-between">
                 <Switch
                   checked={!!somenteAlertas}
                   onCheckedChange={onSomenteAlertasChange}
                   className="75"
                 />
-                <span className="text-xs font-medium text-slate-600 leading-tight">Somente alertas</span>
+                <span className="text-xs font-medium text-white leading-tight">Somente alertas</span>
                 {somenteAlertas ? (
-                  <span className="inline-flex items-center rounded-md bg-red-100 px-1 py-0.5 text-[10px] text-red-700 whitespace-nowrap">
+                  <span className="inline-flex items-center rounded-md bg-white/20 px-2 py-0.5 text-[10px] text-white whitespace-nowrap">
                     <ShieldAlert className="mr-0.5 h-3 w-3" /> ON
                   </span>
                 ) : (
-                  <span className="inline-flex items-center rounded-md bg-slate-100 px-1 py-0.5 text-[10px] text-slate-700">
-                    OFF
-                  </span>
+                  <span className="inline-flex items-center rounded-md bg-white/10 px-2 py-0.5 text-[10px] text-white/80">OFF</span>
                 )}
               </div>
 
               {/* Modo foco */}
-              <div className="inline-flex items-center gap-0.5 rounded-md border px-2 py-2 bg-white/60 shrink-0 min-w-[130px] justify-between">
+              <div className="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/10 px-3 py-2 shrink-0 min-w-[160px] justify-between">
                 <Switch checked={!!modoFoco} onCheckedChange={onModoFocoChange} className="75" />
-                <span className="text-xs font-medium text-slate-600 leading-tight">Modo foco</span>
+                <span className="text-xs font-medium text-white leading-tight">Modo foco</span>
                 {modoFoco ? (
-                  <span className="inline-flex items-center rounded-md bg-emerald-100 px-1 py-0.5 text-[10px] text-emerald-700 whitespace-nowrap">ON</span>
+                  <span className="inline-flex items-center rounded-md bg-white/20 px-2 py-0.5 text-[10px] text-white whitespace-nowrap">ON</span>
                 ) : (
-                  <span className="inline-flex items-center rounded-md bg-slate-100 px-1 py-0.5 text-[10px] text-slate-700">OFF</span>
+                  <span className="inline-flex items-center rounded-md bg-white/10 px-2 py-0.5 text-[10px] text-white/80">OFF</span>
                 )}
               </div>
             </div>
           </div>
         </div>
-        
-        <Separator />
       </div>
     </header>
   );

--- a/frontend/src/components/InlineBadge.jsx
+++ b/frontend/src/components/InlineBadge.jsx
@@ -1,39 +1,20 @@
 import React from "react";
+import Chip from "@/components/Chip";
+
+const COLOR_TOKEN = /^(bg-|text-|border-)/;
 
 function InlineBadge({ children, className = "", variant = "solid", ...props }) {
-  const base =
-    "inline-flex items-center justify-center gap-1 rounded-full border px-2 py-0.5 text-center text-xs font-medium";
-  
-  const variants = {
-    solid: "bg-slate-100 border-transparent text-slate-700",
-    outline: "bg-white border-slate-200 text-slate-600",
-    plain: "bg-transparent border-transparent text-slate-500",
-  };
+  const mappedVariant = variant === "solid" ? "neutral" : variant === "plain" ? "outline" : variant;
+  const sanitizedClassName = className
+    .split(" ")
+    .filter(Boolean)
+    .filter((token) => !COLOR_TOKEN.test(token))
+    .join(" ");
 
-  const variantClasses = variants[variant] || variants.solid;
-
-  const hasCustomBg = /\bbg-[\w/-]+/.test(className);
-  const hasCustomBorder = /\bborder-[\w/-]+/.test(className);
-  const hasCustomText = /\btext-[\w/-]+/.test(className);
-
-  const pickVariantPart = (pattern) =>
-    (variantClasses.match(pattern) || []).join(" ");
-
-  const composedVariantClasses =
-    hasCustomBg || hasCustomBorder || hasCustomText
-      ? [
-          hasCustomBg ? "" : pickVariantPart(/\bbg-[^\s]+/g),
-          hasCustomBorder ? "" : pickVariantPart(/\bborder-[^\s]+/g),
-          hasCustomText ? "" : pickVariantPart(/\btext-[^\s]+/g),
-        ]
-          .filter(Boolean)
-          .join(" ")
-      : variantClasses;
-  
   return (
-    <span className={`${base} ${composedVariantClasses} ${className}`} {...props}>
+    <Chip variant={mappedVariant} className={sanitizedClassName} {...props}>
       {children}
-    </span>
+    </Chip>
   );
 }
 

--- a/frontend/src/components/StatusBadge.jsx
+++ b/frontend/src/components/StatusBadge.jsx
@@ -1,19 +1,15 @@
 import React from "react";
-import InlineBadge from "@/components/InlineBadge";
 import { normalizeText } from "@/lib/text";
 import { resolveStatusClass } from "@/lib/status";
+import Chip from "@/components/Chip";
 
 function StatusBadge({ status }) {
   const normalized = normalizeText(status);
   const trimmed = normalized.trim();
   const displayValue =
     trimmed === "" || trimmed === "*" || trimmed === "-" || trimmed === "—" ? "—" : trimmed;
-  const { variant, className } = resolveStatusClass(status);
-  return (
-    <InlineBadge variant={variant} className={className}>
-      {displayValue}
-    </InlineBadge>
-  );
+  const { variant } = resolveStatusClass(status);
+  return <Chip variant={variant}>{displayValue}</Chip>;
 }
 
 export default StatusBadge;

--- a/frontend/src/components/ui/card.jsx
+++ b/frontend/src/components/ui/card.jsx
@@ -2,11 +2,19 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 export function Card({ className, ...props }) {
-  return <div className={cn("rounded-2xl border bg-card text-card-foreground shadow-sm", className)} {...props} />;
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-slate-100 bg-surface-card text-slate-900 shadow-soft",
+        className,
+      )}
+      {...props}
+    />
+  );
 }
 
 export function CardHeader({ className, ...props }) {
-  return <div className={cn("flex flex-col space-y-1.5 p-4", className)} {...props} />;
+  return <div className={cn("flex flex-col space-y-1.5 p-4 lg:p-5", className)} {...props} />;
 }
 
 export function CardTitle({ className, ...props }) {
@@ -14,9 +22,9 @@ export function CardTitle({ className, ...props }) {
 }
 
 export function CardContent({ className, ...props }) {
-  return <div className={cn("p-4 pt-0", className)} {...props} />;
+  return <div className={cn("p-4 pt-0 lg:p-5 lg:pt-0", className)} {...props} />;
 }
 
 export function CardFooter({ className, ...props }) {
-  return <div className={cn("flex items-center p-4 pt-0", className)} {...props} />;
+  return <div className={cn("flex items-center p-4 pt-0 lg:p-5 lg:pt-0", className)} {...props} />;
 }

--- a/frontend/src/features/empresas/EmpresasScreen.jsx
+++ b/frontend/src/features/empresas/EmpresasScreen.jsx
@@ -12,7 +12,7 @@ import {
   MiniBadge,
   Kbd,
 } from "@/components/ui/dropdown-menu";
-import InlineBadge from "@/components/InlineBadge";
+import Chip from "@/components/Chip";
 import StatusBadge from "@/components/StatusBadge";
 import CopyableIdentifier from "@/components/CopyableIdentifier";
 import { Mail, Phone, Clipboard, ExternalLink, File, Loader2 } from "lucide-react";
@@ -251,7 +251,7 @@ export default function EmpresasScreen({
         <span>
           {filteredEmpresas.length} de {empresas.length} empresas exibidas
         </span>
-        {soAlertas && <InlineBadge variant="outline">Modo alertas ativo</InlineBadge>}
+        {soAlertas && <Chip variant="warning">Modo alertas ativo</Chip>}
       </div>
 
       <div className="grid gap-3 lg:grid-cols-2">
@@ -297,12 +297,17 @@ export default function EmpresasScreen({
             item?.name?.startsWith("CAE - ")
           );
           const lastCAE = caeFiles[0];
+          const certificadoSituacao = empresa.certificado || DEFAULT_CERTIFICADO_SITUACAO;
+          const certificadoOk = normalizeTextLower(certificadoSituacao).includes("valido");
+          const debitoKey = normalizeTextLower(empresa.debito);
+          const semDebitos =
+            debitoKey.includes("nao") || debitoKey.includes("não") || debitoKey.includes("sem");
 
           return (
-            <Card key={empresa.id} className="shadow-sm overflow-hidden border border-white/60">
-              <CardContent className="p-4 space-y-3">
+            <Card key={empresa.id} className="overflow-hidden">
+              <CardContent className="space-y-3">
                 <div className="flex items-start gap-3">
-                  <div className="h-12 w-12 rounded-xl bg-indigo-100 text-indigo-700 font-semibold grid place-items-center">
+                  <div className="h-12 w-12 rounded-xl bg-brand-100 text-brand-900 font-semibold grid place-items-center">
                     {avatarLabel}
                   </div>
                   <div className="flex-1 min-w-0">
@@ -324,19 +329,15 @@ export default function EmpresasScreen({
                     </div>
 
                     <div className="mt-2 flex flex-wrap gap-2 text-xs text-slate-600">
-                      <InlineBadge variant="outline" className="bg-white">
-                        Categoria: {empresa.categoria || "—"}
-                      </InlineBadge>
-                      <InlineBadge variant="outline" className="bg-white">
-                        Certificado: {empresa.certificado || DEFAULT_CERTIFICADO_SITUACAO}
-                      </InlineBadge>
-                      <InlineBadge variant="outline" className="bg-white">
-                        Débito: {empresa.debito}
-                      </InlineBadge>
+                      <Chip>Categoria: {empresa.categoria || "—"}</Chip>
+                      <Chip variant={certificadoOk ? "success" : "danger"}>
+                        Certificado: {certificadoSituacao}
+                      </Chip>
+                      <Chip variant={semDebitos ? "success" : "danger"} size="md">
+                        {semDebitos ? "Sem débitos" : `Débito: ${empresa.debito || "—"}`}
+                      </Chip>
                       {empresa.responsavelFiscal && (
-                        <InlineBadge variant="outline" className="bg-white">
-                          Resp. fiscal: {empresa.responsavelFiscal}
-                        </InlineBadge>
+                        <Chip>Resp. fiscal: {empresa.responsavelFiscal}</Chip>
                       )}
                     </div>
 
@@ -369,26 +370,26 @@ export default function EmpresasScreen({
                 <Separator />
 
                 <div className="grid grid-cols-2 gap-3 text-xs">
-                  <div className="rounded-lg border border-emerald-100 bg-emerald-50/70 p-3">
-                    <p className="text-[11px] uppercase text-emerald-600 font-semibold">Licenças</p>
+                  <div className="rounded-2xl border border-slate-100 bg-surface-card p-3 shadow-soft">
+                    <p className="text-[11px] uppercase text-slate-600 font-semibold">Licenças</p>
                     <div className="mt-1 flex items-end gap-2">
-                      <span className="text-2xl font-semibold text-emerald-700">
+                      <span className="text-2xl font-semibold text-slate-900">
                         {licSummary.total}
                       </span>
-                      <div className="space-y-0.5 text-[11px] text-emerald-700/80">
+                      <div className="space-y-0.5 text-[11px] text-slate-600">
                         <p>Ativas: {licSummary.ativas}</p>
                         <p>Vencendo: {licSummary.vencendo}</p>
                         <p>Vencidas: {licSummary.vencidas}</p>
                       </div>
                     </div>
                   </div>
-                  <div className="rounded-lg border border-sky-100 bg-sky-50/70 p-3">
-                    <p className="text-[11px] uppercase text-sky-600 font-semibold">Processos</p>
+                  <div className="rounded-2xl border border-slate-100 bg-surface-card p-3 shadow-soft">
+                    <p className="text-[11px] uppercase text-slate-600 font-semibold">Processos</p>
                     <div className="mt-1 flex items-end gap-2">
-                      <span className="text-2xl font-semibold text-sky-700">
+                      <span className="text-2xl font-semibold text-slate-900">
                         {processosEmpresa.length}
                       </span>
-                      <div className="space-y-0.5 text-[11px] text-sky-700/80">
+                      <div className="space-y-0.5 text-[11px] text-slate-600">
                         <p>Ativos: {processosAtivosEmpresa.length}</p>
                         <p>Encerrados: {processosEmpresa.length - processosAtivosEmpresa.length}</p>
                         <p>

--- a/frontend/src/features/painel/PainelScreen.jsx
+++ b/frontend/src/features/painel/PainelScreen.jsx
@@ -327,21 +327,21 @@ export default function PainelScreen(props) {
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
             {selfTestResults.map((item) => (
-              <div
-                key={item.label}
-                className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2"
-              >
-                <span className="font-medium text-slate-700">{item.label}</span>
-                {item.pass ? (
-                  <InlineBadge className="bg-emerald-100 text-emerald-700 border-emerald-200">
-                    <CheckCircle2 className="h-3.5 w-3.5 mr-1" /> OK
-                  </InlineBadge>
-                ) : (
-                  <InlineBadge className="bg-amber-100 text-amber-700 border-amber-200">
-                    <AlertTriangle className="h-3.5 w-3.5 mr-1" /> Verificar
-                  </InlineBadge>
-                )}
-              </div>
+                <div
+                  key={item.label}
+                  className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2"
+                >
+                  <span className="font-medium text-slate-700">{item.label}</span>
+                  {item.pass ? (
+                    <InlineBadge variant="success">
+                      <CheckCircle2 className="h-3.5 w-3.5 mr-1" /> OK
+                    </InlineBadge>
+                  ) : (
+                    <InlineBadge variant="warning">
+                      <AlertTriangle className="h-3.5 w-3.5 mr-1" /> Verificar
+                    </InlineBadge>
+                  )}
+                </div>
             ))}
           </CardContent>
         </Card>

--- a/frontend/src/features/processos/ProcessosScreen.jsx
+++ b/frontend/src/features/processos/ProcessosScreen.jsx
@@ -316,8 +316,8 @@ export default function ProcessosScreen({
       </div>
 
       {selectedProcessType === PROCESS_DIVERSOS_LABEL && diversosOperacoes.length > 0 && (
-        <div className="flex flex-wrap items-center gap-3 rounded-xl border border-violet-200 bg-violet-50/70 p-3">
-          <Label className="text-xs uppercase text-violet-600">
+        <div className="flex flex-wrap items-center gap-3 rounded-2xl border border-slate-200 bg-surface-card p-3 shadow-soft">
+          <Label className="text-xs uppercase text-slate-600">
             Filtrar Diversos por operação
           </Label>
           <Select value={selectedDiversosOperacao} onValueChange={setSelectedDiversosOperacao}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Variáveis de tema (compatíveis com tailwind.config.js) */
+/* Paleta base usada pelos componentes derivados do shadcn/ui */
 :root {
   --background: 0 0% 100%;
   --foreground: 222.2 47.4% 11.2%;
@@ -36,6 +36,7 @@
 }
 
 @layer base {
-  * { @apply border-border; }
-  body { @apply bg-background text-foreground; }
+  body {
+    @apply bg-surface-body text-slate-900 antialiased;
+  }
 }

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -2,13 +2,13 @@ export const MUNICIPIO_ALL = "__ALL__";
 export const PROCESS_ALL = "__PROCESS_ALL__";
 
 export const TAB_BACKGROUNDS = {
-  painel: "bg-sky-50",
-  empresas: "bg-indigo-50",
-  certificados: "bg-teal-50",
-  licencas: "bg-emerald-50",
-  taxas: "bg-amber-50",
-  processos: "bg-violet-50",
-  uteis: "bg-slate-50",
+  painel: "bg-transparent",
+  empresas: "bg-transparent",
+  certificados: "bg-transparent",
+  licencas: "bg-transparent",
+  taxas: "bg-transparent",
+  processos: "bg-transparent",
+  uteis: "bg-transparent",
 };
 
 export const TAB_SHORTCUTS = {

--- a/frontend/src/lib/status.js
+++ b/frontend/src/lib/status.js
@@ -107,14 +107,14 @@ export const isAlertStatus = (status) => {
   return ALERT_STATUS_KEYWORDS.some((keyword) => key.includes(keyword));
 };
 
-export const STATUS_VARIANT_CLASSES = {
-  success: "bg-emerald-100 text-emerald-700 border-emerald-200",
-  warning: "bg-amber-100 text-amber-700 border-amber-200",
-  danger: "bg-red-100 text-red-700 border-red-200",
-  info: "bg-sky-100 text-sky-700 border-sky-200",
-  neutral: "bg-slate-200 text-slate-700 border-slate-300",
-  muted: "bg-slate-100 text-slate-600 border-slate-200",
-  plain: "bg-transparent border-transparent text-slate-500",
+export const STATUS_VARIANTS = {
+  success: "success",
+  warning: "warning",
+  danger: "danger",
+  info: "neutral",
+  neutral: "neutral",
+  muted: "neutral",
+  plain: "outline",
 };
 
 export const resolveStatusClass = (status) => {
@@ -122,94 +122,94 @@ export const resolveStatusClass = (status) => {
   const trimmed = normalized.trim();
 
   if (trimmed === "" || trimmed === "*" || trimmed === "-" || trimmed === "—") {
-    return { variant: "plain", className: STATUS_VARIANT_CLASSES.plain };
+    return { variant: STATUS_VARIANTS.plain };
   }
 
   const key = removeDiacritics(trimmed.toLowerCase());
   const normalizedKey = key.replace(/\s+/g, " ").trim();
 
   if (normalizedKey === "valido") {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: STATUS_VARIANTS.success };
   }
 
   if (normalizedKey === "vencido") {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: STATUS_VARIANTS.danger };
   }
 
   const fraction = parseProgressFraction(trimmed);
   if (fraction) {
     const { current, total } = fraction;
     if (!Number.isFinite(current) || !Number.isFinite(total) || total <= 0) {
-      return { variant: "solid", className: STATUS_VARIANT_CLASSES.warning };
+      return { variant: STATUS_VARIANTS.warning };
     }
     if (current < total) {
-      return { variant: "solid", className: STATUS_VARIANT_CLASSES.warning };
+      return { variant: STATUS_VARIANTS.warning };
     }
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: STATUS_VARIANTS.success };
   }
 
   if (key.includes("possui debit")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: STATUS_VARIANTS.danger };
   }
 
   if (key.includes("sem debit") || key.includes("nao possui debit")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: STATUS_VARIANTS.success };
   }
 
   if (key.includes("sujeit")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: STATUS_VARIANTS.warning };
   }
 
   if (key.includes("valido")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: STATUS_VARIANTS.success };
   }
 
   if (key.includes("vencid")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: STATUS_VARIANTS.danger };
   }
 
   if (key.includes("vencend") || key.includes("vence")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.warning };
+    return { variant: STATUS_VARIANTS.warning };
   }
 
   if (key === "nao" || key.startsWith("nao ") || key.includes(" nao ")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.muted };
+    return { variant: STATUS_VARIANTS.muted };
   }
 
   if (key.includes("possui")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: STATUS_VARIANTS.success };
   }
 
   if (key.includes("pago") && !key.includes("nao")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: STATUS_VARIANTS.success };
   }
 
   if (key.includes("em aberto") || key.includes("emaberto") || key.includes("nao pago")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: STATUS_VARIANTS.danger };
   }
 
   if (key.includes("indefer") || key.includes("negad")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: STATUS_VARIANTS.danger };
   }
 
   if (key.includes("conclu")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: STATUS_VARIANTS.success };
   }
 
   if (key.includes("andament") || key.includes("aguard")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.warning };
+    return { variant: STATUS_VARIANTS.warning };
   }
 
   if (key.includes("pendent")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.muted };
+    return { variant: STATUS_VARIANTS.warning };
   }
 
   if (key.includes("nao se aplica") || key.includes("n/a")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.info };
+    return { variant: STATUS_VARIANTS.info };
   }
 
   if (key.includes("dispens") || key.includes("orient") || key.includes("inform") || key.includes("consult")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.info };
+    return { variant: STATUS_VARIANTS.info };
   }
 
   if (
@@ -219,7 +219,7 @@ export const resolveStatusClass = (status) => {
     key.includes("bloque") ||
     key.includes("inadimpl")
   ) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: STATUS_VARIANTS.danger };
   }
 
   if (
@@ -230,10 +230,10 @@ export const resolveStatusClass = (status) => {
     (key.includes("em dia") && !key.includes("irregular")) ||
     (key === "sim" && !key.includes("irregular"))
   ) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: STATUS_VARIANTS.success };
   }
 
-  return { variant: "solid", className: STATUS_VARIANT_CLASSES.neutral };
+  return { variant: STATUS_VARIANTS.neutral };
 };
 
 export const isProcessStatusInactive = (status) => {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,12 +1,6 @@
 /** @type {import('tailwindcss').Config} */
-export default {
-  darkMode: ["class"],
-  content: [
-    './pages/**/*.{js,jsx}',
-    './components/**/*.{js,jsx}',
-    './app/**/*.{js,jsx}',
-    './src/**/*.{js,jsx}',
-  ],
+const config = {
+  content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {
       colors: {
@@ -43,13 +37,36 @@ export default {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        brand: {
+          900: "#22489c",
+          700: "#2857b8",
+          600: "#2f66d4",
+          100: "#e3ebff",
+        },
+        surface: {
+          body: "#F5F7FB",
+          card: "#FFFFFF",
+        },
+        status: {
+          success: "#16A34A",
+          warning: "#F97316",
+          danger: "#EF4444",
+          neutral: "#6B7280",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+        xl: "0.75rem",
+        "2xl": "1rem",
+      },
+      boxShadow: {
+        soft: "0 18px 45px rgba(15, 23, 42, 0.06)",
       },
     },
   },
   plugins: [],
-}
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add brand, surface, and status tokens plus refreshed card defaults and chip component
- update the app shell with the glassy navy header, neutral background, and new logo placeholder
- standardize chips and neutral cards across company and process views for cleaner status cues

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396aa9d47c8326871b51344193f564)