### PR TITLE
Expose certificado password in schema

### DIFF
--- a/backend/app/schemas/certificados.py
+++ b/backend/app/schemas/certificados.py
@@ -15,6 +15,7 @@ class CertificadoView(BaseModel):
     org_id: UUID
     empresa: Optional[str] = None
     cnpj: Optional[str] = None
+    senha: Optional[str] = None
     valido_de: Optional[date] = None
     valido_ate: Optional[date] = None
     dias_restantes: Optional[int] = None


### PR DESCRIPTION
## Summary
- add the senha field to CertificadoView so certificate responses include the password

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa9495b288326b43943745efc0050)