### PR TITLE
Adjust header tint and solidify card backgrounds

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -583,7 +583,7 @@ function AppContent() {
   );
 
   return (
-    <div className="min-h-screen bg-surface-body text-slate-900">
+    <div className="min-h-screen bg-surface-body bg-[#F5F7FB] text-slate-900">
       <HeaderMenuPro
         tab={tab}
         onTabChange={setTab}

--- a/frontend/src/components/HeaderMenuPro.jsx
+++ b/frontend/src/components/HeaderMenuPro.jsx
@@ -97,7 +97,14 @@ export default function HeaderMenuPro({
   const handleNew = (type) => console.log(`[Novo] criar ${type}`);
 
   return (
-    <header className="fixed inset-x-0 top-0 z-40 border-b border-white/10 bg-brand-900/85 backdrop-blur-xl">
+    <header
+      className="
+        fixed inset-x-0 top-0 z-40
+        border-b border-white/10
+        bg-[#22489c] bg-opacity-90
+        backdrop-blur-xl
+      "
+    >
       <div className="max-w-[1400px] mx-auto px-4 lg:px-6">
         {/* Linha 1: marca + busca + ações + perfil */}
         <div className="h-16 flex items-center gap-4">

--- a/frontend/src/components/ui/card.jsx
+++ b/frontend/src/components/ui/card.jsx
@@ -5,7 +5,7 @@ export function Card({ className, ...props }) {
   return (
     <section
       className={cn(
-        "bg-surface-card rounded-2xl shadow-soft border border-slate-100 p-4 lg:p-5",
+        "bg-white rounded-2xl shadow-soft border border-slate-100 p-4 lg:p-5",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- set the main header background to the specified translucent dark blue with blur
- ensure all cards use a solid white container with border and shadow via the shared Card component

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939bf4678f88326a5e354a38fbc830b)