### PR TITLE
Ajusta cores e dados da aba de processos

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -358,6 +358,8 @@ function AppContent() {
     () =>
       processos.map((proc) => {
         const empresaId = extractEmpresaId(proc);
+        const empresa = empresaId !== undefined ? empresasById.get(empresaId) : undefined;
+        const empresaMunicipio = normalizeText(empresa?.municipio).trim();
         const statusCandidates = [proc.status, proc.status_padrao, proc.situacao];
         const resolvedStatus = statusCandidates.find((value) => normalizeIdentifier(value));
         const tipoNormalizado = normalizeProcessType(proc);
@@ -366,6 +368,12 @@ function AppContent() {
           tipoBase === PROCESS_DIVERSOS_LABEL
             ? buildDiversosOperacaoKey(proc.operacao)
             : undefined;
+        const municipioProcesso = normalizeText(proc?.municipio).trim();
+        const municipioExibicaoProcesso = normalizeText(proc?.municipio_exibicao).trim();
+        const resolvedMunicipio =
+          municipioProcesso || municipioExibicaoProcesso || empresaMunicipio || undefined;
+        const resolvedMunicipioExibicao =
+          municipioExibicaoProcesso || municipioProcesso || empresaMunicipio || undefined;
         return {
           ...proc,
           empresaId,
@@ -373,10 +381,12 @@ function AppContent() {
           tipoNormalizado,
           tipoBase,
           diversosOperacaoKey,
+          municipio: resolvedMunicipio,
+          municipio_exibicao: resolvedMunicipioExibicao,
           status: resolvedStatus ?? proc.status ?? proc.status_padrao ?? proc.situacao,
         };
       }),
-    [processos],
+    [empresasById, processos],
   );
 
   const processosByEmpresa = useMemo(() => {

--- a/frontend/src/features/processos/ProcessosScreen.jsx
+++ b/frontend/src/features/processos/ProcessosScreen.jsx
@@ -11,7 +11,11 @@ import {
 } from "@/components/ui/table";
 import InlineBadge from "@/components/InlineBadge";
 import StatusBadge from "@/components/StatusBadge";
+import { Chip } from "@/components/Chip";
 import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
   Clock,
   Clipboard,
   FileText,
@@ -63,21 +67,6 @@ const tipoBadge = {
   "LICENCA AMBIENTAL": `${badgeBase} bg-emerald-50 text-emerald-700 ring-emerald-200`,
   AMBIENTAL: `${badgeBase} bg-emerald-50 text-emerald-700 ring-emerald-200`,
   "USO DO SOLO": `${badgeBase} bg-orange-50 text-orange-700 ring-orange-200`,
-};
-
-const situacaoBadge = {
-  CONCLUIDO: `${badgeBase} bg-emerald-50 text-emerald-700 ring-emerald-200`,
-  LICENCIADO: `${badgeBase} bg-emerald-50 text-emerald-700 ring-emerald-200`,
-  INDEFERIDO: `${badgeBase} bg-rose-50 text-rose-700 ring-rose-200`,
-  "EM ANALISE": `${badgeBase} bg-blue-50 text-blue-700 ring-blue-200`,
-  PENDENTE: `${badgeBase} bg-amber-50 text-amber-800 ring-amber-200`,
-  "AGUARD DOCTO": `${badgeBase} bg-amber-50 text-amber-800 ring-amber-200`,
-  "AGUARD PAGTO": `${badgeBase} bg-amber-50 text-amber-800 ring-amber-200`,
-  "AGUARD VISTORIA": `${badgeBase} bg-amber-50 text-amber-800 ring-amber-200`,
-  "AGUARD REGULARIZACAO": `${badgeBase} bg-amber-50 text-amber-800 ring-amber-200`,
-  "AGUARD LIBERACAO": `${badgeBase} bg-amber-50 text-amber-800 ring-amber-200`,
-  "IR NA VISA": `${badgeBase} bg-amber-50 text-amber-800 ring-amber-200`,
-  NOTIFICACAO: `${badgeBase} bg-violet-50 text-violet-700 ring-violet-200`,
 };
 
 function normKey(s) {
@@ -717,8 +706,6 @@ export default function ProcessosScreen({
               const municipio = formatMunicipio(proc);
               const tipoKey = normKey(proc?.tipo);
               const tipoCls = tipoBadge[tipoKey] ?? `${badgeBase} bg-slate-50 text-slate-700 ring-slate-200`;
-              const sitKey = normKey(proc?.situacao || proc?.status);
-              const sitCls = situacaoBadge[sitKey] ?? `${badgeBase} bg-slate-50 text-slate-700 ring-slate-200`;
               const maskedCnpj = maskCNPJ(proc?.cnpj);
 
               const specificFields = [];
@@ -823,7 +810,7 @@ export default function ProcessosScreen({
                           <Icon className="h-4 w-4 text-slate-500" />
                           {proc.tipoDisplay}
                         </span>
-                        <span className={sitCls}>{proc?.situacao || proc?.status || "Situação"}</span>
+                        <StatusBadge status={proc?.situacao || proc?.status || "Situação"} />
                       </div>
                       <p className="text-base font-semibold leading-tight text-slate-900">
                         {proc?.empresa || "—"}
@@ -852,7 +839,7 @@ export default function ProcessosScreen({
                     <div className="grid gap-3 md:grid-cols-2">
                       <InfoItem label="Protocolo">
                         <div className="flex items-center gap-2">
-                          <span className="font-semibold text-slate-800">
+                          <span className="text-sm font-semibold text-slate-800">
                             {normalizeIdentifier(proc?.protocolo) || "—"}
                           </span>
                           {proc?.protocolo && (

--- a/frontend/src/lib/status.js
+++ b/frontend/src/lib/status.js
@@ -118,6 +118,28 @@ export const resolveStatusClass = (status) => {
   const key = removeDiacritics(trimmed.toLowerCase());
   const normalizedKey = key.replace(/\s+/g, " ").trim();
 
+  const palette = {
+    "aguard docto": { variant: "warning" },
+    "aguard pagto": { variant: "danger" },
+    "em analise": { variant: "warning" },
+    pendente: { variant: "neutral" },
+    indeferido: { variant: "danger", className: "bg-rose-100 text-rose-800 border-rose-200" },
+    concluido: { variant: "success" },
+    licenciado: { variant: "success" },
+    notificacao: { variant: "warning" },
+    "aguard vistoria": { variant: "warning" },
+    "aguard regularizacao": { variant: "danger" },
+    "aguard liberacao": { variant: "warning" },
+    "ir na visa": {
+      variant: "outline",
+      className: "border-blue-200 bg-blue-50 text-blue-700",
+    },
+  };
+
+  if (palette[normalizedKey]) {
+    return palette[normalizedKey];
+  }
+
   if (trimmed.includes("/")) {
     return { variant: "warning" };
   }


### PR DESCRIPTION
## Summary
- atualiza o mapa de status para refletir as cores específicas solicitadas na aba de processos
- preenche o município dos processos com o município cadastrado na empresa correspondente
- utiliza StatusBadge nos cartões de processos e reduz o tamanho do texto do protocolo
- corrige a importação dos ícones de ordenação na tabela de processos, evitando erro em tempo de execução
- importa o componente Chip na tela de Processos para evitar referência indefinida nos chips de informações

## Testing
- npm run build --prefix frontend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69418fedfd6483268f6ae9de7885ba2c)