### PR TITLE
Improve certificate ingestion deduplication

### DIFF
--- a/backend/app/services/certificados_ingest.py
+++ b/backend/app/services/certificados_ingest.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.serialization.pkcs12 import (
     load_key_and_certificates,
 )
-from sqlalchemy import func, text
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
 from app.models.certificados import Certificado
@@ -19,7 +19,15 @@ from app.models.certificados import Certificado
 logger = logging.getLogger(__name__)
 
 
-def extract_cert_info(cert_path: str, password: str) -> Dict[str, object]:
+def _dotnet_serial_from_int(serial_number: int) -> str:
+    hex_str = f"{serial_number:x}"
+    if len(hex_str) % 2 == 1:
+        hex_str = "0" + hex_str
+    b = bytes.fromhex(hex_str)
+    return b[::-1].hex().upper()
+
+
+def extract_cert_info(cert_path: str, password: str | None) -> Dict[str, object]:
     """Extrai informações principais de um arquivo ``.pfx``."""
 
     with open(cert_path, "rb") as cert_file:
@@ -34,8 +42,8 @@ def extract_cert_info(cert_path: str, password: str) -> Dict[str, object]:
     issuer = certificate.issuer.rfc4514_string()
     valid_from = certificate.not_valid_before.date()
     valid_until = certificate.not_valid_after.date()
-    thumbprint = certificate.fingerprint(hashes.SHA1()).hex()
-    serial = hex(certificate.serial_number)[2:].upper()
+    thumbprint = certificate.fingerprint(hashes.SHA1()).hex().upper()
+    serial = _dotnet_serial_from_int(certificate.serial_number)
 
     return {
         "subject": subject,
@@ -48,51 +56,35 @@ def extract_cert_info(cert_path: str, password: str) -> Dict[str, object]:
 
 
 def upsert_certificado(cert_info: Dict[str, object], db_session: Session) -> Certificado:
-    """
-    Atualiza ou insere um certificado.
-
-    Regra:
-      1) tenta por (org_id, serial)
-      2) se não achar por serial e houver empresa_id, substitui o certificado "ativo" da empresa
-         (mantém 1 registro por empresa, como o ingest legado via JSON)
-      3) senão, insere novo
-    """
+    """Atualiza ou insere um certificado priorizando serial ou thumbprint."""
 
     org_id = cert_info["org_id"]
     serial = cert_info["serial"]
+    sha1 = cert_info["thumbprint"]
     empresa_id = cert_info.get("empresa_id")
 
-    certificado = (
+    certificados = (
         db_session.query(Certificado)
         .filter(
-            Certificado.serial == serial,
             Certificado.org_id == org_id,
+            or_(Certificado.serial == serial, Certificado.sha1 == sha1),
         )
-        .first()
+        .order_by(
+            Certificado.valido_ate.desc(),
+            Certificado.valido_de.desc(),
+            Certificado.id.desc(),
+        )
+        .all()
     )
 
-    # Se não achou pelo serial e temos empresa_id, tenta substituir o certificado existente da empresa
-    if not certificado and empresa_id:
-        certificado = (
-            db_session.query(Certificado)
-            .filter(
-                Certificado.org_id == org_id,
-                Certificado.empresa_id == empresa_id,
-            )
-            .order_by(
-                Certificado.valido_ate.desc(),
-                Certificado.valido_de.desc(),
-                Certificado.id.desc(),
-            )
-            .first()
-        )
-        if certificado:
+    certificado = certificados[0] if certificados else None
+    if len(certificados) > 1:
+        for dup in certificados[1:]:
             logger.info(
-                "Substituindo certificado por empresa (serial novo): empresa_id=%s org_id=%s serial=%s",
-                empresa_id,
-                org_id,
-                serial,
+                "Removendo duplicata por serial/sha1: org_id=%s id=%s", org_id, dup.id
             )
+            db_session.delete(dup)
+        db_session.flush()
 
     if certificado:
         logger.info(
@@ -100,17 +92,16 @@ def upsert_certificado(cert_info: Dict[str, object], db_session: Session) -> Cer
             serial,
             org_id,
         )
-        # Atualiza TUDO (inclusive empresa_id/arquivo/caminho), para ficar idêntico ao comportamento do JSON ingest
         certificado.org_id = org_id
         certificado.empresa_id = empresa_id
         certificado.arquivo = os.path.basename(cert_info["path"])
         certificado.caminho = cert_info["path"]
         certificado.serial = serial
+        certificado.sha1 = sha1
         certificado.subject = cert_info["subject"]
         certificado.issuer = cert_info["issuer"]
         certificado.valido_de = cert_info["valid_from"]
         certificado.valido_ate = cert_info["valid_until"]
-        certificado.sha1 = cert_info["thumbprint"]
         certificado.senha = cert_info.get("senha")
     else:
         logger.info(
@@ -124,7 +115,7 @@ def upsert_certificado(cert_info: Dict[str, object], db_session: Session) -> Cer
             arquivo=os.path.basename(cert_info["path"]),
             caminho=cert_info["path"],
             serial=serial,
-            sha1=cert_info["thumbprint"],
+            sha1=sha1,
             subject=cert_info["subject"],
             issuer=cert_info["issuer"],
             valido_de=cert_info["valid_from"],
@@ -133,49 +124,14 @@ def upsert_certificado(cert_info: Dict[str, object], db_session: Session) -> Cer
         )
         db_session.add(certificado)
 
-    # Garante que ficou apenas 1 por empresa_id (remove duplicados antigos)
-    db_session.flush()  # garante id
-    if empresa_id and certificado.id:
-        duplicados = (
-            db_session.query(Certificado)
-            .filter(
-                Certificado.org_id == org_id,
-                Certificado.empresa_id == empresa_id,
-                Certificado.id != certificado.id,
-            )
-            .all()
-        )
-        for dup in duplicados:
-            logger.info(
-                "Removendo duplicata por empresa após upsert: empresa_id=%s org_id=%s id=%s",
-                empresa_id,
-                org_id,
-                dup.id,
-            )
-            db_session.delete(dup)
-
     db_session.commit()
     db_session.refresh(certificado)
     return certificado
 
 
-def _iter_certificados(
-    certificados_dir: str, recursive: bool = True
-) -> Iterable[tuple[str, str]]:
-    """
-    Percorre o diretório (recursivamente por padrão) retornando caminhos de ``.pfx``
-    e senhas extraídas do nome do arquivo.
-    """
-    if recursive:
-        for root, _, files in os.walk(certificados_dir):
-            for filename in files:
-                if not filename.lower().endswith(".pfx"):
-                    continue
-                password = _extract_password_from_filename(filename)
-                yield os.path.join(root, filename), password
-        return
+def _iter_certificados(certificados_dir: str) -> Iterable[tuple[str, str | None]]:
+    """Percorre somente a raiz do diretório retornando caminhos de ``.pfx``."""
 
-    # Não-recursivo (somente raiz)
     try:
         with os.scandir(certificados_dir) as it:
             for entry in it:
@@ -185,90 +141,12 @@ def _iter_certificados(
                 if not filename.lower().endswith(".pfx"):
                     continue
                 password = _extract_password_from_filename(filename)
-                yield entry.path, password
+                yield entry.path, password or None
     except FileNotFoundError:
         logger.warning("Diretório de certificados não encontrado: %s", certificados_dir)
 
 
 def _extract_password_from_filename(filename: str) -> str:
-    # aceita "Senha xxxxxx.pfx" e "senha xxxxxx.pfx"
-    m = re.search(r"senha\s*(.+?)\.pfx$", filename, flags=re.IGNORECASE)
-    return m.group(1).strip() if m else ""
-
-
-def cleanup_certificados_antigos(org_id: str, db_session: Session) -> int:
-    """Remove certificados antigos/duplicados seguindo a regra do script legado."""
-
-    # Apenas para log de referência (evita NameError visto em execuções legadas)
-    duplicados_previos = (
-        db_session.query(func.count())
-        .filter(Certificado.org_id == org_id, Certificado.empresa_id.isnot(None))
-        .group_by(Certificado.empresa_id)
-        .having(func.count(Certificado.id) > 1)
-    ).count()
-    if duplicados_previos:
-        logger.info(
-            "Identificados %s grupos de certificados duplicados antes da limpeza",
-            duplicados_previos,
-        )
-
-    remove_por_serial = text(
-        """
-        WITH ranked AS (
-          SELECT
-            id,
-            org_id,
-            serial,
-            ROW_NUMBER() OVER (
-              PARTITION BY org_id, serial
-              ORDER BY valido_ate DESC NULLS LAST, valido_de DESC NULLS LAST, id DESC
-            ) AS rn
-          FROM certificados
-          WHERE serial IS NOT NULL AND org_id = :org_id
-        )
-        DELETE FROM certificados c
-        USING ranked r
-        WHERE c.id = r.id
-          AND r.rn > 1;
-        """
-    )
-
-    remove_por_empresa = text(
-        """
-        WITH ranked AS (
-          SELECT
-            id,
-            org_id,
-            empresa_id,
-            ROW_NUMBER() OVER (
-              PARTITION BY org_id, empresa_id
-              ORDER BY valido_ate DESC NULLS LAST, valido_de DESC NULLS LAST, id DESC
-            ) AS rn
-          FROM certificados
-          WHERE empresa_id IS NOT NULL AND org_id = :org_id
-        )
-        DELETE FROM certificados c
-        USING ranked r
-        WHERE c.id = r.id
-          AND r.rn > 1;
-        """
-    )
-
-    removidos_serial = db_session.execute(remove_por_serial, {"org_id": org_id}).rowcount
-    removidos_empresa = db_session.execute(remove_por_empresa, {"org_id": org_id}).rowcount
-
-    removed = (removidos_serial or 0) + (removidos_empresa or 0)
-    if removed:
-        db_session.commit()
-        logger.info("%s certificados antigos/duplicados removidos", removed)
-    else:
-        logger.info("Nenhum certificado duplicado identificado para limpeza")
-
-    return removed
-
-
-def _extract_password_from_filename(filename: str) -> str:
-    # aceita "Senha xxxxxx.pfx" e "senha xxxxxx.pfx"
     m = re.search(r"senha\s*(.+?)\.pfx$", filename, flags=re.IGNORECASE)
     return m.group(1).strip() if m else ""
 
@@ -351,17 +229,29 @@ def cleanup_certificados_antigos(org_id: str, db_session: Session) -> int:
     return removed
 
 
-def ingest_certificados(
-    certificados_dir: str, org_id: str, db_session: Session, recursive: bool = False
-) -> int:
+def prune_missing_by_arquivo(org_id: str, keep_arquivos: set[str], db_session: Session) -> int:
+    """Remove certificados do org que não existem na pasta de origem."""
+
+    query = db_session.query(Certificado).filter(Certificado.org_id == org_id)
+    if keep_arquivos:
+        query = query.filter(Certificado.arquivo.notin_(keep_arquivos))
+    removidos = query.delete(synchronize_session=False)
+    db_session.commit()
+    return removidos
+
+
+def ingest_certificados(certificados_dir: str, org_id: str, db_session: Session) -> int:
     """Percorre o diretório informado e realiza o *upsert* dos certificados."""
 
     logger.info("Iniciando ingestão de certificados no diretório %s", certificados_dir)
     removed = cleanup_certificados_antigos(org_id, db_session)
 
+    items = list(_iter_certificados(certificados_dir))
+    keep_arquivos = {os.path.basename(path) for path, _ in items}
+
     processed = 0
     failed = 0
-    for cert_path, password in _iter_certificados(certificados_dir, recursive=True):
+    for cert_path, password in items:
         try:
             cert_data = extract_cert_info(cert_path, password)
         except Exception as exc:  # noqa: BLE001
@@ -378,10 +268,13 @@ def ingest_certificados(
         upsert_certificado(cert_info, db_session)
         processed += 1
 
+    pruned = prune_missing_by_arquivo(org_id, keep_arquivos, db_session)
+
     logger.info(
-        "Ingestão finalizada. Processados: %s | Falhas: %s | Limpeza prévia: %s",
+        "Ingestão finalizada. Processados: %s | Falhas: %s | Limpeza prévia: %s | Removidos por sync: %s",
         processed,
         failed,
         removed,
+        pruned,
     )
     return processed


### PR DESCRIPTION
## Summary
- normalize certificate serials and thumbprints to match .NET ingestion format
- restrict ingestion to root-level .pfx files and improve upsert deduplication
- prune database records missing from the source directory during ingestion

## Testing
- python -m compileall backend/app/services/certificados_ingest.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c48f14a2083268c8a15c9257fc18f)