### PR TITLE
Refatora cards de resumo por tipo

### DIFF
--- a/frontend/src/components/ResumoTipoCard.jsx
+++ b/frontend/src/components/ResumoTipoCard.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Chip } from "@/components/Chip";
+
+const baseCardClasses =
+  "flex items-center justify-between gap-4 rounded-2xl border border-slate-100 bg-white shadow-sm px-4 py-3";
+
+const IconBadge = ({ icon: Icon, corClasse }) => (
+  <div
+    className={`flex h-10 w-10 items-center justify-center rounded-2xl ${corClasse} bg-opacity-10 text-opacity-90`}
+  >
+    <Icon className="h-5 w-5" />
+  </div>
+);
+
+export function ResumoTipoCardLicenca({ tipo, total, icon, corClasse, stats }) {
+  return (
+    <div className={baseCardClasses}>
+      <div className="flex items-center gap-3">
+        <IconBadge icon={icon} corClasse={corClasse} />
+        <div>
+          <p className="text-xs font-medium uppercase text-slate-500">{tipo}</p>
+          <p className="text-2xl font-semibold leading-tight text-slate-900">{total}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap justify-end gap-2 text-xs">
+        {stats.possui > 0 && <Chip variant="success">Possui {stats.possui}</Chip>}
+        {stats.ate30d > 0 && <Chip variant="warning">≤ 30d {stats.ate30d}</Chip>}
+        {stats.vencido > 0 && <Chip variant="danger">Vencido {stats.vencido}</Chip>}
+        {stats.sujeito > 0 && <Chip variant="warning">Sujeito {stats.sujeito}</Chip>}
+        {stats.dispensa > 0 && <Chip variant="neutral">Dispensa {stats.dispensa}</Chip>}
+      </div>
+    </div>
+  );
+}
+
+export function ResumoTipoCardTaxa({ tipo, total, icon, corClasse, stats }) {
+  return (
+    <div className={baseCardClasses}>
+      <div className="flex items-center gap-3">
+        <IconBadge icon={icon} corClasse={corClasse} />
+        <div>
+          <p className="text-xs font-medium uppercase text-slate-500">{tipo}</p>
+          <p className="text-2xl font-semibold leading-tight text-slate-900">{total}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap justify-end gap-2 text-xs">
+        {stats.ok > 0 && <Chip variant="success">OK {stats.ok}</Chip>}
+        {stats.alerta > 0 && <Chip variant="warning">Alertas {stats.alerta}</Chip>}
+        {stats.semStatus > 0 && (
+          <Chip variant="neutral">Sem status {stats.semStatus}</Chip>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/licencas/LicencasScreen.jsx
+++ b/frontend/src/features/licencas/LicencasScreen.jsx
@@ -15,22 +15,23 @@ import {
 import StatusBadge from "@/components/StatusBadge";
 import { DEFAULT_LICENCA_TIPOS } from "@/lib/constants";
 import { getStatusKey, hasRelevantStatus, isAlertStatus } from "@/lib/status";
+import { ResumoTipoCardLicenca } from "@/components/ResumoTipoCard";
 import { Droplets, Shield, ClipboardCheck, MapPin, Trees, Settings } from "lucide-react";
 
-const LIC_ICONS = {
-  SANITARIA: <Droplets className="h-4 w-4" />,
-  CERCON: <Shield className="h-4 w-4" />,
-  FUNCIONAMENTO: <ClipboardCheck className="h-4 w-4" />,
-  USO_DO_SOLO: <MapPin className="h-4 w-4" />,
-  AMBIENTAL: <Trees className="h-4 w-4" />,
+const LIC_ICON_COMPONENTS = {
+  SANITARIA: Droplets,
+  CERCON: Shield,
+  FUNCIONAMENTO: ClipboardCheck,
+  USO_DO_SOLO: MapPin,
+  AMBIENTAL: Trees,
 };
 
-const LIC_COLORS = {
-  SANITARIA: "border-sky-500 text-sky-700",
-  CERCON: "border-indigo-500 text-indigo-700",
-  FUNCIONAMENTO: "border-blue-500 text-blue-700",
-  USO_DO_SOLO: "border-amber-500 text-amber-700",
-  AMBIENTAL: "border-emerald-600 text-emerald-700",
+const LIC_ICON_COLORS = {
+  SANITARIA: "bg-sky-100 text-sky-700",
+  CERCON: "bg-indigo-100 text-indigo-700",
+  FUNCIONAMENTO: "bg-blue-100 text-blue-700",
+  USO_DO_SOLO: "bg-amber-100 text-amber-700",
+  AMBIENTAL: "bg-emerald-100 text-emerald-700",
 };
 
 // Rótulos de exibição por tipo normalizado
@@ -349,42 +350,26 @@ export default function LicencasScreen({ licencas, filteredLicencas, modoFoco })
         )
       ) : (
         <>
-          <div className="grid md:grid-cols-2 gap-3 mb-3">
+          <div className="grid gap-3 md:grid-cols-2 mb-3">
             {tiposLicencaStats.map(({ normalized, display, total, venc, soon, subj, disp, poss }) => {
-              const icon = LIC_ICONS[normalized] || <Settings className="h-4 w-4" />;
-              const colorClasses = LIC_COLORS[normalized] || "border-slate-400 text-slate-700";
+              const IconComponent = LIC_ICON_COMPONENTS[normalized] || Settings;
+              const colorClasses = LIC_ICON_COLORS[normalized] || "bg-slate-100 text-slate-700";
 
               return (
-                <Card key={normalized} className="shadow-sm">
-                  <CardContent className={`p-4 rounded-xl border-l-4 ${colorClasses}`}>
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <div className="text-xs text-slate-500">{display}</div>
-                        <div className="text-2xl font-semibold">{total}</div>
-                      </div>
-                      <div className="h-8 w-8 rounded-full bg-white/70 grid place-items-center text-slate-600">
-                        {icon}
-                      </div>
-                    </div>
-                    <div className="mt-3 flex flex-wrap gap-2 text-xs">
-                      <InlineBadge className="bg-emerald-100 text-emerald-700 border-emerald-200">
-                        Possui {poss}
-                      </InlineBadge>
-                      <InlineBadge className="bg-amber-100 text-amber-800 border-amber-200">
-                        ≤30d {soon}
-                      </InlineBadge>
-                      <InlineBadge className="bg-orange-100 text-orange-800 border-orange-200">
-                        Vencido {venc}
-                      </InlineBadge>
-                      <InlineBadge className="bg-red-100 text-red-700 border-red-200">
-                        Sujeito {subj}
-                      </InlineBadge>
-                      <InlineBadge className="bg-indigo-100 text-indigo-700 border-indigo-200">
-                        Dispensa {disp}
-                      </InlineBadge>
-                    </div>
-                  </CardContent>
-                </Card>
+                <ResumoTipoCardLicenca
+                  key={normalized}
+                  tipo={display}
+                  total={total}
+                  icon={IconComponent}
+                  corClasse={colorClasses}
+                  stats={{
+                    possui: poss,
+                    ate30d: soon,
+                    vencido: venc,
+                    sujeito: subj,
+                    dispensa: disp,
+                  }}
+                />
               );
             })}
           </div>
@@ -400,8 +385,8 @@ export default function LicencasScreen({ licencas, filteredLicencas, modoFoco })
                 }
                 return normalizeTipoLicenca(lic?.tipo) === normalized;
               }).length;
-              const icon =
-                normalized === "Todos" ? null : LIC_ICONS[normalized] || <Settings className="h-4 w-4" />;
+              const IconComponent =
+                normalized === "Todos" ? null : LIC_ICON_COMPONENTS[normalized] || Settings;
 
               return (
                 <Button
@@ -411,7 +396,11 @@ export default function LicencasScreen({ licencas, filteredLicencas, modoFoco })
                   onClick={() => setSelectedLicTipo(normalized)}
                   className="inline-flex items-center gap-1"
                 >
-                  {icon && <span className="opacity-80">{icon}</span>}
+                  {IconComponent && (
+                    <span className="opacity-80">
+                      <IconComponent className="h-4 w-4" />
+                    </span>
+                  )}
                   {display}
                   <span className="ml-1 text-xs opacity-70">{count}</span>
                 </Button>
@@ -437,13 +426,15 @@ export default function LicencasScreen({ licencas, filteredLicencas, modoFoco })
                   .filter((lic) => hasRelevantStatus(lic.status))
                   .sort((a, b) => (a?.empresa || "").localeCompare(b?.empresa || ""));
 
-                const icon = LIC_ICONS[tipoNormalized] || <Settings className="h-4 w-4" />;
+                const IconComponent = LIC_ICON_COMPONENTS[tipoNormalized] || Settings;
 
                 return (
                   <Card key={tipoNormalized} className="shadow-sm">
                     <CardHeader className="pb-2">
                       <CardTitle className="text-base flex items-center gap-2">
-                        <span className="opacity-80">{icon}</span>
+                        <span className="opacity-80">
+                          <IconComponent className="h-4 w-4" />
+                        </span>
                         {display}
                         <InlineBadge variant="outline" className="bg-white">
                           {registros.length}

--- a/frontend/src/features/taxas/TaxasScreen.jsx
+++ b/frontend/src/features/taxas/TaxasScreen.jsx
@@ -14,6 +14,20 @@ import {
 } from "@/components/ui/table";
 import { TAXA_ALERT_KEYS, TAXA_COLUMNS, TAXA_SEARCH_KEYS } from "@/lib/constants";
 import { hasRelevantStatus, isAlertStatus } from "@/lib/status";
+import { ResumoTipoCardTaxa } from "@/components/ResumoTipoCard";
+import { Receipt, FileCheck2, BriefcaseBusiness } from "lucide-react";
+
+const TAXA_ICON_COMPONENTS = {
+  tpi: Receipt,
+  taxa_funcionamento: FileCheck2,
+  taxa_publicidade: BriefcaseBusiness,
+};
+
+const TAXA_ICON_COLORS = {
+  tpi: "bg-indigo-100 text-indigo-700",
+  taxa_funcionamento: "bg-blue-100 text-blue-700",
+  taxa_publicidade: "bg-amber-100 text-amber-700",
+};
 
 function TaxasScreen({ taxas, modoFoco, matchesMunicipioFilter, matchesQuery }) {
   const [viewMode, setViewMode] = useState("empresas");
@@ -181,32 +195,25 @@ function TaxasScreen({ taxas, modoFoco, matchesMunicipioFilter, matchesQuery }) 
       ) : (
         <div className="space-y-4">
           <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-            {taxaTipoStats.map((tipo) => (
-              <Card key={tipo.key} className="shadow-sm">
-                <CardContent className="p-4 space-y-2">
-                  <div className="flex items-center justify-between text-sm text-slate-500">
-                    <span className="font-semibold text-slate-700">{tipo.label}</span>
-                    <InlineBadge className="bg-red-100 text-red-700 border-red-200">
-                      Alertas {tipo.alertas}
-                    </InlineBadge>
-                  </div>
-                  <div className="text-2xl font-semibold text-slate-800">
-                    {tipo.total}
-                  </div>
-                  <div className="flex flex-wrap gap-2 text-xs">
-                    <InlineBadge className="bg-emerald-100 text-emerald-700 border-emerald-200">
-                      OK {tipo.ok}
-                    </InlineBadge>
-                    <InlineBadge className="bg-red-100 text-red-700 border-red-200">
-                      Alertas {tipo.alertas}
-                    </InlineBadge>
-                    <InlineBadge className="bg-slate-100 text-slate-700 border-slate-200">
-                      Sem status {tipo.semStatus}
-                    </InlineBadge>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
+            {taxaTipoStats.map((tipo) => {
+              const IconComponent = TAXA_ICON_COMPONENTS[tipo.key] || Receipt;
+              const colorClasses = TAXA_ICON_COLORS[tipo.key] || "bg-slate-100 text-slate-700";
+
+              return (
+                <ResumoTipoCardTaxa
+                  key={tipo.key}
+                  tipo={tipo.label}
+                  total={tipo.total}
+                  icon={IconComponent}
+                  corClasse={colorClasses}
+                  stats={{
+                    ok: tipo.ok,
+                    alerta: tipo.alertas,
+                    semStatus: tipo.semStatus,
+                  }}
+                />
+              );
+            })}
           </div>
 
           <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- cria componente reutilizável de resumo por tipo com layout compacto de KPI
- aplica o novo card às visões "Por tipo" de Licenças e Taxas, mantendo os chips apenas com valores

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ab2987fb88326a5568b19866d7e07)