### PR TITLE
Refactor Processos view into card grid

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -623,7 +623,7 @@ function AppContent() {
         modoFoco={modoFoco}
         onModoFocoChange={setModoFoco}
       />
-      <main className="pt-14 px-4 pb-6 lg:px-8">
+      <main className="pt-12 md:pt-14 px-4 pb-6 lg:px-8">
         <div className="mx-auto max-w-[1400px] space-y-4">
           {loading ? (
             <div className="p-6 text-center">Carregando dados...</div>

--- a/frontend/src/features/processos/ProcessosScreen.jsx
+++ b/frontend/src/features/processos/ProcessosScreen.jsx
@@ -1,22 +1,9 @@
 import React, { useCallback, useMemo, useState } from "react";
 import dayjs from "dayjs";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import { Card } from "@/components/ui/card";
 import InlineBadge from "@/components/InlineBadge";
 import StatusBadge from "@/components/StatusBadge";
-import { Chip } from "@/components/Chip";
 import {
-  ArrowDown,
-  ArrowUp,
-  ArrowUpDown,
   Clock,
   Clipboard,
   FileText,
@@ -27,16 +14,11 @@ import {
   Settings,
   X,
 } from "lucide-react";
-import {
-  buildDiversosOperacaoKey,
-  formatProcessDate,
-  getDiversosOperacaoLabel,
-  getProcessBaseType,
-  normalizeProcessType,
-} from "@/lib/process";
+import { formatProcessDate, getDiversosOperacaoLabel, getProcessBaseType, normalizeProcessType } from "@/lib/process";
 import { normalizeIdentifier, normalizeText } from "@/lib/text";
 import { isProcessStatusActiveOrPending } from "@/lib/status";
 import { fetchJson } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 const PROCESS_TYPE_DISPLAY = {
   BOMBEIROS: "CERCON",
@@ -60,49 +42,11 @@ const normalizeTipoKey = (tipoBase) =>
     .toUpperCase()
     .replace(/[^A-Z0-9]+/g, "_");
 
-const baseColumns = [
-  { id: "empresa", label: "Empresa", sortable: true },
-  { id: "protocolo", label: "Protocolo", sortable: true },
-  { id: "data_solicitacao", label: "Data solicitação", sortable: true, isDate: true },
-  { id: "municipio", label: "Município", sortable: true },
-  { id: "situacao", label: "Situação", sortable: true, isStatus: true },
-  { id: "obs", label: "OBS", sortable: true },
+const SORT_OPTIONS = [
+  { value: "data_solicitacao", label: "Data solicitação", defaultDir: "desc" },
+  { value: "empresa", label: "Empresa", defaultDir: "asc" },
+  { value: "situacao", label: "Situação", defaultDir: "asc" },
 ];
-
-const extraColumnsByTipo = {
-  DIVERSOS: [
-    { id: "operacao", label: "Operação", sortable: true },
-    { id: "orgao", label: "Órgão", sortable: true },
-  ],
-  FUNCIONAMENTO: [{ id: "alvara", label: "Alvará", sortable: true }],
-  BOMBEIROS: [
-    { id: "area_m2", label: "Área (m²)", sortable: true },
-    { id: "projeto", label: "Projeto", sortable: true },
-    { id: "tpi_sync_status", label: "TPI", sortable: true, isStatus: true },
-  ],
-  USO_DO_SOLO: [
-    { id: "inscricao_imobiliaria", label: "Inscrição imobiliária", sortable: true },
-  ],
-  SANITARIO: [
-    { id: "servico", label: "Serviço", sortable: true },
-    { id: "taxa_sanitaria_sync_status", label: "Taxa", sortable: true, isStatus: true },
-    { id: "notificacao", label: "Notificação", sortable: true },
-    {
-      id: "alvara_sanitario_validade",
-      label: "Validade",
-      sortable: true,
-      isDate: true,
-      isDateOnly: true,
-    },
-    { id: "alvara_sanitario_status", label: "Status validade", sortable: true, isStatus: true },
-  ],
-};
-
-const sortDirectionCycle = {
-  undefined: "asc",
-  asc: "desc",
-  desc: undefined,
-};
 
 const extractDateValue = (value) => {
   const normalized = normalizeText(value).trim();
@@ -113,56 +57,37 @@ const extractDateValue = (value) => {
   return fallback.isValid() ? fallback.valueOf() : null;
 };
 
-const toggleSort = (currentState, tipoKey, columnId) => {
-  const current = currentState[tipoKey];
-  const nextDirection = sortDirectionCycle[current?.column === columnId ? current.direction : undefined];
-  return {
-    ...currentState,
-    [tipoKey]: nextDirection
-      ? {
-          column: columnId,
-          direction: nextDirection,
-        }
-      : undefined,
-  };
-};
+const compareProcessos = (a, b, field, direction) => {
+  const dir = direction === "desc" ? -1 : 1;
 
-const getComparator = (column) => {
-  if (!column) return null;
-  if (column.isDate) {
-    return (proc) => extractDateValue(proc?.[column.id]);
+  if (field === "data_solicitacao") {
+    const aValue = extractDateValue(a?.data_solicitacao);
+    const bValue = extractDateValue(b?.data_solicitacao);
+    if (aValue === null && bValue === null) return 0;
+    if (aValue === null) return 1;
+    if (bValue === null) return -1;
+    return (aValue - bValue) * dir;
   }
-  return (proc) => normalizeText(proc?.[column.id]).trim();
-};
 
-const sortRows = (rows, sortState, columns) => {
-  if (!sortState?.column) return rows;
-  const column = columns.find((col) => col.id === sortState.column);
-  const accessor = getComparator(column);
-  if (!accessor) return rows;
+  if (field === "empresa") {
+    const aEmpresa = normalizeText(a?.empresa).trim();
+    const bEmpresa = normalizeText(b?.empresa).trim();
+    if (!aEmpresa && !bEmpresa) return 0;
+    if (!aEmpresa) return 1;
+    if (!bEmpresa) return -1;
+    return aEmpresa.localeCompare(bEmpresa) * dir;
+  }
 
-  const direction = sortState.direction === "desc" ? -1 : 1;
+  if (field === "situacao") {
+    const aSituacao = normalizeText(a?.situacao ?? a?.status ?? "").trim();
+    const bSituacao = normalizeText(b?.situacao ?? b?.status ?? "").trim();
+    if (!aSituacao && !bSituacao) return 0;
+    if (!aSituacao) return 1;
+    if (!bSituacao) return -1;
+    return aSituacao.localeCompare(bSituacao) * dir;
+  }
 
-  return [...rows].sort((a, b) => {
-    const aValue = accessor(a);
-    const bValue = accessor(b);
-
-    if (aValue === null || aValue === undefined) return 1;
-    if (bValue === null || bValue === undefined) return -1;
-
-    if (typeof aValue === "number" && typeof bValue === "number") {
-      return (aValue - bValue) * direction;
-    }
-
-    return aValue.localeCompare(bValue) * direction;
-  });
-};
-
-const renderSortIcon = (isActive, direction) => {
-  if (!isActive) return <ArrowUpDown className="h-3.5 w-3.5 opacity-40" />;
-  if (direction === "asc") return <ArrowUp className="h-3.5 w-3.5" />;
-  if (direction === "desc") return <ArrowDown className="h-3.5 w-3.5" />;
-  return <ArrowUpDown className="h-3.5 w-3.5 opacity-40" />;
+  return 0;
 };
 
 const formatDateTime = (value) => {
@@ -171,17 +96,18 @@ const formatDateTime = (value) => {
   return parsed.format("DD/MM/YYYY HH:mm");
 };
 
-const renderObsSnippet = (value) => {
-  const text = normalizeText(value).trim();
-  if (!text) return "—";
-  const snippet = text.length > 80 ? `${text.slice(0, 77)}…` : text;
-  return (
-    <div className="inline-flex items-center gap-2 text-xs text-slate-600">
-      <FileText className="h-3.5 w-3.5 text-slate-400" />
-      <span className="line-clamp-2 text-left leading-snug">{snippet}</span>
-    </div>
-  );
-};
+const InfoPill = ({ children }) => (
+  <span className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600">
+    {children}
+  </span>
+);
+
+const InfoItem = ({ label, children, className = "" }) => (
+  <div className={cn("space-y-1 rounded-xl border border-slate-200/70 bg-slate-50/60 px-3 py-2.5", className)}>
+    <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">{label}</p>
+    <div className="text-sm text-slate-800">{children ?? "—"}</div>
+  </div>
+);
 
 const renderStatus = (value) => {
   const text = normalizeText(value).trim();
@@ -189,44 +115,9 @@ const renderStatus = (value) => {
   return <StatusBadge status={text} />;
 };
 
-const renderCompany = (proc, handleCopy) => (
-  <div className="space-y-0.5">
-    <p className="text-sm font-semibold text-slate-800 leading-tight">
-      {proc?.empresa || "—"}
-    </p>
-    <button
-      type="button"
-      onClick={() => {
-        const value = normalizeIdentifier(proc?.cnpj);
-        if (value) handleCopy(value, `CNPJ copiado: ${value}`);
-      }}
-      className="inline-flex items-center gap-1 text-[11px] font-medium text-indigo-600 transition-colors hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
-    >
-      {normalizeIdentifier(proc?.cnpj) || "—"}
-      <Clipboard className="h-3 w-3" aria-hidden="true" />
-    </button>
-  </div>
-);
-
-const renderMunicipio = (proc) => {
+const formatMunicipio = (proc) => {
   const municipio = normalizeText(proc?.municipio_exibicao || proc?.municipio).trim();
-  if (!municipio) return "—";
-  return (
-    <div className="inline-flex items-center gap-1 text-xs text-slate-700">
-      <MapPin className="h-3.5 w-3.5 text-slate-400" />
-      <span>{municipio}</span>
-    </div>
-  );
-};
-
-const renderChip = (value) => {
-  const text = normalizeText(value).trim();
-  if (!text) return "—";
-  return (
-    <Chip variant="neutral" className="bg-slate-100 text-slate-700 border-slate-200 text-[11px]">
-      {text}
-    </Chip>
-  );
+  return municipio;
 };
 
 const getTipoDisplay = (tipoBase) => {
@@ -234,9 +125,14 @@ const getTipoDisplay = (tipoBase) => {
   return PROCESS_TYPE_DISPLAY[key] ?? tipoBase ?? "Processo";
 };
 
-const resolveExtraColumns = (tipoBase) => {
-  const key = normalizeTipoKey(tipoBase);
-  return extraColumnsByTipo[key] ?? [];
+const resolveTipoFromProcess = (proc) => {
+  const tipoNormalizado = normalizeProcessType(proc);
+  const tipoBase = getProcessBaseType(tipoNormalizado);
+  return {
+    tipoBase,
+    tipoKey: normalizeTipoKey(tipoBase),
+    tipoDisplay: getTipoDisplay(tipoBase),
+  };
 };
 
 export default function ProcessosScreen({
@@ -246,7 +142,10 @@ export default function ProcessosScreen({
   matchesQuery,
   handleCopy,
 }) {
-  const [sortByTipo, setSortByTipo] = useState({});
+  const [sortField, setSortField] = useState(SORT_OPTIONS[0].value);
+  const [sortDir, setSortDir] = useState(SORT_OPTIONS[0].defaultDir);
+  const [selectedTipo, setSelectedTipo] = useState("TODOS");
+  const [expandedObs, setExpandedObs] = useState({});
   const [obsDrawer, setObsDrawer] = useState({ open: false, processo: null });
   const [obsDraft, setObsDraft] = useState("");
   const [obsHistory, setObsHistory] = useState([]);
@@ -351,175 +250,377 @@ export default function ProcessosScreen({
     [obsOverrides],
   );
 
-  const processosByTipo = useMemo(() => {
-    const groups = new Map();
-
-    processosVisiveis.forEach((proc) => {
-      const tipoNormalizado = normalizeProcessType(proc);
-      const tipoBase = getProcessBaseType(tipoNormalizado);
-      const key = normalizeTipoKey(tipoBase);
-      const entry = groups.get(key) || {
-        key,
-        display: getTipoDisplay(tipoBase),
-        tipoBase,
-        registros: [],
-      };
-      entry.registros.push({
+  const processosEnriquecidos = useMemo(() => {
+    return processosVisiveis.map((proc) => {
+      const { tipoBase, tipoKey, tipoDisplay } = resolveTipoFromProcess(proc);
+      return {
         ...proc,
         tipoBase,
-        diversosOperacaoKey:
-          tipoBase === "Diversos" ? buildDiversosOperacaoKey(proc.operacao) : undefined,
-        diversosOperacaoLabel:
-          tipoBase === "Diversos" ? getDiversosOperacaoLabel(proc.operacao) : undefined,
-      });
-      groups.set(key, entry);
+        tipoKey,
+        tipoDisplay,
+        diversosOperacaoLabel: tipoBase === "Diversos" ? getDiversosOperacaoLabel(proc.operacao) : undefined,
+      };
+    });
+  }, [processosVisiveis]);
+
+  const tiposDisponiveis = useMemo(() => {
+    const groups = new Map();
+
+    processosEnriquecidos.forEach((proc) => {
+      const entry = groups.get(proc.tipoKey) || {
+        key: proc.tipoKey,
+        display: proc.tipoDisplay,
+        count: 0,
+      };
+      entry.count += 1;
+      groups.set(proc.tipoKey, entry);
     });
 
-    return Array.from(groups.values()).sort((a, b) => a.display.localeCompare(b.display));
-  }, [processosVisiveis]);
+    return [
+      { key: "TODOS", display: "Todos", count: processosEnriquecidos.length },
+      ...Array.from(groups.values()).sort((a, b) => a.display.localeCompare(b.display)),
+    ];
+  }, [processosEnriquecidos]);
+
+  const processosOrdenados = useMemo(() => {
+    const filtered =
+      selectedTipo === "TODOS"
+        ? processosEnriquecidos
+        : processosEnriquecidos.filter((proc) => proc.tipoKey === selectedTipo);
+
+    const comparator = (a, b) => {
+      const primary = compareProcessos(a, b, sortField, sortDir);
+      if (primary !== 0) return primary;
+      return compareProcessos(a, b, "data_solicitacao", "desc");
+    };
+
+    return [...filtered].sort(comparator);
+  }, [processosEnriquecidos, selectedTipo, sortDir, sortField]);
+
+  const handleSortClick = (field) => {
+    setSortField((current) => {
+      if (current === field) {
+        setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
+        return current;
+      }
+
+      const defaultDirection = SORT_OPTIONS.find((option) => option.value === field)?.defaultDir ?? "asc";
+      setSortDir(defaultDirection);
+      return field;
+    });
+  };
+
+  const toggleObsExpanded = (key) => {
+    setExpandedObs((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
 
   return (
     <>
-      <div className="mt-4 space-y-3">
-        {processosByTipo.length === 0 ? (
+      <div className="space-y-4">
+        <div className="rounded-2xl border border-slate-200 bg-white/80 p-3 shadow-sm">
+          <div className="flex flex-wrap items-center gap-2">
+            {tiposDisponiveis.map((tipo) => {
+              const isActive = selectedTipo === tipo.key;
+              const Icon = PROCESS_TYPE_ICON[tipo.key] || Settings;
+
+              return (
+                <button
+                  key={tipo.key}
+                  type="button"
+                  onClick={() => setSelectedTipo(tipo.key)}
+                  className={cn(
+                    "inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition",
+                    "border-slate-200 bg-white text-slate-700 hover:bg-slate-50",
+                    isActive && "border-indigo-200 bg-indigo-50 text-indigo-700 shadow-sm",
+                  )}
+                >
+                  <Icon className="h-4 w-4 text-slate-500" />
+                  <span>{tipo.display}</span>
+                  <InlineBadge variant="outline" className="bg-white text-slate-600">
+                    {tipo.count}
+                  </InlineBadge>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+              Ordenar por
+            </span>
+            <div className="flex flex-wrap items-center gap-2">
+              {SORT_OPTIONS.map((option) => {
+                const isActive = sortField === option.value;
+                const directionSymbol = isActive ? (sortDir === "asc" ? "↑" : "↓") : null;
+
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => handleSortClick(option.value)}
+                    className={cn(
+                      "inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition",
+                      "border-slate-200 bg-white text-slate-700 hover:bg-slate-50",
+                      isActive && "border-indigo-200 bg-indigo-50 text-indigo-700 shadow-sm",
+                    )}
+                  >
+                    <span>{option.label}</span>
+                    {directionSymbol && <span className="text-xs">{directionSymbol}</span>}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {processosOrdenados.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-slate-200 bg-white p-6 text-sm text-slate-500">
             Nenhum processo correspondente ao filtro.
           </div>
         ) : (
-          <div className="grid gap-4 lg:grid-cols-2">
-            {processosByTipo.map((tipo) => {
-              const Icon = PROCESS_TYPE_ICON[tipo.key] || Settings;
-              const columns = [...baseColumns, ...resolveExtraColumns(tipo.tipoBase)];
-              const sortState = sortByTipo[tipo.key];
-              const registrosOrdenados = sortRows(tipo.registros, sortState, columns);
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {processosOrdenados.map((proc, index) => {
+              const obsValue = resolveObsValue(proc);
+              const obsText = normalizeText(obsValue).trim();
+              const obsKey = proc?.id ?? proc?.protocolo ?? `${proc.empresa}-${index}`;
+              const isObsExpanded = !!expandedObs[obsKey];
+              const hasLongObs = obsText.length > 140;
+              const municipio = formatMunicipio(proc);
+
+              const specificFields = [];
+
+              if (normalizeText(proc?.operacao || proc?.diversosOperacaoLabel).trim()) {
+                specificFields.push({
+                  key: "operacao",
+                  label: "Operação",
+                  content: (
+                    <InfoPill>{proc.diversosOperacaoLabel || proc.operacao}</InfoPill>
+                  ),
+                });
+              }
+
+              if (normalizeText(proc?.orgao).trim()) {
+                specificFields.push({
+                  key: "orgao",
+                  label: "Órgão",
+                  content: <InfoPill>{proc.orgao}</InfoPill>,
+                });
+              }
+
+              if (normalizeText(proc?.alvara).trim()) {
+                specificFields.push({
+                  key: "alvara",
+                  label: "Alvará",
+                  content: <InfoPill>{proc.alvara}</InfoPill>,
+                });
+              }
+
+              if (normalizeText(proc?.servico).trim()) {
+                specificFields.push({
+                  key: "servico",
+                  label: "Serviço",
+                  content: <InfoPill>{proc.servico}</InfoPill>,
+                });
+              }
+
+              if (normalizeText(proc?.notificacao).trim()) {
+                specificFields.push({
+                  key: "notificacao",
+                  label: "Notificação",
+                  content: <InfoPill>{proc.notificacao}</InfoPill>,
+                });
+              }
+
+              if (proc?.tipoKey === "BOMBEIROS") {
+                const area = normalizeText(proc?.area_m2).trim();
+                const projeto = normalizeText(proc?.projeto).trim();
+                specificFields.push({
+                  key: "area_m2",
+                  label: "Área (m²)",
+                  content: area ? `${area} m²` : "—",
+                });
+                if (projeto) {
+                  specificFields.push({ key: "projeto", label: "Projeto", content: projeto });
+                }
+                specificFields.push({
+                  key: "tpi_sync_status",
+                  label: "TPI",
+                  content: renderStatus(proc?.tpi_sync_status ?? proc?.tpi),
+                });
+              }
+
+              if (proc?.tipoBase === "Uso do Solo" || proc?.tipoKey === "USO_DO_SOLO") {
+                specificFields.push({
+                  key: "inscricao_imobiliaria",
+                  label: "Inscrição imobiliária",
+                  content: normalizeIdentifier(proc?.inscricao_imobiliaria) || "—",
+                });
+              }
+
+              if (proc?.tipoBase === "Sanitário" || proc?.tipoKey === "SANITARIO") {
+                specificFields.push({
+                  key: "taxa_sanitaria_sync_status",
+                  label: "Taxa",
+                  content: renderStatus(proc?.taxa_sanitaria_sync_status ?? proc?.taxa),
+                });
+                specificFields.push({
+                  key: "alvara_sanitario_validade",
+                  label: "Validade",
+                  content: formatProcessDate(proc?.alvara_sanitario_validade),
+                });
+                specificFields.push({
+                  key: "alvara_sanitario_status",
+                  label: "Status validade",
+                  content: renderStatus(proc?.alvara_sanitario_status),
+                });
+              }
+
+              const Icon = PROCESS_TYPE_ICON[proc.tipoKey] || Settings;
 
               return (
                 <Card
-                  key={tipo.key}
-                  className="flex h-[560px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm"
+                  key={`${proc.tipoKey}-${proc.protocolo ?? proc.empresa ?? index}`}
+                  className="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/70 bg-white shadow-sm transition hover:shadow-md"
                 >
-                  <CardHeader className="flex flex-row items-center justify-between border-b border-slate-100 px-6 py-4">
-                    <CardTitle className="flex items-center gap-2 text-base">
-                      <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-slate-100 text-slate-700">
-                        <Icon className="h-4 w-4" />
-                      </span>
-                      <span>{tipo.display}</span>
-                      <InlineBadge variant="outline" className="bg-white text-slate-600">
-                        {registrosOrdenados.length}
-                      </InlineBadge>
-                    </CardTitle>
-                  </CardHeader>
-
-                  <CardContent className="flex-1 p-0">
-                    <div className="flex-1 overflow-auto px-0">
-                      <div className="w-max min-w-full">
-                        <Table className="w-max min-w-full">
-                          <TableHeader className="sticky top-0 z-10 bg-white/95 backdrop-blur border-b border-slate-200">
-                            <TableRow className="shadow-[0_1px_0_rgba(15,23,42,0.06)]">
-                              {columns.map((col) => {
-                                const isActive = sortState?.column === col.id;
-                                const direction = isActive ? sortState?.direction : undefined;
-
-                                return (
-                                  <TableHead
-                                    key={col.id}
-                                    className="whitespace-nowrap px-4 py-3 align-middle text-xs font-semibold uppercase tracking-wide text-slate-600"
-                                  >
-                                    {col.sortable ? (
-                                      <button
-                                        type="button"
-                                        onClick={() => setSortByTipo((state) => toggleSort(state, tipo.key, col.id))}
-                                        className="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-slate-600 transition-colors hover:text-slate-900"
-                                      >
-                                        {col.label}
-                                        {renderSortIcon(isActive, direction)}
-                                      </button>
-                                    ) : (
-                                      <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-600">
-                                        {col.label}
-                                      </span>
-                                    )}
-                                  </TableHead>
-                                );
-                              })}
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {registrosOrdenados.length === 0 ? (
-                              <TableRow>
-                                <TableCell colSpan={columns.length} className="text-sm text-slate-500">
-                                  Nenhum registro para este tipo.
-                                </TableCell>
-                              </TableRow>
-                            ) : (
-                              registrosOrdenados.map((proc, index) => (
-                                <TableRow
-                                  key={`${tipo.key}-${proc.empresa_id ?? proc.empresa}-${proc.protocolo ?? index}`}
-                                  className="hover:bg-slate-50/60"
-                                >
-                                  {columns.map((col) => {
-                                    let content = normalizeText(proc?.[col.id]).trim() || "—";
-                                    const resolvedObs = resolveObsValue(proc);
-
-                                    if (col.id === "empresa") {
-                                      content = renderCompany(proc, handleCopy);
-                                    } else if (col.id === "protocolo") {
-                                      content = normalizeIdentifier(proc?.protocolo) || "—";
-                                    } else if (col.isDate) {
-                                      content = formatProcessDate(proc?.[col.id]);
-                                    } else if (col.id === "municipio") {
-                                      content = renderMunicipio(proc);
-                                    } else if (col.id === "situacao" || col.isStatus) {
-                                      content = renderStatus(proc?.[col.id]);
-                                    } else if (col.id === "obs") {
-                                      content = (
-                                        <button
-                                          type="button"
-                                          onClick={() => openObsDrawer(proc)}
-                                          className="inline-flex w-full max-w-xs items-start gap-2 text-left text-slate-700 transition-colors hover:text-slate-900"
-                                        >
-                                          {renderObsSnippet(resolvedObs)}
-                                        </button>
-                                      );
-                                    } else if (col.id === "area_m2") {
-                                      const area = normalizeText(proc?.area_m2).trim();
-                                      content = area ? `${area} m²` : "—";
-                                    } else if (col.id === "operacao") {
-                                      content = renderChip(proc?.operacao || proc?.diversosOperacaoLabel);
-                                    } else if (col.id === "orgao") {
-                                      content = renderChip(proc?.orgao);
-                                    } else if (col.id === "alvara") {
-                                      content = renderChip(proc?.alvara);
-                                    } else if (col.id === "servico") {
-                                      content = renderChip(proc?.servico);
-                                    } else if (col.id === "notificacao") {
-                                      content = renderChip(proc?.notificacao);
-                                    } else if (col.id === "tpi_sync_status") {
-                                      content = renderStatus(proc?.tpi_sync_status ?? proc?.tpi);
-                                    } else if (col.id === "taxa_sanitaria_sync_status") {
-                                      content = renderStatus(proc?.taxa_sanitaria_sync_status ?? proc?.taxa);
-                                    } else if (col.id === "alvara_sanitario_status") {
-                                      content = renderStatus(proc?.alvara_sanitario_status);
-                                    } else if (col.id === "alvara_sanitario_validade") {
-                                      content = formatProcessDate(proc?.alvara_sanitario_validade);
-                                    } else if (col.id === "inscricao_imobiliaria") {
-                                      content = normalizeIdentifier(proc?.inscricao_imobiliaria) || "—";
-                                    }
-
-                                    return (
-                                      <TableCell key={col.id} className="align-top text-xs text-slate-700">
-                                        {content}
-                                      </TableCell>
-                                    );
-                                  })}
-                                </TableRow>
-                              ))
-                            )}
-                          </TableBody>
-                        </Table>
+                  <div className="flex items-start justify-between gap-3 border-b border-slate-100 px-4 py-3">
+                    <div className="space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <InfoPill>
+                          <Icon className="h-4 w-4 text-slate-500" />
+                          {proc.tipoDisplay}
+                        </InfoPill>
+                        {renderStatus(proc?.situacao || proc?.status)}
+                      </div>
+                      <p className="text-base font-semibold leading-tight text-slate-900">
+                        {proc?.empresa || "—"}
+                      </p>
+                      <div className="flex flex-wrap items-center gap-2 text-[12px] text-slate-600">
+                        <InfoPill>
+                          Protocolo
+                          {normalizeIdentifier(proc?.protocolo) || "—"}
+                          {proc?.protocolo && (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                const value = normalizeIdentifier(proc?.protocolo);
+                                if (value) handleCopy(value, `Protocolo copiado: ${value}`);
+                              }}
+                              className="ml-1 text-slate-500 transition hover:text-slate-700"
+                            >
+                              <Clipboard className="h-3.5 w-3.5" />
+                            </button>
+                          )}
+                        </InfoPill>
+                        <InfoPill>
+                          <Clock className="h-3.5 w-3.5 text-slate-500" />
+                          {formatProcessDate(proc?.data_solicitacao)}
+                        </InfoPill>
+                        {municipio && (
+                          <InfoPill>
+                            <MapPin className="h-3.5 w-3.5 text-slate-500" />
+                            {municipio}
+                          </InfoPill>
+                        )}
                       </div>
                     </div>
-                  </CardContent>
+                    <div className="flex flex-col items-end gap-2 text-right">
+                      {normalizeIdentifier(proc?.cnpj) && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            const value = normalizeIdentifier(proc?.cnpj);
+                            if (value) handleCopy(value, `CNPJ copiado: ${value}`);
+                          }}
+                          className="text-[12px] font-semibold text-indigo-600 transition hover:text-indigo-800"
+                        >
+                          {normalizeIdentifier(proc?.cnpj)}
+                        </button>
+                      )}
+                      {normalizeText(proc?.prazo).trim() && (
+                        <InfoPill>Prazo {proc.prazo}</InfoPill>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="space-y-3 p-4">
+                    <div className="grid gap-3 md:grid-cols-2">
+                      <InfoItem label="Protocolo">
+                        <div className="flex items-center gap-2">
+                          <span className="font-semibold text-slate-800">
+                            {normalizeIdentifier(proc?.protocolo) || "—"}
+                          </span>
+                          {proc?.protocolo && (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                const value = normalizeIdentifier(proc?.protocolo);
+                                if (value) handleCopy(value, `Protocolo copiado: ${value}`);
+                              }}
+                              className="text-slate-500 transition hover:text-slate-700"
+                            >
+                              <Clipboard className="h-3.5 w-3.5" />
+                            </button>
+                          )}
+                        </div>
+                      </InfoItem>
+
+                      <InfoItem label="Data solicitação">{formatProcessDate(proc?.data_solicitacao)}</InfoItem>
+
+                      <InfoItem label="Município">{municipio || "—"}</InfoItem>
+
+                      <InfoItem label="Situação">{renderStatus(proc?.situacao || proc?.status)}</InfoItem>
+
+                      <InfoItem label="OBS" className="md:col-span-2">
+                        {obsText ? (
+                          <div className="space-y-2">
+                            <p
+                              className={cn(
+                                "text-sm leading-relaxed text-slate-700",
+                                !isObsExpanded && "line-clamp-2",
+                              )}
+                            >
+                              {obsText}
+                            </p>
+                            <div className="flex flex-wrap items-center gap-3">
+                              {hasLongObs && (
+                                <button
+                                  type="button"
+                                  onClick={() => toggleObsExpanded(obsKey)}
+                                  className="text-xs font-semibold text-indigo-600 transition hover:text-indigo-800"
+                                >
+                                  Ver {isObsExpanded ? "menos" : "mais"}
+                                </button>
+                              )}
+                              <button
+                                type="button"
+                                onClick={() => openObsDrawer(proc)}
+                                className="text-xs font-semibold text-slate-600 underline-offset-2 hover:underline"
+                              >
+                                Editar OBS
+                              </button>
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                            <FileText className="h-4 w-4 text-slate-400" /> Nenhuma observação
+                            <button
+                              type="button"
+                              onClick={() => openObsDrawer(proc)}
+                              className="text-xs font-semibold text-indigo-600 underline-offset-2 hover:underline"
+                            >
+                              Adicionar
+                            </button>
+                          </div>
+                        )}
+                      </InfoItem>
+
+                      {specificFields.map((field) => (
+                        <InfoItem key={field.key} label={field.label}>
+                          {field.content}
+                        </InfoItem>
+                      ))}
+                    </div>
+                  </div>
                 </Card>
               );
             })}


### PR DESCRIPTION
## Summary
- replace the Processos table with a card-based grid that mirrors the Certificados visual style and includes per-type filtering, sorting, and inline OBS controls
- present process metadata and optional fields with compact neutral chips and status badges to keep the layout clean and legible
- reduce top padding under the header to tighten the gap before page content

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69414893088483268833587c861b29de)