### PR TITLE
Apply glass header and chip-based styling

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,12 +21,7 @@ import {
   getProcessBaseType,
   normalizeProcessType,
 } from "@/lib/process";
-import {
-  MUNICIPIO_ALL,
-  TAB_BACKGROUNDS,
-  TAB_SHORTCUTS,
-  TAXA_TYPE_KEYS,
-} from "@/lib/constants";
+import { MUNICIPIO_ALL, TAB_SHORTCUTS, TAXA_TYPE_KEYS } from "@/lib/constants";
 import { fetchJson } from "@/lib/api";
 import { isAlertStatus, isProcessStatusInactive } from "@/lib/status";
 import {
@@ -588,7 +583,7 @@ function AppContent() {
   );
 
   return (
-    <>
+    <div className="min-h-screen bg-surface-body text-slate-900">
       <HeaderMenuPro
         tab={tab}
         onTabChange={setTab}
@@ -605,113 +600,115 @@ function AppContent() {
         modoFoco={modoFoco}
         onModoFocoChange={setModoFoco}
       />
-      <div className={`p-4 md:p-6 max-w-[1400px] mx-auto rounded-2xl ${TAB_BACKGROUNDS[tab]}`}>
-        {loading ? (
-          <div className="p-6 text-center">Carregando dados...</div>
-        ) : (
-          <Tabs value={tab} onValueChange={setTab}>
-            <TabsContent value="painel">
-              <PainelScreen
-                query={query}
-                municipio={municipio}
-                soAlertas={somenteAlertas}
-                kpis={kpis}
-                empresas={empresasComCertificados}
-                licencas={licencas}
-                taxas={taxas}
-                certificados={certificados}
-                filteredLicencas={filteredLicencas}
-                processosNormalizados={processosNormalizados}
-                filterEmpresas={filterEmpresas}
-                companyHasAlert={companyHasAlert}
-                licencasByEmpresa={licencasByEmpresa}
-                extractEmpresaId={extractEmpresaId}
-              />
-            </TabsContent>
+      <main className="pt-20 px-4 pb-8 lg:px-8">
+        <div className="mx-auto max-w-[1400px] space-y-4">
+          {loading ? (
+            <div className="p-6 text-center">Carregando dados...</div>
+          ) : (
+            <Tabs value={tab} onValueChange={setTab}>
+              <TabsContent value="painel">
+                <PainelScreen
+                  query={query}
+                  municipio={municipio}
+                  soAlertas={somenteAlertas}
+                  kpis={kpis}
+                  empresas={empresasComCertificados}
+                  licencas={licencas}
+                  taxas={taxas}
+                  certificados={certificados}
+                  filteredLicencas={filteredLicencas}
+                  processosNormalizados={processosNormalizados}
+                  filterEmpresas={filterEmpresas}
+                  companyHasAlert={companyHasAlert}
+                  licencasByEmpresa={licencasByEmpresa}
+                  extractEmpresaId={extractEmpresaId}
+                />
+              </TabsContent>
 
-            <TabsContent value="empresas" className="mt-4 space-y-3">
-              <EmpresasScreen
-                filteredEmpresas={filteredEmpresas}
-                empresas={empresasComCertificados}
-                soAlertas={somenteAlertas}
-                extractEmpresaId={extractEmpresaId}
-                licencasByEmpresa={licencasByEmpresa}
-                taxasByEmpresa={taxasByEmpresa}
-                processosByEmpresa={processosByEmpresa}
-                handleCopy={handleCopy}
-                enqueueToast={enqueueToast}
-              />
-            </TabsContent>
+              <TabsContent value="empresas" className="mt-4 space-y-3">
+                <EmpresasScreen
+                  filteredEmpresas={filteredEmpresas}
+                  empresas={empresasComCertificados}
+                  soAlertas={somenteAlertas}
+                  extractEmpresaId={extractEmpresaId}
+                  licencasByEmpresa={licencasByEmpresa}
+                  taxasByEmpresa={taxasByEmpresa}
+                  processosByEmpresa={processosByEmpresa}
+                  handleCopy={handleCopy}
+                  enqueueToast={enqueueToast}
+                />
+              </TabsContent>
 
-            <TabsContent value="licencas" className="mt-4">
-              <LicencasScreen licencas={licencas} filteredLicencas={filteredLicencas} modoFoco={modoFoco} />
-            </TabsContent>
+              <TabsContent value="licencas" className="mt-4">
+                <LicencasScreen licencas={licencas} filteredLicencas={filteredLicencas} modoFoco={modoFoco} />
+              </TabsContent>
 
-            <TabsContent value="taxas" className="mt-4">
-              <TaxasScreen
-                taxas={taxas}
-                modoFoco={modoFoco}
-                matchesMunicipioFilter={matchesMunicipioFilter}
-                matchesQuery={matchesQuery}
-              />
-            </TabsContent>
+              <TabsContent value="taxas" className="mt-4">
+                <TaxasScreen
+                  taxas={taxas}
+                  modoFoco={modoFoco}
+                  matchesMunicipioFilter={matchesMunicipioFilter}
+                  matchesQuery={matchesQuery}
+                />
+              </TabsContent>
 
-            <TabsContent value="processos">
-              <ProcessosScreen
-                processosNormalizados={processosNormalizados}
-                modoFoco={modoFoco}
-                matchesMunicipioFilter={matchesMunicipioFilter}
-                matchesQuery={matchesQuery}
-                handleCopy={handleCopy}
-              />
-            </TabsContent>
+              <TabsContent value="processos">
+                <ProcessosScreen
+                  processosNormalizados={processosNormalizados}
+                  modoFoco={modoFoco}
+                  matchesMunicipioFilter={matchesMunicipioFilter}
+                  matchesQuery={matchesQuery}
+                  handleCopy={handleCopy}
+                />
+              </TabsContent>
 
-            <TabsContent value="uteis">
-              <UteisScreen
-                query={query}
-                municipio={municipio}
-                soAlertas={somenteAlertas}
-                contatos={contatos}
-                modelos={modelos}
-                matchesMunicipioFilter={matchesMunicipioFilter}
-                handleCopy={handleCopy}
-              />
-            </TabsContent>
+              <TabsContent value="uteis">
+                <UteisScreen
+                  query={query}
+                  municipio={municipio}
+                  soAlertas={somenteAlertas}
+                  contatos={contatos}
+                  modelos={modelos}
+                  matchesMunicipioFilter={matchesMunicipioFilter}
+                  handleCopy={handleCopy}
+                />
+              </TabsContent>
 
-            <TabsContent value="certificados" className="mt-4">
-              <CertificadosScreen
-                certificados={certificados}
-                agendamentos={agendamentos}
-                soAlertas={somenteAlertas}
-              />
-            </TabsContent>
-          </Tabs>
-        )}
+              <TabsContent value="certificados" className="mt-4">
+                <CertificadosScreen
+                  certificados={certificados}
+                  agendamentos={agendamentos}
+                  soAlertas={somenteAlertas}
+                />
+              </TabsContent>
+            </Tabs>
+          )}
 
-        <div className="pointer-events-none fixed inset-x-0 bottom-4 flex justify-center sm:justify-end px-4">
-          <div className="w-full sm:max-w-sm space-y-2">
-            {toasts.map((toast) => (
-              <div
-                key={toast.id}
-                className="pointer-events-auto rounded-xl border border-slate-200 bg-white shadow-lg px-4 py-3 flex items-start gap-3"
-              >
-                <div className="mt-0.5">
-                  <Sparkles className="h-4 w-4 text-amber-500" />
-                </div>
-                <div className="text-sm text-slate-700 flex-1">{toast.message}</div>
-                <button
-                  type="button"
-                  className="text-slate-400 hover:text-slate-600"
-                  onClick={() => dismissToast(toast.id)}
+          <div className="pointer-events-none fixed inset-x-0 bottom-4 flex justify-center sm:justify-end px-4">
+            <div className="w-full sm:max-w-sm space-y-2">
+              {toasts.map((toast) => (
+                <div
+                  key={toast.id}
+                  className="pointer-events-auto rounded-xl border border-slate-200 bg-white shadow-lg px-4 py-3 flex items-start gap-3"
                 >
-                  <X className="h-4 w-4" />
-                </button>
-              </div>
-            ))}
+                  <div className="mt-0.5">
+                    <Sparkles className="h-4 w-4 text-amber-500" />
+                  </div>
+                  <div className="text-sm text-slate-700 flex-1">{toast.message}</div>
+                  <button
+                    type="button"
+                    className="text-slate-400 hover:text-slate-600"
+                    onClick={() => dismissToast(toast.id)}
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
-      </div>
-    </>
+      </main>
+    </div>
   );
 }
 

--- a/frontend/src/components/Chip.jsx
+++ b/frontend/src/components/Chip.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const baseChip = "inline-flex items-center gap-1 border text-xs font-medium rounded-lg";
+
+const chipSizeClasses = {
+  sm: "px-2 py-0.5",
+  md: "px-2.5 py-1",
+};
+
+const chipVariantClasses = {
+  neutral: "bg-slate-100 text-slate-600 border-slate-200",
+  success: "bg-green-50 text-green-700 border-green-100",
+  danger: "bg-red-50 text-red-700 border-red-100",
+  warning: "bg-amber-50 text-amber-700 border-amber-100",
+  outline: "bg-transparent text-slate-600 border-slate-300",
+};
+
+export function Chip({ children, variant = "neutral", size = "sm", className = "" }) {
+  return (
+    <span className={[baseChip, chipSizeClasses[size], chipVariantClasses[variant], className].join(" ")}>
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/HeaderMenuPro.jsx
+++ b/frontend/src/components/HeaderMenuPro.jsx
@@ -36,22 +36,18 @@ const NAV_ITEMS = [
 function Brand() {
   const [failed, setFailed] = React.useState(false);
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-3">
       {failed ? (
-        <Crown aria-label="eControle" className="h-8 w-8 text-indigo-600" />
+        <Crown aria-label="eControle" className="h-7 w-7 text-white" />
       ) : (
         <img
-          src="/favicons/crown/favicon-coroa-gradient.svg"
+          src="/logo-econtrole-branca.svg"
           alt="eControle"
-          className="h-8 w-8"
+          className="h-7 w-auto"
           onError={() => setFailed(true)}
         />
       )}
-      <div className="text-xl md:text-2xl font-extrabold tracking-tight">
-        <span className="bg-gradient-to-r from-indigo-600 via-sky-500 to-emerald-500 bg-clip-text text-transparent">
-          eControle
-        </span>
-      </div>
+      <span className="text-lg font-semibold text-white">eControle</span>
     </div>
   );
 }
@@ -101,19 +97,19 @@ export default function HeaderMenuPro({
   const handleNew = (type) => console.log(`[Novo] criar ${type}`);
 
   return (
-    <header className="sticky top-0 z-40 w-full border-b bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/60">
-      <div className="max-w-[1400px] mx-auto px-4">
+    <header className="fixed inset-x-0 top-0 z-40 border-b border-white/10 bg-brand-900/85 backdrop-blur-xl">
+      <div className="max-w-[1400px] mx-auto px-4 lg:px-6">
         {/* Linha 1: marca + busca + ações + perfil */}
-        <div className="h-16 flex items-center gap-3">
+        <div className="h-16 flex items-center gap-4">
           <Brand />
 
           {/* Busca global */}
           <div className="flex-1">
             <div className="relative flex items-end gap-3">
               <div className="flex w-36 md:w-40 flex-col gap-1">
-                <Label className="text-[11px] text-slate-500">Pesquisar por</Label>
+                <Label className="text-[11px] text-brand-100/80">Pesquisar por</Label>
                 <Select value={searchField} onValueChange={onSearchFieldChange}>
-                  <SelectTrigger className="h-9 rounded-lg border border-slate-200 bg-white/70 px-3 text-[13px] shadow-sm">
+                  <SelectTrigger className="h-9 rounded-lg border border-white/15 bg-white/10 px-3 text-[13px] text-white shadow-sm">
                     <SelectValue placeholder="Campo" />
                   </SelectTrigger>
                   <SelectContent>
@@ -126,23 +122,30 @@ export default function HeaderMenuPro({
                 </Select>
               </div>
               <div className="relative flex-1">
-                <Search className="absolute left-2 top-2.5 h-4 w-4 text-slate-350" />
+                <Search className="absolute left-2 top-2.5 h-4 w-4 text-brand-100" />
                 <Input
                   id="global-search-input"
                   placeholder="Buscar: Empresa, CNPJ ou comando (ex.: nome: Silva)  (Ctrl/Cmd + K)"
                   value={query}
                   onChange={(e) => onQueryChange?.(e.target.value)}
-                  className="pl-8"
+                  className="pl-8 border-white/20 bg-white/10 text-white placeholder:text-white/70 focus-visible:ring-white/40"
                 />
               </div>
             </div>
           </div>
 
           {/* Ações rápidas */}
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 text-white">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button size="sm" variant="secondary" title="Criar novo">+ Novo</Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  className="border border-white/15 bg-white/10 text-white hover:bg-white/15"
+                  title="Criar novo"
+                >
+                  + Novo
+                </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-44">
                 <DropdownMenuItem onSelect={() => handleNew("empresa")}>
@@ -153,31 +156,45 @@ export default function HeaderMenuPro({
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <Button size="icon" variant="secondary" title="Notificações"><Bell className="h-4 w-4" /></Button>
-            <Button size="icon" variant="secondary" title="Favoritos"><Star className="h-4 w-4" /></Button>
+            <Button
+              size="icon"
+              variant="secondary"
+              className="border border-white/15 bg-white/10 text-white hover:bg-white/15"
+              title="Notificações"
+            >
+              <Bell className="h-4 w-4" />
+            </Button>
+            <Button
+              size="icon"
+              variant="secondary"
+              className="border border-white/15 bg-white/10 text-white hover:bg-white/15"
+              title="Favoritos"
+            >
+              <Star className="h-4 w-4" />
+            </Button>
           </div>
 
           {/* Perfil */}
-          <div className="flex items-center gap-2 rounded-xl border bg-white/70 backdrop-blur px-2 py-1">
-            <div className="h-7 w-7 rounded-full bg-gradient-to-tr from-indigo-500 to-sky-500 grid place-items-center text-white text-xs font-semibold">MC</div>
+          <div className="flex items-center gap-2 rounded-xl border border-white/15 bg-white/10 px-2 py-1 text-white">
+            <div className="h-7 w-7 rounded-full bg-white/20 grid place-items-center text-white text-xs font-semibold">MC</div>
             <div className="hidden md:block leading-tight">
-              <div className="text-xs font-medium">Maria Clara</div>
-              <div className="text-[10px] text-slate-500">Neto Contabilidade</div>
+              <div className="text-xs font-medium text-white">Maria Clara</div>
+              <div className="text-[10px] text-brand-100/80">Neto Contabilidade</div>
             </div>
-            <ChevronsUpDown className="h-4 w-4 text-slate-500" />
+            <ChevronsUpDown className="h-4 w-4 text-brand-100" />
           </div>
         </div>
 
         {/* Linha 2: navegação + filtros */}
-        <div className="pb-3 -mt-1">
+        <div className="pb-3 -mt-1 text-white">
           <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-y-2 lg:gap-y-1.5 gap-x-1">
             <Tabs value={tab} onValueChange={onTabChange} className="w-full lg:flex-1 min-w-0">
-              <TabsList className="flex w-full flex-nowrap items-stretch gap-1 overflow-x-auto lg:overflow-visible">
+              <TabsList className="flex w-full flex-nowrap items-stretch gap-1 overflow-x-auto lg:overflow-visible bg-white/10">
                 {NAV_ITEMS.map(({ key, label, icon: Icon }, index) => (
                   <TabsTrigger
                     key={key}
                     value={key}
-                    className="gap-2 whitespace-nowrap lg:flex-1 lg:basis-0 lg:justify-center"
+                    className="gap-2 whitespace-nowrap lg:flex-1 lg:basis-0 lg:justify-center text-white data-[state=active]:bg-white/15"
                     data-tab-target={key}
                     title={`Alt+${index + 1} para abrir | Alt+↑ para topo`}
                   >
@@ -191,9 +208,9 @@ export default function HeaderMenuPro({
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-y-2 sm:gap-y-0 sm:gap-x-1">
               {/* Municípios */}
               <div className="w-36 md:w-44 xl:w-45 shrink-0">
-                <Label className="text-[11px] text-slate-500 lg:inline xl:inline">Município</Label>
+                <Label className="text-[11px] text-brand-100/80 lg:inline xl:inline">Município</Label>
                 <Select value={municipio} onValueChange={onMunicipioChange}>
-                  <SelectTrigger className="h-8 px-2 text-[13px]">
+                  <SelectTrigger className="h-8 px-2 text-[13px] border-white/20 bg-white/10 text-white">
                     <SelectValue placeholder="Todos" />
                   </SelectTrigger>
                   <SelectContent>
@@ -203,39 +220,37 @@ export default function HeaderMenuPro({
               </div>
 
               {/* Somente alertas */}
-              <div className="inline-flex items-center gap-0.5 rounded-md border px-2 py-2 bg-white/60 shrink-0 min-w-[160px] justify-between">
+              <div className="inline-flex items-center gap-0.5 rounded-md border border-white/20 px-2 py-2 bg-white/5 shrink-0 min-w-[160px] justify-between text-white">
                 <Switch
                   checked={!!somenteAlertas}
                   onCheckedChange={onSomenteAlertasChange}
                   className="75"
                 />
-                <span className="text-xs font-medium text-slate-600 leading-tight">Somente alertas</span>
+                <span className="text-xs font-medium leading-tight">Somente alertas</span>
                 {somenteAlertas ? (
-                  <span className="inline-flex items-center rounded-md bg-red-100 px-1 py-0.5 text-[10px] text-red-700 whitespace-nowrap">
+                  <span className="inline-flex items-center rounded-md bg-red-100/90 px-1 py-0.5 text-[10px] text-red-700 whitespace-nowrap">
                     <ShieldAlert className="mr-0.5 h-3 w-3" /> ON
                   </span>
                 ) : (
-                  <span className="inline-flex items-center rounded-md bg-slate-100 px-1 py-0.5 text-[10px] text-slate-700">
-                    OFF
-                  </span>
+                  <span className="inline-flex items-center rounded-md bg-white/15 px-1 py-0.5 text-[10px] text-white">OFF</span>
                 )}
               </div>
 
               {/* Modo foco */}
-              <div className="inline-flex items-center gap-0.5 rounded-md border px-2 py-2 bg-white/60 shrink-0 min-w-[130px] justify-between">
+              <div className="inline-flex items-center gap-0.5 rounded-md border border-white/20 px-2 py-2 bg-white/5 shrink-0 min-w-[130px] justify-between text-white">
                 <Switch checked={!!modoFoco} onCheckedChange={onModoFocoChange} className="75" />
-                <span className="text-xs font-medium text-slate-600 leading-tight">Modo foco</span>
+                <span className="text-xs font-medium leading-tight">Modo foco</span>
                 {modoFoco ? (
                   <span className="inline-flex items-center rounded-md bg-emerald-100 px-1 py-0.5 text-[10px] text-emerald-700 whitespace-nowrap">ON</span>
                 ) : (
-                  <span className="inline-flex items-center rounded-md bg-slate-100 px-1 py-0.5 text-[10px] text-slate-700">OFF</span>
+                  <span className="inline-flex items-center rounded-md bg-white/15 px-1 py-0.5 text-[10px] text-white">OFF</span>
                 )}
               </div>
             </div>
           </div>
         </div>
-        
-        <Separator />
+
+        <Separator className="border-white/15" />
       </div>
     </header>
   );

--- a/frontend/src/components/InlineBadge.jsx
+++ b/frontend/src/components/InlineBadge.jsx
@@ -1,39 +1,17 @@
 import React from "react";
+import { Chip } from "@/components/Chip";
 
 function InlineBadge({ children, className = "", variant = "solid", ...props }) {
-  const base =
-    "inline-flex items-center justify-center gap-1 rounded-full border px-2 py-0.5 text-center text-xs font-medium";
-  
-  const variants = {
-    solid: "bg-slate-100 border-transparent text-slate-700",
-    outline: "bg-white border-slate-200 text-slate-600",
-    plain: "bg-transparent border-transparent text-slate-500",
+  const variantMap = {
+    solid: "neutral",
+    outline: "outline",
+    plain: "outline",
   };
 
-  const variantClasses = variants[variant] || variants.solid;
-
-  const hasCustomBg = /\bbg-[\w/-]+/.test(className);
-  const hasCustomBorder = /\bborder-[\w/-]+/.test(className);
-  const hasCustomText = /\btext-[\w/-]+/.test(className);
-
-  const pickVariantPart = (pattern) =>
-    (variantClasses.match(pattern) || []).join(" ");
-
-  const composedVariantClasses =
-    hasCustomBg || hasCustomBorder || hasCustomText
-      ? [
-          hasCustomBg ? "" : pickVariantPart(/\bbg-[^\s]+/g),
-          hasCustomBorder ? "" : pickVariantPart(/\bborder-[^\s]+/g),
-          hasCustomText ? "" : pickVariantPart(/\btext-[^\s]+/g),
-        ]
-          .filter(Boolean)
-          .join(" ")
-      : variantClasses;
-  
   return (
-    <span className={`${base} ${composedVariantClasses} ${className}`} {...props}>
+    <Chip variant={variantMap[variant] || "neutral"} className={className} {...props}>
       {children}
-    </span>
+    </Chip>
   );
 }
 

--- a/frontend/src/components/StatusBadge.jsx
+++ b/frontend/src/components/StatusBadge.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import InlineBadge from "@/components/InlineBadge";
+import { Chip } from "@/components/Chip";
 import { normalizeText } from "@/lib/text";
 import { resolveStatusClass } from "@/lib/status";
 
@@ -10,9 +10,9 @@ function StatusBadge({ status }) {
     trimmed === "" || trimmed === "*" || trimmed === "-" || trimmed === "—" ? "—" : trimmed;
   const { variant, className } = resolveStatusClass(status);
   return (
-    <InlineBadge variant={variant} className={className}>
+    <Chip variant={variant} className={className}>
       {displayValue}
-    </InlineBadge>
+    </Chip>
   );
 }
 

--- a/frontend/src/components/ui/card.jsx
+++ b/frontend/src/components/ui/card.jsx
@@ -2,7 +2,15 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 export function Card({ className, ...props }) {
-  return <div className={cn("rounded-2xl border bg-card text-card-foreground shadow-sm", className)} {...props} />;
+  return (
+    <section
+      className={cn(
+        "bg-surface-card rounded-2xl shadow-soft border border-slate-100 p-4 lg:p-5",
+        className,
+      )}
+      {...props}
+    />
+  );
 }
 
 export function CardHeader({ className, ...props }) {

--- a/frontend/src/features/empresas/EmpresasScreen.jsx
+++ b/frontend/src/features/empresas/EmpresasScreen.jsx
@@ -12,7 +12,7 @@ import {
   MiniBadge,
   Kbd,
 } from "@/components/ui/dropdown-menu";
-import InlineBadge from "@/components/InlineBadge";
+import { Chip } from "@/components/Chip";
 import StatusBadge from "@/components/StatusBadge";
 import CopyableIdentifier from "@/components/CopyableIdentifier";
 import { Mail, Phone, Clipboard, ExternalLink, File, Loader2 } from "lucide-react";
@@ -251,7 +251,7 @@ export default function EmpresasScreen({
         <span>
           {filteredEmpresas.length} de {empresas.length} empresas exibidas
         </span>
-        {soAlertas && <InlineBadge variant="outline">Modo alertas ativo</InlineBadge>}
+        {soAlertas && <Chip variant="warning">Modo alertas ativo</Chip>}
       </div>
 
       <div className="grid gap-3 lg:grid-cols-2">
@@ -299,13 +299,13 @@ export default function EmpresasScreen({
           const lastCAE = caeFiles[0];
 
           return (
-            <Card key={empresa.id} className="shadow-sm overflow-hidden border border-white/60">
-              <CardContent className="p-4 space-y-3">
+            <Card key={empresa.id} className="overflow-hidden">
+              <CardContent className="p-0 space-y-3">
                 <div className="flex items-start gap-3">
                   <div className="h-12 w-12 rounded-xl bg-indigo-100 text-indigo-700 font-semibold grid place-items-center">
                     {avatarLabel}
                   </div>
-                  <div className="flex-1 min-w-0">
+                  <div className="flex-1 min-w-0 p-4 pb-0">
                     <div className="flex items-start justify-between gap-2">
                       <div>
                         <h3 className="text-base font-semibold leading-tight text-slate-800">
@@ -324,20 +324,22 @@ export default function EmpresasScreen({
                     </div>
 
                     <div className="mt-2 flex flex-wrap gap-2 text-xs text-slate-600">
-                      <InlineBadge variant="outline" className="bg-white">
-                        Categoria: {empresa.categoria || "—"}
-                      </InlineBadge>
-                      <InlineBadge variant="outline" className="bg-white">
+                      <Chip>Categoria: {empresa.categoria || "—"}</Chip>
+                      <Chip
+                        variant={getStatusKey(empresa.certificado).includes("valido") ? "success" : "danger"}
+                      >
                         Certificado: {empresa.certificado || DEFAULT_CERTIFICADO_SITUACAO}
-                      </InlineBadge>
-                      <InlineBadge variant="outline" className="bg-white">
+                      </Chip>
+                      <Chip
+                        variant={getStatusKey(empresa.debito).includes("sem debit") ? "success" : "neutral"}
+                        size={getStatusKey(empresa.debito).includes("sem debit") ? "md" : "sm"}
+                      >
                         Débito: {empresa.debito}
-                      </InlineBadge>
+                      </Chip>
                       {empresa.responsavelFiscal && (
-                        <InlineBadge variant="outline" className="bg-white">
-                          Resp. fiscal: {empresa.responsavelFiscal}
-                        </InlineBadge>
+                        <Chip>Resp. fiscal: {empresa.responsavelFiscal}</Chip>
                       )}
+                      {empresa.municipio && <Chip>Município: {empresa.municipio}</Chip>}
                     </div>
 
                     <div className="mt-3 grid gap-2 text-xs text-slate-700 sm:grid-cols-2">
@@ -368,27 +370,23 @@ export default function EmpresasScreen({
 
                 <Separator />
 
-                <div className="grid grid-cols-2 gap-3 text-xs">
-                  <div className="rounded-lg border border-emerald-100 bg-emerald-50/70 p-3">
-                    <p className="text-[11px] uppercase text-emerald-600 font-semibold">Licenças</p>
-                    <div className="mt-1 flex items-end gap-2">
-                      <span className="text-2xl font-semibold text-emerald-700">
-                        {licSummary.total}
-                      </span>
-                      <div className="space-y-0.5 text-[11px] text-emerald-700/80">
+                <div className="grid grid-cols-2 gap-3 text-xs px-4 pb-2">
+                  <div className="rounded-xl border border-slate-200 bg-white p-3">
+                    <p className="text-[11px] uppercase text-slate-500 font-semibold">Licenças</p>
+                    <div className="mt-1 flex items-end gap-2 text-slate-800">
+                      <span className="text-2xl font-semibold">{licSummary.total}</span>
+                      <div className="space-y-0.5 text-[11px] text-slate-600">
                         <p>Ativas: {licSummary.ativas}</p>
                         <p>Vencendo: {licSummary.vencendo}</p>
                         <p>Vencidas: {licSummary.vencidas}</p>
                       </div>
                     </div>
                   </div>
-                  <div className="rounded-lg border border-sky-100 bg-sky-50/70 p-3">
-                    <p className="text-[11px] uppercase text-sky-600 font-semibold">Processos</p>
-                    <div className="mt-1 flex items-end gap-2">
-                      <span className="text-2xl font-semibold text-sky-700">
-                        {processosEmpresa.length}
-                      </span>
-                      <div className="space-y-0.5 text-[11px] text-sky-700/80">
+                  <div className="rounded-xl border border-slate-200 bg-white p-3">
+                    <p className="text-[11px] uppercase text-slate-500 font-semibold">Processos</p>
+                    <div className="mt-1 flex items-end gap-2 text-slate-800">
+                      <span className="text-2xl font-semibold">{processosEmpresa.length}</span>
+                      <div className="space-y-0.5 text-[11px] text-slate-600">
                         <p>Ativos: {processosAtivosEmpresa.length}</p>
                         <p>Encerrados: {processosEmpresa.length - processosAtivosEmpresa.length}</p>
                         <p>
@@ -404,7 +402,7 @@ export default function EmpresasScreen({
 
                 <Separator />
 
-                <div className="flex flex-wrap gap-2">
+                <div className="flex flex-wrap gap-2 px-4 pb-4">
                   <Button
                     size="sm"
                     variant="outline"

--- a/frontend/src/features/painel/PainelScreen.jsx
+++ b/frontend/src/features/painel/PainelScreen.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import InlineBadge from "@/components/InlineBadge";
+import { Chip } from "@/components/Chip";
 import StatusBadge from "@/components/StatusBadge";
 import KPI from "@/components/KPI";
 import {
@@ -333,13 +333,13 @@ export default function PainelScreen(props) {
               >
                 <span className="font-medium text-slate-700">{item.label}</span>
                 {item.pass ? (
-                  <InlineBadge className="bg-emerald-100 text-emerald-700 border-emerald-200">
+                  <Chip variant="success">
                     <CheckCircle2 className="h-3.5 w-3.5 mr-1" /> OK
-                  </InlineBadge>
+                  </Chip>
                 ) : (
-                  <InlineBadge className="bg-amber-100 text-amber-700 border-amber-200">
+                  <Chip variant="warning">
                     <AlertTriangle className="h-3.5 w-3.5 mr-1" /> Verificar
-                  </InlineBadge>
+                  </Chip>
                 )}
               </div>
             ))}

--- a/frontend/src/lib/status.js
+++ b/frontend/src/lib/status.js
@@ -107,109 +107,99 @@ export const isAlertStatus = (status) => {
   return ALERT_STATUS_KEYWORDS.some((keyword) => key.includes(keyword));
 };
 
-export const STATUS_VARIANT_CLASSES = {
-  success: "bg-emerald-100 text-emerald-700 border-emerald-200",
-  warning: "bg-amber-100 text-amber-700 border-amber-200",
-  danger: "bg-red-100 text-red-700 border-red-200",
-  info: "bg-sky-100 text-sky-700 border-sky-200",
-  neutral: "bg-slate-200 text-slate-700 border-slate-300",
-  muted: "bg-slate-100 text-slate-600 border-slate-200",
-  plain: "bg-transparent border-transparent text-slate-500",
-};
-
 export const resolveStatusClass = (status) => {
   const normalized = normalizeText(status);
   const trimmed = normalized.trim();
 
   if (trimmed === "" || trimmed === "*" || trimmed === "-" || trimmed === "—") {
-    return { variant: "plain", className: STATUS_VARIANT_CLASSES.plain };
+    return { variant: "outline" };
   }
 
   const key = removeDiacritics(trimmed.toLowerCase());
   const normalizedKey = key.replace(/\s+/g, " ").trim();
 
   if (normalizedKey === "valido") {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: "success" };
   }
 
   if (normalizedKey === "vencido") {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: "danger" };
   }
 
   const fraction = parseProgressFraction(trimmed);
   if (fraction) {
     const { current, total } = fraction;
     if (!Number.isFinite(current) || !Number.isFinite(total) || total <= 0) {
-      return { variant: "solid", className: STATUS_VARIANT_CLASSES.warning };
+      return { variant: "warning" };
     }
     if (current < total) {
-      return { variant: "solid", className: STATUS_VARIANT_CLASSES.warning };
+      return { variant: "warning" };
     }
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: "success" };
   }
 
   if (key.includes("possui debit")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: "danger" };
   }
 
   if (key.includes("sem debit") || key.includes("nao possui debit")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: "success" };
   }
 
   if (key.includes("sujeit")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: "warning" };
   }
 
   if (key.includes("valido")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: "success" };
   }
 
   if (key.includes("vencid")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: "danger" };
   }
 
   if (key.includes("vencend") || key.includes("vence")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.warning };
+    return { variant: "warning" };
   }
 
   if (key === "nao" || key.startsWith("nao ") || key.includes(" nao ")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.muted };
+    return { variant: "neutral" };
   }
 
   if (key.includes("possui")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: "success" };
   }
 
   if (key.includes("pago") && !key.includes("nao")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: "success" };
   }
 
   if (key.includes("em aberto") || key.includes("emaberto") || key.includes("nao pago")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: "danger" };
   }
 
   if (key.includes("indefer") || key.includes("negad")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: "danger" };
   }
 
   if (key.includes("conclu")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: "success" };
   }
 
   if (key.includes("andament") || key.includes("aguard")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.warning };
+    return { variant: "warning" };
   }
 
   if (key.includes("pendent")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.muted };
+    return { variant: "neutral" };
   }
 
   if (key.includes("nao se aplica") || key.includes("n/a")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.info };
+    return { variant: "neutral" };
   }
 
   if (key.includes("dispens") || key.includes("orient") || key.includes("inform") || key.includes("consult")) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.info };
+    return { variant: "neutral" };
   }
 
   if (
@@ -219,7 +209,7 @@ export const resolveStatusClass = (status) => {
     key.includes("bloque") ||
     key.includes("inadimpl")
   ) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.danger };
+    return { variant: "danger" };
   }
 
   if (
@@ -230,10 +220,10 @@ export const resolveStatusClass = (status) => {
     (key.includes("em dia") && !key.includes("irregular")) ||
     (key === "sim" && !key.includes("irregular"))
   ) {
-    return { variant: "solid", className: STATUS_VARIANT_CLASSES.success };
+    return { variant: "success" };
   }
 
-  return { variant: "solid", className: STATUS_VARIANT_CLASSES.neutral };
+  return { variant: "neutral" };
 };
 
 export const isProcessStatusInactive = (status) => {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,6 +6,8 @@ export default {
     './components/**/*.{js,jsx}',
     './app/**/*.{js,jsx}',
     './src/**/*.{js,jsx}',
+    './src/**/*.{ts,tsx}',
+    './index.html',
   ],
   theme: {
     extend: {
@@ -43,11 +45,32 @@ export default {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        brand: {
+          900: "#22489c",
+          700: "#2857b8",
+          600: "#2f66d4",
+          100: "#e3ebff",
+        },
+        surface: {
+          body: "#F5F7FB",
+          card: "#FFFFFF",
+        },
+        status: {
+          success: "#16A34A",
+          warning: "#F97316",
+          danger: "#EF4444",
+          neutral: "#6B7280",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+        xl: "0.75rem",
+        "2xl": "1rem",
+      },
+      boxShadow: {
+        soft: "0 18px 45px rgba(15, 23, 42, 0.06)",
       },
     },
   },


### PR DESCRIPTION
## Summary
- add new brand palette, surface tokens, and softer card styling across the app
- refresh the global layout with a glassy blue header, neutral background, and standardized cards
- introduce a reusable chip component and align badges/status styles on dashboard and company views

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b4d013f48326859254f3734f4523)