### PR TITLE
Ensure certificado password surfaces in frontend

### DIFF
--- a/backend/app/schemas/certificados.py
+++ b/backend/app/schemas/certificados.py
@@ -15,6 +15,7 @@ class CertificadoView(BaseModel):
     org_id: UUID
     empresa: Optional[str] = None
     cnpj: Optional[str] = None
+    senha: Optional[str] = None
     valido_de: Optional[date] = None
     valido_ate: Optional[date] = None
     dias_restantes: Optional[int] = None

--- a/frontend/src/features/certificados/CertificadoCard.jsx
+++ b/frontend/src/features/certificados/CertificadoCard.jsx
@@ -74,7 +74,13 @@ export default function CertificadoCard({ certificado }) {
   const titular = certificado?.titular ?? "";
   const validoDe = extractDateLabel(certificado?.validoDe ?? "");
   const validoAte = extractDateLabel(certificado?.validoAte ?? "");
-  const senha = certificado?.senha ?? "";
+  const senha =
+    certificado?.senha ??
+    certificado?.senha_certificado ??
+    certificado?.senhaCertificado ??
+    certificado?.senha_cert ??
+    certificado?.password ??
+    "";
   const situacao = certificado?.situacao ?? "";
   const cpfCnpj =
     certificado?.cnpj ??

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -425,6 +425,21 @@ export const normalizeCertificadoFromApi = (item) => {
   if (!item || typeof item !== "object") return item;
   const normalized = { ...item };
 
+  // senha
+  if (normalized.senha === undefined) {
+    const senhaCandidates = [
+      normalized.senha_certificado,
+      normalized.senha_cert,
+      normalized.password,
+    ];
+    const firstSenha = senhaCandidates.find(
+      (candidate) => typeof candidate === "string" && candidate.trim() !== "",
+    );
+    if (firstSenha !== undefined) {
+      normalized.senha = firstSenha;
+    }
+  }
+
   // id / cert_id
   const idCandidates = [item.id, item.cert_id, item.certId];
   for (const candidate of idCandidates) {


### PR DESCRIPTION
## Summary
- map password aliases when normalizing certificado responses so the senha field is retained
- update certificado card to display senha using common backend field variants

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa9495b288326b43943745efc0050)