### PR TITLE
Fix header background tint and layout surface color

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -583,7 +583,7 @@ function AppContent() {
   );
 
   return (
-    <div className="min-h-screen bg-surface-body text-slate-900">
+    <div className="min-h-screen bg-surface-body bg-[#F5F7FB] text-slate-900">
       <HeaderMenuPro
         tab={tab}
         onTabChange={setTab}

--- a/frontend/src/components/HeaderMenuPro.jsx
+++ b/frontend/src/components/HeaderMenuPro.jsx
@@ -97,7 +97,14 @@ export default function HeaderMenuPro({
   const handleNew = (type) => console.log(`[Novo] criar ${type}`);
 
   return (
-    <header className="fixed inset-x-0 top-0 z-40 border-b border-white/10 bg-brand-900/85 backdrop-blur-xl">
+    <header
+      className="
+        fixed inset-x-0 top-0 z-40
+        border-b border-white/10
+        bg-brand-900 bg-opacity-90
+        backdrop-blur-xl
+      "
+    >
       <div className="max-w-[1400px] mx-auto px-4 lg:px-6">
         {/* Linha 1: marca + busca + ações + perfil */}
         <div className="h-16 flex items-center gap-4">


### PR DESCRIPTION
## Summary
- ensure the fixed header uses the brand background with opacity and blur for the glass effect
- apply the surface body background with fallback on the root layout to keep pages on the light gray backdrop

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939bf4678f88326a5e354a38fbc830b)