### PR TITLE
Refatorar ingestão de certificados para pipeline oficial

### DIFF
--- a/SCRIPTS/Certificados/executar_certificados_novo.ps1
+++ b/SCRIPTS/Certificados/executar_certificados_novo.ps1
@@ -1,0 +1,49 @@
+# Orquestrador para ingestão direta de certificados usando o pipeline oficial em Python
+
+$ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$EnvFile = Join-Path $ScriptRoot "..\backend\.env"
+
+if (-not (Test-Path $EnvFile)) {
+    Write-Host "Arquivo .env não encontrado em $EnvFile" -ForegroundColor Red
+    exit 1
+}
+
+# Carrega variáveis do .env
+Get-Content $EnvFile | ForEach-Object {
+    if ($_ -match '^\s*#' -or $_ -match '^\s*$') { return }
+    $parts = $_ -split '=', 2
+    if ($parts.Length -eq 2) {
+        $name = $parts[0].Trim()
+        $value = $parts[1].Trim()
+        [Environment]::SetEnvironmentVariable($name, $value)
+    }
+}
+
+$BackendRoot = Split-Path $EnvFile -Parent
+$ScriptIngest = Join-Path $BackendRoot "scripts\certificates_orchestrate.py"
+
+# Determina o Python a ser usado
+$VenvPython = Join-Path $BackendRoot ".venv\Scripts\python.exe"
+if (Test-Path $VenvPython) {
+    $PythonPath = $VenvPython
+} else {
+    $PythonPath = "python"
+}
+
+Write-Host "`n=== INGERINDO CERTIFICADOS DIRETO NO BANCO ===" -ForegroundColor Cyan
+Write-Host ""
+
+& "$PythonPath" "$ScriptIngest"
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -ne 0) {
+    $errIcon = "[!]"
+    Write-Host "`n$errIcon Script Python finalizou com erro (código $exitCode)." -ForegroundColor Red
+    Write-Host "`nDicas:" -ForegroundColor Yellow
+    Write-Host "  - Verifique se a venv e dependências estão corretas" -ForegroundColor Yellow
+    Write-Host "  - Teste a conexão com o banco manualmente" -ForegroundColor Yellow
+    Write-Host "  - Verifique os logs acima para detalhes do erro`n" -ForegroundColor Yellow
+    exit $exitCode
+}
+
+Write-Host "`nCertificados ingeridos com sucesso pelo pipeline Python oficial." -ForegroundColor Green

--- a/SCRIPTS/Certificados/extrair_certificados_json.ps1
+++ b/SCRIPTS/Certificados/extrair_certificados_json.ps1
@@ -1,0 +1,5 @@
+# LEGADO/DEV: script apenas para gerar certificados.json para inspeção manual.
+# O pipeline oficial do portal NÃO usa mais este arquivo diretamente.
+
+Write-Host "Gerador legado de certificados.json não está mais suportado pelo fluxo principal." -ForegroundColor Yellow
+Write-Host "Use certificates_orchestrate.py para ingerir certificados diretamente no banco." -ForegroundColor Yellow

--- a/backend/app/api/v1/endpoints/certificados.py
+++ b/backend/app/api/v1/endpoints/certificados.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import os
 from typing import Dict
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.api.v1.endpoints.utils import (
@@ -11,8 +12,10 @@ from app.api.v1.endpoints.utils import (
     paginate_query,
     resolve_sort,
 )
+from app.db.session import SessionLocal
 from app.deps.auth import Role, User, db_with_org, require_role
 from app.schemas.certificados import CertificadoListResponse
+from app.services.certificados_ingest import ingest_certificados
 
 router = APIRouter(prefix="/certificados", tags=["Certificados"])
 
@@ -49,3 +52,26 @@ def listar_certificados(
     sort_column, direction = resolve_sort(sort, ALLOWED_SORTS, "valido_ate")
     data = paginate_query(db, base_query, params, sort_column, direction, page, size)
     return CertificadoListResponse(**data)
+
+
+@router.post("/ingest", status_code=202)
+def ingest_certificados_endpoint(
+    background_tasks: BackgroundTasks,
+    current_user: User = Depends(require_role(Role.ADMIN)),
+):
+    """Agenda a ingestão de certificados diretamente do diretório padrão."""
+
+    def job() -> None:
+        db = SessionLocal()
+        try:
+            cert_dir = os.getenv("CERTIFICADOS_DIR", r"G:\\CERTIFICADOS DIGITAIS")
+            ingest_certificados(cert_dir, str(current_user.org_id), db)
+            db.commit()
+        except Exception:  # noqa: BLE001
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    background_tasks.add_task(job)
+    return {"message": "Ingestão de certificados agendada"}

--- a/backend/app/services/certificados_ingest.py
+++ b/backend/app/services/certificados_ingest.py
@@ -10,6 +10,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.serialization.pkcs12 import (
     load_key_and_certificates,
 )
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.models.certificados import Certificado
@@ -108,15 +109,98 @@ def _iter_certificados(certificados_dir: str) -> Iterable[tuple[str, str]]:
             yield os.path.join(root, filename), password
 
 
+def cleanup_certificados_antigos(org_id: str, db_session: Session) -> int:
+    """Remove certificados antigos/duplicados seguindo a regra do script legado."""
+
+    removed = 0
+
+    duplicate_serials = (
+        db_session.query(Certificado.serial)
+        .filter(Certificado.org_id == org_id, Certificado.serial.isnot(None))
+        .group_by(Certificado.serial)
+        .having(func.count(Certificado.id) > 1)
+        .all()
+    )
+
+    for (serial,) in duplicate_serials:
+        certificados = (
+            db_session.query(Certificado)
+            .filter(Certificado.org_id == org_id, Certificado.serial == serial)
+            .order_by(
+                Certificado.valido_ate.desc(),
+                Certificado.valido_de.desc(),
+                Certificado.id.desc(),
+            )
+            .all()
+        )
+        for certificado in certificados[1:]:
+            logger.info(
+                "Removendo duplicata por serial: serial=%s org_id=%s id=%s",
+                serial,
+                org_id,
+                certificado.id,
+            )
+            db_session.delete(certificado)
+            removed += 1
+
+    duplicate_empresas = (
+        db_session.query(Certificado.empresa_id)
+        .filter(
+            Certificado.org_id == org_id,
+            Certificado.empresa_id.isnot(None),
+        )
+        .group_by(Certificado.empresa_id)
+        .having(func.count(Certificado.id) > 1)
+        .all()
+    )
+
+    for (empresa_id,) in duplicate_empresas:
+        certificados = (
+            db_session.query(Certificado)
+            .filter(
+                Certificado.org_id == org_id,
+                Certificado.empresa_id == empresa_id,
+            )
+            .order_by(
+                Certificado.valido_ate.desc(),
+                Certificado.valido_de.desc(),
+                Certificado.id.desc(),
+            )
+            .all()
+        )
+        for certificado in certificados[1:]:
+            logger.info(
+                "Removendo duplicata por empresa: empresa_id=%s org_id=%s id=%s",
+                empresa_id,
+                org_id,
+                certificado.id,
+            )
+            db_session.delete(certificado)
+            removed += 1
+
+    if removed:
+        db_session.commit()
+        logger.info("%s certificados antigos/duplicados removidos", removed)
+    else:
+        logger.info("Nenhum certificado duplicado identificado para limpeza")
+
+    return removed
+
+
 def ingest_certificados(certificados_dir: str, org_id: str, db_session: Session) -> int:
     """Percorre o diretório informado e realiza o *upsert* dos certificados."""
 
+    logger.info("Iniciando ingestão de certificados no diretório %s", certificados_dir)
+    removed = cleanup_certificados_antigos(org_id, db_session)
+
     processed = 0
+    failed = 0
     for cert_path, password in _iter_certificados(certificados_dir):
         try:
             cert_data = extract_cert_info(cert_path, password)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Falha ao ler certificado %s: %s", cert_path, exc)
+            failed += 1
             continue
 
         cert_info: Dict[str, object] = {
@@ -128,4 +212,10 @@ def ingest_certificados(certificados_dir: str, org_id: str, db_session: Session)
         upsert_certificado(cert_info, db_session)
         processed += 1
 
+    logger.info(
+        "Ingestão finalizada. Processados: %s | Falhas: %s | Limpeza prévia: %s",
+        processed,
+        failed,
+        removed,
+    )
     return processed

--- a/backend/scripts/certificates_orchestrate.py
+++ b/backend/scripts/certificates_orchestrate.py
@@ -1,0 +1,91 @@
+"""CLI de orquestração da ingestão de certificados (.pfx) para o banco."""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+# Adiciona backend ao PYTHONPATH para importações funcionarem em execução direta
+backend_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(backend_dir))
+
+# Carrega .env antes de importar configurações
+from dotenv import load_dotenv
+
+env_path = backend_dir / ".env"
+if env_path.exists():
+    load_dotenv(dotenv_path=env_path)
+
+from app.db.session import SessionLocal
+from app.services.certificados_ingest import ingest_certificados
+
+logger = logging.getLogger(__name__)
+
+
+def get_session() -> Session:
+    return SessionLocal()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Ingestão de certificados digitais (.pfx) no banco"
+    )
+    parser.add_argument(
+        "--org-id",
+        dest="org_id",
+        default=os.getenv("ECONTROLE_ORG_ID"),
+        help="UUID da organização (ou defina ECONTROLE_ORG_ID no ambiente)",
+    )
+    parser.add_argument(
+        "--cert-dir",
+        dest="cert_dir",
+        default=os.getenv("CERTIFICADOS_DIR", r"G:\\CERTIFICADOS DIGITAIS"),
+        help="Diretório raiz onde estão os arquivos .pfx dos certificados",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    args = parse_args()
+
+    if not args.org_id:
+        logger.error(
+            "ORG_ID não informado. Use --org-id ou defina ECONTROLE_ORG_ID no ambiente."
+        )
+        return 1
+
+    cert_dir = args.cert_dir
+    if not os.path.isdir(cert_dir):
+        logger.error(f"Diretório de certificados não encontrado: {cert_dir}")
+        return 1
+
+    logger.info("Iniciando ingestão de certificados")
+    logger.info("Org ID: %s", args.org_id)
+    logger.info("Diretório: %s", cert_dir)
+
+    session: Session = get_session()
+    try:
+        processed = ingest_certificados(cert_dir, args.org_id, session)
+        session.commit()
+    except Exception:  # noqa: BLE001
+        logger.exception("Erro durante a ingestão de certificados")
+        session.rollback()
+        return 1
+    finally:
+        session.close()
+
+    logger.info("Ingestão concluída. Certificados processados: %s", processed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/ingest_certificados_from_json.py
+++ b/backend/scripts/ingest_certificados_from_json.py
@@ -1,0 +1,51 @@
+"""LEGADO: Script de ingestão de certificados a partir de JSON.
+
+Mantido apenas para debug/migrações pontuais. O pipeline oficial
+deve usar app.services.certificados_ingest + certificates_orchestrate.py.
+"""
+# ⚠️ NÃO USE ESTE SCRIPT NO FLUXO PRINCIPAL (S4).
+# Use backend/scripts/certificates_orchestrate.py em vez disso.
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    logger.warning(
+        "Este script é legado e não deve ser usado no fluxo principal. "
+        "Execute certificates_orchestrate.py para a ingestão oficial."
+    )
+
+    json_path = Path(os.getenv("CERTIFICADOS_JSON", r"G:\\CERTIFICADOS DIGITAIS\certificados.json"))
+    if not json_path.exists():
+        logger.error("Arquivo JSON não encontrado: %s", json_path)
+        return 1
+
+    try:
+        raw = json_path.read_text(encoding="utf-8")
+        data: Any = json.loads(raw)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Falha ao ler certificados do JSON legado: %s", exc)
+        return 1
+
+    logger.info(
+        "JSON carregado apenas para inspeção (sem persistir). Registros encontrados: %s",
+        len(data) if isinstance(data, list) else "desconhecido",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add duplicate cleanup and richer logging to the certificate ingestion service, plus a background ingestion endpoint
- introduce a Python CLI orchestrator and mark the old JSON-based ingestion as legacy
- update PowerShell scripts to call the new pipeline and document the legacy extractor script

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c0bb6f62083268f84f19af72e83c4)