### PR TITLE
Refine Taxas por empresa card layout

### DIFF
--- a/frontend/src/features/taxas/TaxasScreen.jsx
+++ b/frontend/src/features/taxas/TaxasScreen.jsx
@@ -16,6 +16,7 @@ import { TAXA_ALERT_KEYS, TAXA_COLUMNS, TAXA_SEARCH_KEYS } from "@/lib/constants
 import { hasRelevantStatus, isAlertStatus } from "@/lib/status";
 import { ResumoTipoCardTaxa } from "@/components/ResumoTipoCard";
 import { Receipt, FileCheck2, BriefcaseBusiness } from "lucide-react";
+import { Chip } from "@/components/Chip";
 
 const TAXA_ICON_COMPONENTS = {
   tpi: Receipt,
@@ -28,6 +29,36 @@ const TAXA_ICON_COLORS = {
   taxa_funcionamento: "bg-blue-100 text-blue-700",
   taxa_publicidade: "bg-amber-100 text-amber-700",
 };
+
+function LinhaTipoTaxa({ tipo, status }) {
+  const normalized = String(status || "").toLowerCase();
+
+  let variant = "neutral";
+
+  if (normalized.startsWith("em aberto")) {
+    variant = "danger";
+  } else if (normalized === "pago") {
+    variant = "success";
+  } else if (normalized === "isento" || normalized === "sem status") {
+    variant = "neutral";
+  } else if (normalized.includes("alerta")) {
+    variant = "warning";
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 py-1.5 border-b last:border-0 border-slate-100">
+      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+        {tipo}
+      </span>
+
+      {status && (
+        <Chip variant={variant} className="text-xs">
+          {status}
+        </Chip>
+      )}
+    </div>
+  );
+}
 
 function TaxasScreen({ taxas, modoFoco, matchesMunicipioFilter, matchesQuery }) {
   const [viewMode, setViewMode] = useState("empresas");
@@ -145,49 +176,39 @@ function TaxasScreen({ taxas, modoFoco, matchesMunicipioFilter, matchesQuery }) 
           ) : (
             <div className="grid gap-3 lg:grid-cols-2">
               {taxasVisiveis.map((taxa, index) => (
-                <Card
+                <div
                   key={`${taxa.empresa_id ?? taxa.empresa}-${index}`}
-                  className="shadow-sm overflow-hidden border border-white/60"
+                  className="rounded-2xl border border-slate-100 bg-white shadow-sm p-4 lg:p-5"
                 >
-                  <CardContent className="p-4 space-y-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="space-y-2 min-w-0">
-                        <h3 className="text-base font-semibold leading-tight text-slate-800 truncate">
-                          {taxa.empresa || "—"}
-                        </h3>
-                        <div className="flex flex-wrap gap-2 text-xs text-slate-600">
-                          {taxa.cnpj && (
-                            <InlineBadge variant="outline" className="bg-white">
-                              CNPJ: {taxa.cnpj}
-                            </InlineBadge>
-                          )}
-                          {taxa.municipio && (
-                            <InlineBadge variant="outline" className="bg-white">
-                              Município: {taxa.municipio}
-                            </InlineBadge>
-                          )}
-                          {taxa.data_envio && (
-                            <InlineBadge variant="outline" className="bg-white">
-                              Último envio: {taxa.data_envio}
-                            </InlineBadge>
-                          )}
-                        </div>
+                  <div className="flex items-start justify-between gap-3 mb-3">
+                    <div className="space-y-1">
+                      <h3 className="text-sm font-semibold text-slate-900">
+                        {taxa.empresa || "—"}
+                      </h3>
+                      <div className="flex flex-wrap gap-1.5 text-xs">
+                        {taxa.cnpj && <Chip>CNPJ: {taxa.cnpj}</Chip>}
                       </div>
-                      <StatusBadge status={taxa.status_geral} />
                     </div>
+                    {taxa.status_geral && (
+                      <Chip variant="success" className="text-[11px] whitespace-nowrap">
+                        {taxa.status_geral}
+                      </Chip>
+                    )}
+                  </div>
 
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      {taxaTipos.map(({ key, label }) => (
-                        <div key={key} className="space-y-1">
-                          <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-                            {label}
-                          </p>
-                          <StatusBadge status={taxa?.[key]} />
-                        </div>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
+                  <div className="mt-1">
+                    <LinhaTipoTaxa tipo="TPI" status={taxa.tpi} />
+                    <LinhaTipoTaxa tipo="PUBLICIDADE" status={taxa.publicidade} />
+                    <LinhaTipoTaxa
+                      tipo="LOCALIZAÇÃO/INSTALAÇÃO"
+                      status={taxa.localizacao_instalacao}
+                    />
+                    <LinhaTipoTaxa tipo="BOMBEIROS" status={taxa.bombeiros} />
+                    <LinhaTipoTaxa tipo="FUNCIONAMENTO" status={taxa.func} />
+                    <LinhaTipoTaxa tipo="SANITÁRIA" status={taxa.sanitaria} />
+                    <LinhaTipoTaxa tipo="ÁREA PÚBLICA" status={taxa.area_publica} />
+                  </div>
+                </div>
               ))}
             </div>
           )}


### PR DESCRIPTION
## Summary
- add LinhaTipoTaxa helper to render tax rows with consistent chip variants
- restyle company cards in Taxas/Por empresa with compact header and status chips
- display each tax type as a single line for reduced card height

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac3dd67688326af7cf2a227022850)