### PR TITLE
Ajusta dados de taxas e filtros na aba de processos

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -360,6 +360,7 @@ function AppContent() {
         const empresaId = extractEmpresaId(proc);
         const empresa = empresaId !== undefined ? empresasById.get(empresaId) : undefined;
         const empresaMunicipio = normalizeText(empresa?.municipio).trim();
+        const taxa = empresaId !== undefined ? taxasByEmpresa.get(empresaId) : undefined;
         const statusCandidates = [proc.status, proc.status_padrao, proc.situacao];
         const resolvedStatus = statusCandidates.find((value) => normalizeIdentifier(value));
         const tipoNormalizado = normalizeProcessType(proc);
@@ -384,9 +385,13 @@ function AppContent() {
           municipio: resolvedMunicipio,
           municipio_exibicao: resolvedMunicipioExibicao,
           status: resolvedStatus ?? proc.status ?? proc.status_padrao ?? proc.situacao,
+          tpi_sync_status: tipoBase === "Bombeiros" ? taxa?.tpi : undefined,
+          taxa_sanitaria_sync_status: tipoBase?.toLowerCase().includes("sanit")
+            ? taxa?.sanitaria
+            : undefined,
         };
       }),
-    [empresasById, processos],
+    [empresasById, processos, taxasByEmpresa],
   );
 
   const processosByEmpresa = useMemo(() => {
@@ -695,6 +700,7 @@ function AppContent() {
                 <ProcessosScreen
                   processosNormalizados={processosNormalizados}
                   modoFoco={modoFoco}
+                  soAlertas={somenteAlertas}
                   matchesMunicipioFilter={matchesMunicipioFilter}
                   matchesQuery={matchesQuery}
                   handleCopy={handleCopy}

--- a/frontend/src/features/processos/ProcessosScreen.jsx
+++ b/frontend/src/features/processos/ProcessosScreen.jsx
@@ -227,6 +227,7 @@ const resolveTipoFromProcess = (proc) => {
 export default function ProcessosScreen({
   processosNormalizados,
   modoFoco,
+  soAlertas,
   matchesMunicipioFilter,
   matchesQuery,
   handleCopy,
@@ -294,9 +295,14 @@ export default function ProcessosScreen({
 
       const matchesFoco = modoFoco ? isProcessStatusActiveOrPending(proc.status) : true;
 
-      return matchesMunicipio && matchesBusca && matchesFoco;
+      const statusKey = removeDiacritics(normalizeText(proc?.situacao || proc?.status).toLowerCase());
+      const blockedByAlertMode =
+        soAlertas &&
+        ["pendente", "concluido", "licenciado"].some((keyword) => statusKey.includes(keyword));
+
+      return matchesMunicipio && matchesBusca && matchesFoco && !blockedByAlertMode;
     });
-  }, [matchesMunicipioFilter, matchesQuery, modoFoco, processosNormalizados]);
+  }, [matchesMunicipioFilter, matchesQuery, modoFoco, processosNormalizados, soAlertas]);
 
   const fetchObsHistory = useCallback(async (processoId) => {
     setLoadingHistory(true);


### PR DESCRIPTION
## Summary
- Enrich normalized processes with TPI and sanitary tax statuses from company tax records
- Pass alert toggle to the Processos screen and filter out pending/concluded/licensed items when active
- Keep CERCON TPI and sanitary tax columns displaying the synchronized statuses

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941b2e1c2888326bc2519a77f605cb0)