### PR TITLE
Add new process columns to payloads

### DIFF
--- a/backend/app/schemas/processos.py
+++ b/backend/app/schemas/processos.py
@@ -42,6 +42,14 @@ class ProcessoView(BaseModel):
     situacao: str
     status_padrao: Optional[str] = None
     prazo: Optional[date] = None
+    operacao: Optional[str] = None
+    orgao: Optional[str] = None
+    alvara: Optional[str] = None
+    area_m2: Optional[float] = None
+    projeto: Optional[str] = None
+    inscricao_imobiliaria: Optional[str] = None
+    servico: Optional[str] = None
+    notificacao: Optional[str] = None
     status_cor: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
@@ -63,6 +71,8 @@ class ProcessoBase(BaseModel):
     operacao: Optional[str] = None
     orgao: Optional[str] = None
     alvara: Optional[str] = None
+    area_m2: Optional[float] = None
+    projeto: Optional[str] = None
     municipio: Optional[str] = None
     tpi: Optional[str] = None
     inscricao_imobiliaria: Optional[str] = None
@@ -89,6 +99,8 @@ class ProcessoUpdate(BaseModel):
     operacao: Optional[str] = None
     orgao: Optional[str] = None
     alvara: Optional[str] = None
+    area_m2: Optional[float] = None
+    projeto: Optional[str] = None
     municipio: Optional[str] = None
     tpi: Optional[str] = None
     inscricao_imobiliaria: Optional[str] = None

--- a/backend/db/models_sql.py
+++ b/backend/db/models_sql.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    Numeric,
     String,
     Text,
     UniqueConstraint,
@@ -175,6 +176,8 @@ class Processo(Base):
     operacao = Column(pg_enum("operacoes_diversos"), nullable=True)
     orgao = Column(pg_enum("orgaos_diversos"), nullable=True)
     alvara = Column(pg_enum("alvaras_funcionamento"), nullable=True)
+    area_m2 = Column(Numeric(12, 2))
+    projeto = Column(String(120))
     municipio = Column(String(120))
     tpi = Column(String(120))
     inscricao_imobiliaria = Column(String(120))

--- a/backend/migrations/versions/20251106_01_s3_api_views_org_audit.py
+++ b/backend/migrations/versions/20251106_01_s3_api_views_org_audit.py
@@ -161,6 +161,14 @@ def _create_views() -> None:
             p.situacao,
             p.status_padrao,
             p.prazo,
+            p.operacao,
+            p.orgao,
+            p.alvara,
+            p.area_m2,
+            p.projeto,
+            p.inscricao_imobiliaria,
+            p.servico,
+            p.notificacao,
             CASE
                 WHEN LOWER(COALESCE(p.status_padrao, p.situacao::text)) LIKE '%conclu%'
                      OR LOWER(COALESCE(p.status_padrao, p.situacao::text)) LIKE '%licenc%'


### PR DESCRIPTION
## Summary
- expose additional process columns in v_processos_resumo to include operations, authorities, project details, and sanitary notifications
- update Processo ORM model and schemas to handle the new fields for create/update and view payloads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694199febef08326a70972609c24f7fa)