### PR TITLE
Add Redis-backed worker queue and filesystem watchers

### DIFF
--- a/README_worker.md
+++ b/README_worker.md
@@ -1,0 +1,86 @@
+# Worker e watchers (S4.3)
+
+Este documento resume como operar o stack de fila/watchers/worker.
+
+## Dependências
+- Redis (URL configurável via `REDIS_URL`, padrão `redis://localhost:6379/0`).
+- Python com dependências do backend (`rq`, `redis`, `watchdog`).
+
+## Iniciando o Redis localmente
+
+```bash
+# Via Docker
+docker run --name redis-econtrole -p 6379:6379 -d redis:7
+
+# Ou via podman
+podman run --name redis-econtrole -p 6379:6379 -d docker.io/redis:7
+```
+
+## Executando o worker RQ
+
+```bash
+cd backend
+python -m app.worker.worker_main
+```
+
+O worker registra os jobs disponíveis e inicia o consumo da fila configurada
+(`RQ_QUEUE_NAME`, padrão `econtrole`).
+
+## Iniciando os watchers
+
+```bash
+cd backend
+python - <<'PY'
+from app.worker.watchers import start_certificados_watcher, start_licencas_watcher
+
+# Ajuste caminhos e org_id conforme o ambiente
+start_certificados_watcher(
+    org_id="${ORG_ID_DEFAULT}",
+    certificados_root=r"${CERTIFICADOS_ROOT}",
+)
+PY
+```
+
+Para licenças:
+
+```bash
+cd backend
+python - <<'PY'
+from app.worker.watchers import start_licencas_watcher
+
+start_licencas_watcher(
+    org_id="${ORG_ID_DEFAULT}",
+    licencas_root=r"${LICENCAS_ROOT}",
+)
+PY
+```
+
+Variáveis úteis:
+- `CERTIFICADOS_ROOT` (alias de `ECONTROLE_CERTIFICADOS_DIR`).
+- `LICENCAS_ROOT` (alias de `EMPRESAS_ROOT_DIR`).
+- `ORG_ID_DEFAULT` (org padrão para ambientes single-org).
+- `WATCHER_DEBOUNCE_SECONDS` (padrão 3s).
+- `WATCHER_MAX_EVENTS_PER_MINUTE` (rate limit opcional).
+
+## Testando via API (fila)
+
+Certificados:
+```bash
+curl -X POST http://localhost:8000/api/v1/certificados/ingest \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json"
+```
+
+Licenças:
+```bash
+curl -X POST "http://localhost:8000/api/v1/licencas/ingest-from-fs" \
+  -H "Authorization: Bearer <token>"
+```
+
+Status do worker:
+```bash
+curl -H "Authorization: Bearer <token>" http://localhost:8000/api/v1/worker/health
+curl -H "Authorization: Bearer <token>" http://localhost:8000/api/v1/worker/jobs/<job_id>
+```
+
+Os endpoints retornam `job_id` para acompanhamento.

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -14,6 +14,7 @@ from app.api.v1.endpoints import (
     processos,
     taxas,
     uteis,
+    worker,
 )
 
 api_router = APIRouter(prefix="/api/v1")
@@ -29,3 +30,4 @@ api_router.include_router(cnds.router)
 api_router.include_router(municipios.router)
 api_router.include_router(uteis.router)
 api_router.include_router(agendamentos.router)
+api_router.include_router(worker.router)

--- a/backend/app/api/v1/endpoints/certificados.py
+++ b/backend/app/api/v1/endpoints/certificados.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Dict
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Query
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.api.v1.endpoints.utils import (
@@ -13,16 +13,17 @@ from app.api.v1.endpoints.utils import (
     paginate_query,
     resolve_sort,
 )
-from app.db.session import SessionLocal
 from app.deps.auth import Role, User, db_with_org, require_role
 from app.schemas.certificados import CertificadoListResponse
-from app.services.certificados_ingest import ingest_certificados
+from app.worker.jobs_certificados import ingest_certificados_full
+from app.worker.queue import enqueue_unique
 
 
 logger = logging.getLogger(__name__)
 
 # Diretório padrão dos .pfx; pode ser sobrescrito por variável de ambiente
 CERTIFICADOS_DIR_ENV = "ECONTROLE_CERTIFICADOS_DIR"
+CERTIFICADOS_ROOT_ENV = "CERTIFICADOS_ROOT"
 DEFAULT_CERTIFICADOS_DIR = r"G:\CERTIFICADOS DIGITAIS"
 
 router = APIRouter(prefix="/certificados", tags=["Certificados"])
@@ -64,7 +65,6 @@ def listar_certificados(
 
 @router.post("/ingest")
 def disparar_ingest_certificados(
-    background_tasks: BackgroundTasks,
     current_user: User = Depends(require_role(Role.ADMIN)),
 ) -> dict:
     """
@@ -74,30 +74,21 @@ def disparar_ingest_certificados(
     fazendo upsert em `certificados` e refletindo em `v_certificados_status`.
     """
 
-    certificados_dir = os.environ.get(CERTIFICADOS_DIR_ENV, DEFAULT_CERTIFICADOS_DIR)
+    certificados_dir = os.environ.get(
+        CERTIFICADOS_ROOT_ENV, os.environ.get(CERTIFICADOS_DIR_ENV, DEFAULT_CERTIFICADOS_DIR)
+    )
     org_id = str(current_user.org_id)
+    job_id = f"cert:ingest_full:{org_id}"
 
-    def job(dir_path: str, org_id_: str) -> None:
-        db = SessionLocal()
-        try:
-            processed = ingest_certificados(dir_path, org_id_, db)
-            logger.info(
-                "Ingestão de certificados finalizada: org_id=%s dir=%s processed=%s",
-                org_id_,
-                dir_path,
-                processed,
-            )
-        except Exception:
-            logger.exception(
-                "Erro ao ingerir certificados: org_id=%s dir=%s", org_id_, dir_path
-            )
-            db.rollback()
-        finally:
-            db.close()
-
-    background_tasks.add_task(job, certificados_dir, org_id)
+    job = enqueue_unique(
+        ingest_certificados_full,
+        job_id=job_id,
+        kwargs={"org_id": org_id, "certificados_dir": certificados_dir},
+    )
 
     return {
-        "message": "Ingestão de certificados agendada",
+        "queued": True,
+        "job_id": job.id if job else job_id,
+        "message": "Ingest de certificados enfileirado",
         "certificados_dir": certificados_dir,
     }

--- a/backend/app/api/v1/endpoints/licencas.py
+++ b/backend/app/api/v1/endpoints/licencas.py
@@ -14,7 +14,8 @@ from app.api.v1.endpoints.utils import (
 )
 from app.deps.auth import Role, User, db_with_org, require_role
 from app.schemas.licencas import LicencaCreate, LicencaListResponse, LicencaUpdate, LicencaView
-from app.services.licencas_ingest import ingest_licencas_from_fs
+from app.worker.jobs_licencas import ingest_licencas_full
+from app.worker.queue import enqueue_unique
 from db.models_sql import Empresa, Licenca
 
 router = APIRouter(prefix="/licencas", tags=["Licenças"])
@@ -152,9 +153,14 @@ def atualizar_licenca(
 @router.post("/ingest-from-fs")
 def disparar_ingestao(
     empresa_id: int | None = Query(None, description="Limitar ingestão a uma empresa específica."),
-    db: Session = Depends(db_with_org),
     user: User = Depends(require_role(Role.ADMIN)),
-) -> dict[str, int]:
+) -> dict[str, object]:
     """Dispara a ingestão de licenças a partir do sistema de arquivos."""
 
-    return ingest_licencas_from_fs(db, user.org_id, empresa_id)
+    job_id = f"lic:ingest_full:{user.org_id}:{empresa_id or 'all'}"
+    job = enqueue_unique(
+        ingest_licencas_full,
+        job_id=job_id,
+        kwargs={"org_id": str(user.org_id), "empresa_id": empresa_id},
+    )
+    return {"queued": True, "job_id": job.id if job else job_id, "message": "Ingest de licenças enfileirado"}

--- a/backend/app/api/v1/endpoints/worker.py
+++ b/backend/app/api/v1/endpoints/worker.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from rq.job import Job
+
+from app.deps.auth import Role, require_role
+from app.worker.queue import get_queue, get_redis
+
+router = APIRouter(prefix="/worker", tags=["Worker"])
+logger = logging.getLogger(__name__)
+
+
+@router.get("/health")
+def worker_health(_: str = Depends(require_role(Role.ADMIN))) -> dict[str, object]:
+    try:
+        redis_conn = get_redis()
+        redis_conn.ping()
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Falha ao pingar Redis")
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc))
+
+    queue = get_queue()
+    return {"redis": "ok", "queue": queue.name}
+
+
+@router.get("/jobs/{job_id}")
+def job_status(job_id: str, _: str = Depends(require_role(Role.ADMIN))) -> dict[str, object]:
+    queue = get_queue()
+    job: Job | None = queue.fetch_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job não encontrado")
+
+    status_value = job.get_status(refresh=True)
+    enqueued_at = job.enqueued_at.isoformat() if job.enqueued_at else None
+    started_at = job.started_at.isoformat() if job.started_at else None
+    ended_at = job.ended_at.isoformat() if job.ended_at else None
+    return {
+        "job_id": job_id,
+        "status": status_value,
+        "enqueued_at": enqueued_at,
+        "started_at": started_at,
+        "ended_at": ended_at,
+    }

--- a/backend/app/services/certificados_ingest.py
+++ b/backend/app/services/certificados_ingest.py
@@ -240,6 +240,26 @@ def prune_missing_by_arquivo(org_id: str, keep_arquivos: set[str], db_session: S
     return removidos
 
 
+def ingest_certificado_arquivo(cert_path: str, org_id: str, db_session: Session) -> Certificado:
+    """Processa um único arquivo ``.pfx`` reaproveitando o pipeline existente.
+
+    Não dispara *cleanup* completo para evitar custo elevado em operações unitárias.
+    """
+
+    if not cert_path.lower().endswith(".pfx"):
+        raise ValueError(f"Arquivo não suportado para ingestão de certificado: {cert_path}")
+
+    password = _extract_password_from_filename(os.path.basename(cert_path))
+    cert_data = extract_cert_info(cert_path, password or None)
+    cert_info: Dict[str, object] = {
+        **cert_data,
+        "senha": password,
+        "org_id": org_id,
+        "path": cert_path,
+    }
+    return upsert_certificado(cert_info, db_session)
+
+
 def ingest_certificados(certificados_dir: str, org_id: str, db_session: Session) -> int:
     """Percorre o diretório informado e realiza o *upsert* dos certificados."""
 

--- a/backend/app/services/licencas_ingest.py
+++ b/backend/app/services/licencas_ingest.py
@@ -18,6 +18,7 @@ from db.models_sql import Empresa, Licenca, Processo
 logger = logging.getLogger(__name__)
 
 EMPRESAS_ROOT_ENV = "EMPRESAS_ROOT_DIR"
+LICENCAS_ROOT_ENV = "LICENCAS_ROOT"
 DEFAULT_EMPRESAS_ROOT = Path(r"G:\EMPRESAS")
 LICENSE_DIR_PARTS = ["Societário", "Alvarás e Certidões"]
 
@@ -362,8 +363,21 @@ def _should_protect_status(status: str | None) -> bool:
     return value in {"*", "NÃO"}
 
 
+def resolve_empresa_id_por_dir(
+    db: Session, org_id: UUID, empresa_dir: Path
+) -> int | None:
+    """Resolve ``empresa_id`` a partir do nome da pasta normalizado."""
+
+    target = _normalize_empresa_nome(empresa_dir.name)
+    empresas_query = select(Empresa).where(Empresa.org_id == org_id)
+    for empresa in db.execute(empresas_query).scalars():
+        if _normalize_empresa_nome(empresa.empresa) == target:
+            return empresa.id
+    return None
+
+
 def ingest_licencas_from_fs(db: Session, org_id: UUID | None = None, empresa_id: int | None = None) -> dict[str, int]:
-    root_env = os.getenv(EMPRESAS_ROOT_ENV)
+    root_env = os.getenv(LICENCAS_ROOT_ENV) or os.getenv(EMPRESAS_ROOT_ENV)
     root_dir = Path(root_env) if root_env else DEFAULT_EMPRESAS_ROOT
 
     empresas_query = select(Empresa).where(Empresa.municipio.isnot(None))

--- a/backend/app/worker/__init__.py
+++ b/backend/app/worker/__init__.py
@@ -1,0 +1,1 @@
+# Package initialization for worker utilities.

--- a/backend/app/worker/jobs_certificados.py
+++ b/backend/app/worker/jobs_certificados.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from app.db.session import SessionLocal
+from app.services.certificados_ingest import (
+    ingest_certificado_arquivo,
+    ingest_certificados,
+)
+
+logger = logging.getLogger(__name__)
+
+CERTIFICADOS_ENV = "CERTIFICADOS_ROOT"
+LEGACY_CERTIFICADOS_ENV = "ECONTROLE_CERTIFICADOS_DIR"
+DEFAULT_CERTIFICADOS_DIR = r"G:\\CERTIFICADOS DIGITAIS"
+
+
+def _resolve_certificados_dir(explicit: str | None = None) -> str:
+    if explicit:
+        return explicit
+    env = os.getenv(CERTIFICADOS_ENV) or os.getenv(LEGACY_CERTIFICADOS_ENV)
+    return env or DEFAULT_CERTIFICADOS_DIR
+
+
+def processar_certificado_por_arquivo(org_id: str, caminho_arquivo: str) -> dict[str, object]:
+    logger.info("Processando certificado: org_id=%s arquivo=%s", org_id, caminho_arquivo)
+    caminho_normalizado = str(Path(caminho_arquivo))
+    with SessionLocal() as db:
+        certificado = ingest_certificado_arquivo(caminho_normalizado, org_id, db)
+        logger.info(
+            "Certificado processado: org_id=%s arquivo=%s id=%s",
+            org_id,
+            caminho_normalizado,
+            certificado.id,
+        )
+        return {"certificado_id": certificado.id, "caminho": caminho_normalizado}
+
+
+def ingest_certificados_full(org_id: str, certificados_dir: str | None = None) -> dict[str, int]:
+    dir_path = _resolve_certificados_dir(certificados_dir)
+    logger.info("Iniciando ingest full de certificados: org_id=%s dir=%s", org_id, dir_path)
+    with SessionLocal() as db:
+        processed = ingest_certificados(dir_path, org_id, db)
+        logger.info(
+            "Ingest full de certificados concluída: org_id=%s dir=%s processed=%s",
+            org_id,
+            dir_path,
+            processed,
+        )
+        return {"processed": processed, "dir": dir_path}
+
+
+__all__ = [
+    "processar_certificado_por_arquivo",
+    "ingest_certificados_full",
+]

--- a/backend/app/worker/jobs_licencas.py
+++ b/backend/app/worker/jobs_licencas.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from app.db.session import SessionLocal
+from app.services.licencas_ingest import (
+    DEFAULT_EMPRESAS_ROOT,
+    EMPRESAS_ROOT_ENV,
+    ingest_licencas_from_fs,
+    resolve_empresa_id_por_dir,
+)
+
+logger = logging.getLogger(__name__)
+
+LICENCAS_ROOT_ENV = "LICENCAS_ROOT"
+ORG_DEFAULT_ENV = "ORG_ID_DEFAULT"
+
+
+def _resolve_org_id(org_id: str | None) -> str:
+    env_org = os.getenv(ORG_DEFAULT_ENV)
+    if org_id:
+        return org_id
+    if env_org:
+        return env_org
+    raise ValueError("org_id é obrigatório para reprocessar licenças")
+
+
+def _resolve_root_dir(explicit: str | None = None) -> Path:
+    if explicit:
+        return Path(explicit)
+    env = os.getenv(LICENCAS_ROOT_ENV) or os.getenv(EMPRESAS_ROOT_ENV)
+    return Path(env) if env else DEFAULT_EMPRESAS_ROOT
+
+
+def _to_uuid(org_id: str) -> UUID:
+    return UUID(str(org_id))
+
+
+def reprocessar_licencas_por_empresa(
+    org_id: str | None,
+    empresa_id: int | None = None,
+    empresa_dir: str | None = None,
+    licencas_root: str | None = None,
+) -> dict[str, Any]:
+    org_id_resolvido = _resolve_org_id(org_id)
+    root_dir = _resolve_root_dir(licencas_root)
+    empresa_dir_path = Path(empresa_dir) if empresa_dir else None
+
+    if licencas_root:
+        os.environ[EMPRESAS_ROOT_ENV] = str(root_dir)
+
+    logger.info(
+        "Reprocessando licenças: org_id=%s empresa_id=%s empresa_dir=%s root=%s",
+        org_id_resolvido,
+        empresa_id,
+        empresa_dir_path,
+        root_dir,
+    )
+
+    with SessionLocal() as db:
+        empresa_resolvida = empresa_id
+        if empresa_resolvida is None and empresa_dir_path:
+            try:
+                empresa_resolvida = resolve_empresa_id_por_dir(
+                    db, _to_uuid(org_id_resolvido), empresa_dir_path
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Falha ao resolver empresa por diretório: org_id=%s dir=%s",
+                    org_id_resolvido,
+                    empresa_dir_path,
+                )
+
+        resultado = ingest_licencas_from_fs(db, _to_uuid(org_id_resolvido), empresa_resolvida)
+
+    logger.info(
+        "Reprocessamento de licenças concluído: org_id=%s empresa_id=%s",
+        org_id_resolvido,
+        empresa_resolvida,
+    )
+    return {
+        "org_id": org_id_resolvido,
+        "empresa_id": empresa_resolvida,
+        "resultado": resultado,
+        "root_dir": str(root_dir),
+    }
+
+
+def ingest_licencas_full(org_id: str | None, empresa_id: int | None = None) -> dict[str, Any]:
+    org_id_resolvido = _resolve_org_id(org_id)
+    logger.info("Iniciando ingest full de licenças: org_id=%s empresa_id=%s", org_id_resolvido, empresa_id)
+    with SessionLocal() as db:
+        resultado = ingest_licencas_from_fs(db, _to_uuid(org_id_resolvido), empresa_id)
+    logger.info("Ingest full de licenças concluído: org_id=%s empresa_id=%s", org_id_resolvido, empresa_id)
+    return {
+        "org_id": org_id_resolvido,
+        "empresa_id": empresa_id,
+        "resultado": resultado,
+    }
+
+
+__all__ = [
+    "reprocessar_licencas_por_empresa",
+    "ingest_licencas_full",
+]

--- a/backend/app/worker/queue.py
+++ b/backend/app/worker/queue.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable
+
+import redis
+from rq import Queue
+
+logger = logging.getLogger(__name__)
+
+QUEUE_NAME_ENV = "RQ_QUEUE_NAME"
+DEFAULT_QUEUE_NAME = "econtrole"
+
+
+_redis_client: redis.Redis | None = None
+_queue: Queue | None = None
+
+
+def get_redis() -> redis.Redis:
+    global _redis_client
+    if _redis_client is None:
+        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        _redis_client = redis.from_url(url)
+    return _redis_client
+
+
+def get_queue() -> Queue:
+    global _queue
+    if _queue is None:
+        queue_name = os.getenv(QUEUE_NAME_ENV, DEFAULT_QUEUE_NAME)
+        _queue = Queue(name=queue_name, connection=get_redis())
+    return _queue
+
+
+def enqueue_unique(
+    job_func: Callable[..., Any],
+    job_id: str,
+    kwargs: dict[str, Any] | None = None,
+    ttl: int | None = None,
+    result_ttl: int | None = 3600,
+):
+    """Enfileira um job com deduplicação por ``job_id``.
+
+    Se já houver um job com mesmo id em estado ativo, o reuso é sinalizado via log.
+    """
+
+    queue = get_queue()
+    existing = queue.fetch_job(job_id)
+    if existing:
+        status = existing.get_status(refresh=True)
+        if status in {"queued", "started", "deferred"}:
+            logger.info("Job duplicado ignorado: job_id=%s status=%s", job_id, status)
+            return existing
+        try:
+            existing.cancel()
+            existing.delete()
+        except Exception:  # noqa: BLE001
+            logger.warning("Falha ao limpar job antigo: job_id=%s", job_id, exc_info=True)
+
+    job = queue.enqueue(
+        job_func,
+        job_id=job_id,
+        ttl=ttl,
+        result_ttl=result_ttl,
+        **(kwargs or {}),
+    )
+    logger.info("Job enfileirado: job_id=%s queue=%s", job_id, queue.name)
+    return job

--- a/backend/app/worker/watchers.py
+++ b/backend/app/worker/watchers.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections import deque
+from hashlib import sha1
+from pathlib import Path
+from typing import Callable
+from uuid import UUID
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+from app.db.session import SessionLocal
+from app.services.licencas_ingest import resolve_empresa_id_por_dir
+from app.worker.jobs_certificados import processar_certificado_por_arquivo
+from app.worker.jobs_licencas import reprocessar_licencas_por_empresa
+from app.worker.queue import enqueue_unique
+
+logger = logging.getLogger(__name__)
+
+DEBOUNCE_ENV = "WATCHER_DEBOUNCE_SECONDS"
+RATE_LIMIT_ENV = "WATCHER_MAX_EVENTS_PER_MINUTE"
+ORG_DEFAULT_ENV = "ORG_ID_DEFAULT"
+
+ALLOWED_LICENSE_EXTS = {".pdf", ".png", ".jpg", ".jpeg"}
+
+
+class DebouncedHandler(FileSystemEventHandler):
+    def __init__(self, debounce_seconds: float, max_events_per_minute: int | None = None):
+        super().__init__()
+        self.debounce_seconds = debounce_seconds
+        self.max_events_per_minute = max_events_per_minute
+        self.last_event: dict[str, float] = {}
+        self.events_window: deque[float] = deque()
+
+    def _should_skip(self, key: str) -> bool:
+        now = time.monotonic()
+        last = self.last_event.get(key)
+        if last and now - last < self.debounce_seconds:
+            logger.debug("Evento ignorado por debounce: %s", key)
+            return True
+
+        if self.max_events_per_minute:
+            while self.events_window and self.events_window[0] < now - 60:
+                self.events_window.popleft()
+            if len(self.events_window) >= self.max_events_per_minute:
+                logger.warning("Rate limit atingido. Evento ignorado: %s", key)
+                return True
+            self.events_window.append(now)
+
+        self.last_event[key] = now
+        return False
+
+
+class CertificadosHandler(DebouncedHandler):
+    def __init__(self, org_id: str, debounce_seconds: float, max_events_per_minute: int | None):
+        super().__init__(debounce_seconds, max_events_per_minute)
+        self.org_id = org_id
+
+    def on_created(self, event: FileSystemEvent) -> None:  # noqa: D401
+        self._handle_event(event)
+
+    def on_modified(self, event: FileSystemEvent) -> None:  # noqa: D401
+        self._handle_event(event)
+
+    def _handle_event(self, event: FileSystemEvent) -> None:
+        if event.is_directory:
+            return
+        if not event.src_path.lower().endswith(".pfx"):
+            return
+        path_norm = os.path.normpath(event.src_path)
+        key = path_norm.lower()
+        if self._should_skip(key):
+            return
+
+        job_id = f"cert:{self.org_id}:{sha1(key.encode()).hexdigest()}"
+        logger.info("Evento de certificado detectado: %s", path_norm)
+        enqueue_unique(
+            processar_certificado_por_arquivo,
+            job_id=job_id,
+            kwargs={"org_id": self.org_id, "caminho_arquivo": path_norm},
+        )
+
+
+class LicencasHandler(DebouncedHandler):
+    def __init__(
+        self,
+        org_id: str,
+        licencas_root: Path,
+        debounce_seconds: float,
+        max_events_per_minute: int | None,
+    ):
+        super().__init__(debounce_seconds, max_events_per_minute)
+        self.org_id = org_id
+        self.licencas_root = licencas_root
+
+    def on_created(self, event: FileSystemEvent) -> None:  # noqa: D401
+        self._handle_event(event)
+
+    def on_modified(self, event: FileSystemEvent) -> None:  # noqa: D401
+        self._handle_event(event)
+
+    def _extract_empresa_dir(self, path: Path) -> Path | None:
+        try:
+            relative = path.resolve().relative_to(self.licencas_root.resolve())
+        except ValueError:
+            return None
+        parts = relative.parts
+        if len(parts) < 3:
+            return None
+        if "societário" not in {p.lower() for p in parts}:
+            return None
+        if "alvarás e certidões" not in {p.lower() for p in parts}:
+            return None
+        return self.licencas_root / parts[0]
+
+    def _handle_event(self, event: FileSystemEvent) -> None:
+        if event.is_directory:
+            return
+        path = Path(event.src_path)
+        if path.suffix.lower() not in ALLOWED_LICENSE_EXTS:
+            return
+
+        empresa_dir = self._extract_empresa_dir(path)
+        if not empresa_dir:
+            return
+
+        key = str(path.resolve()).lower()
+        if self._should_skip(key):
+            return
+
+        empresa_id = None
+        org_uuid = None
+        try:
+            org_uuid = UUID(self.org_id)
+        except Exception:  # noqa: BLE001
+            logger.warning("org_id inválido para resolução de empresa: %s", self.org_id)
+
+        if org_uuid:
+            with SessionLocal() as db:
+                try:
+                    empresa_id = resolve_empresa_id_por_dir(db, org_uuid, empresa_dir)
+                except Exception:  # noqa: BLE001
+                    logger.exception("Falha ao resolver empresa para %s", empresa_dir)
+
+        job_key = (
+            f"lic:{self.org_id}:{empresa_id}" if empresa_id is not None else f"lic:{self.org_id}:{sha1(str(empresa_dir).lower().encode()).hexdigest()}"
+        )
+        logger.info(
+            "Evento de licença detectado: caminho=%s empresa_dir=%s empresa_id=%s",
+            path,
+            empresa_dir,
+            empresa_id,
+        )
+        enqueue_unique(
+            reprocessar_licencas_por_empresa,
+            job_id=job_key,
+            kwargs={
+                "org_id": self.org_id,
+                "empresa_id": empresa_id,
+                "empresa_dir": str(empresa_dir),
+                "licencas_root": str(self.licencas_root),
+            },
+        )
+
+
+def _debounce_seconds(debounce: float | None) -> float:
+    if debounce is not None:
+        return debounce
+    env = os.getenv(DEBOUNCE_ENV)
+    return float(env) if env else 3.0
+
+
+def _max_events_per_minute(default: int | None = None) -> int | None:
+    env_value = os.getenv(RATE_LIMIT_ENV)
+    if env_value:
+        try:
+            return int(env_value)
+        except ValueError:
+            logger.warning("WATCHER_MAX_EVENTS_PER_MINUTE inválido: %s", env_value)
+    return default
+
+
+def _resolve_org_id(org_id: str | None) -> str:
+    if org_id:
+        return org_id
+    env_org = os.getenv(ORG_DEFAULT_ENV)
+    if env_org:
+        return env_org
+    raise ValueError("org_id é obrigatório para iniciar watcher")
+
+
+def _start_observer(path: Path, handler_factory: Callable[[], FileSystemEventHandler]) -> None:
+    handler = handler_factory()
+    observer = Observer()
+    observer.schedule(handler, str(path), recursive=True)
+    observer.start()
+    logger.info("Watcher iniciado em %s", path)
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        logger.info("Watcher interrompido pelo usuário")
+        observer.stop()
+    finally:
+        observer.join()
+
+
+def start_certificados_watcher(
+    org_id: str | None,
+    certificados_root: str,
+    debounce_seconds: float | None = None,
+    max_events_per_minute: int | None = None,
+) -> None:
+    org_resolvido = _resolve_org_id(org_id)
+    debounce = _debounce_seconds(debounce_seconds)
+    rate_limit = _max_events_per_minute(max_events_per_minute)
+    path = Path(certificados_root)
+    logger.info(
+        "Watcher de certificados configurado: org_id=%s root=%s debounce=%ss rate_limit=%s",
+        org_resolvido,
+        path,
+        debounce,
+        rate_limit,
+    )
+
+    def factory() -> FileSystemEventHandler:
+        return CertificadosHandler(org_resolvido, debounce, rate_limit)
+
+    _start_observer(path, factory)
+
+
+def start_licencas_watcher(
+    org_id: str | None,
+    licencas_root: str,
+    debounce_seconds: float | None = None,
+    max_events_per_minute: int | None = None,
+) -> None:
+    org_resolvido = _resolve_org_id(org_id)
+    debounce = _debounce_seconds(debounce_seconds)
+    rate_limit = _max_events_per_minute(max_events_per_minute)
+    path = Path(licencas_root)
+    logger.info(
+        "Watcher de licenças configurado: org_id=%s root=%s debounce=%ss rate_limit=%s",
+        org_resolvido,
+        path,
+        debounce,
+        rate_limit,
+    )
+
+    def factory() -> FileSystemEventHandler:
+        return LicencasHandler(org_resolvido, path, debounce, rate_limit)
+
+    _start_observer(path, factory)

--- a/backend/app/worker/worker_main.py
+++ b/backend/app/worker/worker_main.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+
+from rq import Connection, Worker
+
+from app.worker import jobs_certificados, jobs_licencas
+from app.worker.queue import get_queue, get_redis
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    redis_conn = get_redis()
+    queue = get_queue()
+    logger.info("Conexão com Redis estabelecida: %s", redis_conn)
+    logger.info("Fila em uso: %s", queue.name)
+    logger.info(
+        "Jobs disponíveis: %s",
+        [
+            "app.worker.jobs_certificados.processar_certificado_por_arquivo",
+            "app.worker.jobs_certificados.ingest_certificados_full",
+            "app.worker.jobs_licencas.reprocessar_licencas_por_empresa",
+            "app.worker.jobs_licencas.ingest_licencas_full",
+        ],
+    )
+    with Connection(redis_conn):
+        worker = Worker([queue])
+        worker.work()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,6 +18,9 @@ python-multipart==0.0.6
 aiofiles==23.2.1
 requests==2.31.0
 typer==0.9.0
+rq==1.16.2
+redis==5.0.8
+watchdog==4.0.1
 
 # Automação (CND/CAE)
 playwright==1.40.0


### PR DESCRIPTION
## Summary
- add Redis/RQ queue helpers, worker entrypoint, and filesystem watchers for certificados/licencas
- enqueue ingestion jobs through API endpoints and expose worker health/job status
- document worker usage and new dependencies

## Testing
- python -m compileall backend/app/worker backend/app/api/v1/endpoints backend/app/services

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c5a8f51488326aa18e9b84e90d6aa)